### PR TITLE
add range filter for tilt laser

### DIFF
--- a/jsk_pr2_startup/jsk_pr2_sensors/tilt_scan_cloud.launch
+++ b/jsk_pr2_startup/jsk_pr2_sensors/tilt_scan_cloud.launch
@@ -25,12 +25,13 @@
     <rosparam command="load" file="$(find jsk_pr2_startup)/jsk_pr2_sensors/tilt_self_filter.yaml" />
   </node>
 
-  <node type="laser_scan_assembler" name="tilt_scan_assembler"
-	pkg="laser_assembler" respawn="true">
+  <node type="laser_scan_assembler" name="tilt_scan_assembler" pkg="laser_assembler"
+        output="screen" clear_params="true" respawn="true">
     <remap from="scan" to="tilt_scan"/>
     <param name="max_scans" type="int" value="400" />
     <param name="fixed_frame" type="string" value="base_link" />
     <param name="ignore_laser_skew" type="bool" value="true" />
+    <rosparam command="load" file="$(find jsk_pr2_startup)/jsk_pr2_sensors/tilt_scan_filters.yaml" />
   </node>
 
   <node pkg="pr2_arm_navigation_perception" type="pr2_laser_snapshotter"

--- a/jsk_pr2_startup/jsk_pr2_sensors/tilt_scan_filters.yaml
+++ b/jsk_pr2_startup/jsk_pr2_sensors/tilt_scan_filters.yaml
@@ -1,0 +1,20 @@
+#### laser_scan_assembler
+filters:
+ - name: shadows
+   type: laser_filters/ScanShadowsFilter
+   params:
+     min_angle: 10
+     max_angle: 170
+     neighbors: 20
+     window: 1
+ - name: through
+   type: laser_filters/LaserScanRangeFilter
+   params:
+     lower_threshold: 0.3
+     upper_threshold: 2.8
+# - name: intent
+#   type: laser_filters/LaserScanIntensityFilter
+#   params:
+#     lower_threshold: 750.0
+#     upper_threshold: 100000.0
+#     disp_histogram: 0


### PR DESCRIPTION
tilt laser用にレンジフィルターを追加しました。
moveitで大きなoctomapを作らないためです。
