### PR TITLE
add arg to set nodelet manager name

### DIFF
--- a/jsk_pr2_startup/jsk_pr2_sensors/pr2_robot.launch
+++ b/jsk_pr2_startup/jsk_pr2_sensors/pr2_robot.launch
@@ -21,6 +21,7 @@
     <arg name="USE_HEAD_POINTCLOUD" value="true"/>
     <arg name="HEAD_SELECTED" default="/head_pointcloud_selected"/>
     <arg name="HEAD_TOPIC" default="/openni/depth_registered/points"/>
+    <arg name="HEAD_NODELET_MANAGER" value="/openni_nodelet_manager"/>
     <arg name="BASE_FRAME" value="/base_link"/>
   </include>
 


### PR DESCRIPTION
Add argument to set pcl roi nodelet name.
Pcl roi nodelet uses the same nodelet manager as openni.
