### PR TITLE
Image transport nodelet

### DIFF
--- a/jsk_pr2_startup/jsk_pr2_image_transport/pr2_image_transport.launch
+++ b/jsk_pr2_startup/jsk_pr2_image_transport/pr2_image_transport.launch
@@ -15,16 +15,54 @@
   <arg name="MJPEGSERVER_PORT" default="8181"/>
   <arg name="GAZEBO_MODE" default="false" />
 
-  <arg name="IMAGE_NODELET_MANAGER" default="/openni_nodelet_manager"/>
+  <arg name="LAUNCH_MANAGER" default="true" />
+  <arg name="IMAGE_NODELET_MANAGER" default="image_transport_nodelet_manager"/>
+  <arg name="GDB" default="false" />
+
+  <group if="$(arg LAUNCH_MANAGER)">
+    <node pkg="nodelet" type="nodelet" name="$(arg IMAGE_NODELET_MANAGER)"
+          args="manager"
+          if="$(arg GDB)"
+          launch-prefix="xterm -e gdb --args"
+          output="screen"/>
+    <node pkg="nodelet" type="nodelet" name="$(arg IMAGE_NODELET_MANAGER)"
+          args="manager"
+          unless="$(arg GDB)"
+          output="screen"/>
+  </group>
+
+  <!-- image relay -->
+  <!-- larm -->
+  <node pkg="nodelet" type="nodelet" name="l_forearm_cam_relay"
+	args="load jsk_topic_tools/Relay $(arg IMAGE_NODELET_MANAGER)" output="screen">
+    <remap from="~input" to="/l_forearm_cam/image_rect" />
+    <remap from="~output" to="$(arg IMAGE_NODELET_MANAGER)/l_forearm_cam/image_rect" />
+  </node>
+  <node pkg="nodelet" type="nodelet" name="l_forearm_cam_info_relay"
+	args="load jsk_topic_tools/Relay $(arg IMAGE_NODELET_MANAGER)" output="screen">
+    <remap from="~input" to="/l_forearm_cam/camera_info" />
+    <remap from="~output" to="$(arg IMAGE_NODELET_MANAGER)/l_forearm_cam/camera_info" />
+  </node>
+  <!-- rarm -->
+  <node pkg="nodelet" type="nodelet" name="r_forearm_cam_relay"
+	args="load jsk_topic_tools/Relay $(arg IMAGE_NODELET_MANAGER)" output="screen">
+    <remap from="~input" to="/r_forearm_cam/image_rect" />
+    <remap from="~output" to="$(arg IMAGE_NODELET_MANAGER)/r_forearm_cam/image_rect" />
+  </node>
+  <node pkg="nodelet" type="nodelet" name="r_forearm_cam_info_relay"
+	args="load jsk_topic_tools/Relay $(arg IMAGE_NODELET_MANAGER)" output="screen">
+    <remap from="~input" to="/r_forearm_cam/camera_info" />
+    <remap from="~output" to="$(arg IMAGE_NODELET_MANAGER)/r_forearm_cam/camera_info" />
+  </node>
 
   <!-- rotate hand image -->
-  <group if="$(arg USE_ROTATED)" >
+  <group if="$(arg USE_ROTATED)">
     <node ns="l_forearm_cam"
           pkg="nodelet" type="nodelet"
           name="lhand_resized_rotated"
-          args="load jsk_pcl/ImageRotateNodelet $(arg IMAGE_NODELET_MANAGER)"
+          args="load jsk_pcl/ImageRotateNodelet /$(arg IMAGE_NODELET_MANAGER)"
           output="screen" clear_params="true">
-      <remap from="image" to="image_rect"/>
+      <remap from="image" to="/$(arg IMAGE_NODELET_MANAGER)/l_forearm_cam/image_rect"/>
       <param name="target_frame_id" value="/base_footprint"/>
       <param name="use_tf2" value="true"/>
       <param name="use_camera_info" value="true"/>
@@ -33,9 +71,9 @@
     <node ns="r_forearm_cam"
           pkg="nodelet" type="nodelet"
           name="rhand_resized_rotated"
-          args="load jsk_pcl/ImageRotateNodelet $(arg IMAGE_NODELET_MANAGER)"
+          args="load jsk_pcl/ImageRotateNodelet /$(arg IMAGE_NODELET_MANAGER)"
           output="screen" clear_params="true">
-      <remap from="image" to="image_rect"/>
+      <remap from="image" to="/$(arg IMAGE_NODELET_MANAGER)/r_forearm_cam/image_rect"/>
       <param name="target_frame_id" value="/base_footprint"/>
       <param name="use_tf2" value="true"/>
       <param name="use_camera_info" value="true"/>


### PR DESCRIPTION
Use independent nodelet for image transport.
This PR is helpful to avoid the issue #36.
