### PR TITLE
does not run openni from pr2.launch

### DIFF
--- a/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_startup/pr2.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="launch_openni" default="true" />
+  <arg name="launch_openni" default="false" />
   <arg name="launch_move_base" default="true" />
   <arg name="launch_imagesift" default="false" />
   <arg name="launch_facedetection" default="false" />


### PR DESCRIPTION
kinect should be launched from robot start

`/etc/ros/robot.launch` should be like this:

``` xml
<launch>

    <!-- Robot Description --> <param name="robot_description" textfile="/etc/ros/groovy/urdf/robot.xml" />

    <!-- Robot Analyzer --> <rosparam command="load" file="$(find pr2_bringup)/config/pr2_analyzers.yaml" ns="diag_agg" />

    <!-- Robot bringup --> <include file="$(find pr2_bringup)/pr2.launch" />

    <!-- Web ui --> <!-- <include file="$(find webui)/webui.launch" /> -->

    <!-- Android app --> <include file="$(find local_app_manager)/app_manager.launch" >
      <arg name="ROBOT_NAME" value="pr1040" />
      <arg name="ROBOT_TYPE" value="pr2" />
    </include>

    <!-- RobotWebTools --> <include file="$(find rwt_image_view)/launch/rwt_image_view.launch"/>

    <rosparam file="/etc/ros/robot.yaml"/>
    <!-- kinect -->
    <include file="$(find jsk_pr2_startup)/jsk_pr2_sensors/kinect_head.launch" />

</launch>

```
