### PR TITLE
Remove joy node

### DIFF
--- a/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_startup/pr2.launch
@@ -120,7 +120,9 @@
 
   <!-- joy mux -->
   <node machine="c2" pkg="topic_tools" type="mux" name="multiple_joystick_mux"
-        respawn="true" args="/joy /joy_org /joy_other" />
+        respawn="true" args="/joy /joy_org /joy_other" >
+    <remap from="mux" to="multiple_joystick_mux"/>
+  </node>
 
   <include if="$(arg launch_teleoperation)"
            file="$(find jsk_pr2_startup)/jsk_pr2_sensors/pr2_teleop_robot.launch" />


### PR DESCRIPTION
Remove joy node in pr2.launch.
Joy node is launched when starting pr2.
