### PR TITLE
Catkinize pr2 base trajectory action

### DIFF
--- a/pr2_base_trajectory_action/catkin.cmake
+++ b/pr2_base_trajectory_action/catkin.cmake
@@ -7,8 +7,8 @@ find_package(Boost REQUIRED COMPONENTS thread)
 include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
 catkin_package(
-    DEPENDS roscpp actionlib geometry_msgs nav_msgs trajectory_msgs pr2_controllers_msgs actionlib_msgs pr2_mechanism_model angles
-    CATKIN_DEPENDS # TODO
+    DEPENDS
+    CATKIN_DEPENDS  roscpp actionlib geometry_msgs nav_msgs trajectory_msgs pr2_controllers_msgs actionlib_msgs pr2_mechanism_model angles
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO
 )


### PR DESCRIPTION
I don't know what pr2_base_trajectory_action will do... but this is needed in jsk_pr2_startup(for safe_teleop?)
