### PR TITLE
rgb/image_rect is no longer published, use image_mono_rect instead of the topic

### DIFF
--- a/jsk_pr2_startup/jsk_pr2_image_transport/pr2_roi_transport.launch
+++ b/jsk_pr2_startup/jsk_pr2_image_transport/pr2_roi_transport.launch
@@ -7,7 +7,7 @@
         args="manager" output="screen"/>
 
   <arg name="DECIMATE_CAMERA" default="/openni/rgb" />
-  <arg name="DECIMATE_IMAGE" default="image_rect" />
+  <arg name="DECIMATE_IMAGE" default="image_rect_mono" />
   <arg name="DECIMATE_OUTPUT_CAMERA" default="roi_camera_output" />
   <!--arg name="DECIMATE_OUTPUT_IMAGE" default="image_raw" /-->
 


### PR DESCRIPTION
warning message will be disappeared around [here](https://github.com/ros-perception/image_common/blob/hydro-devel/image_transport/src/camera_subscriber.cpp#L79)
