### PR TITLE
changed shadow_filter

### DIFF
--- a/jsk_pr2_startup/jsk_pr2_sensors/lasers_and_filters.xml
+++ b/jsk_pr2_startup/jsk_pr2_sensors/lasers_and_filters.xml
@@ -34,11 +34,11 @@
   </node>
 
   <!-- Filter for base laser shadowing/veiling -->
-  <node pkg="laser_filters" type="scan_to_cloud_filter_chain" respawn="true" machine="c2" name="base_shadow_filter" >
+  <node pkg="laser_filters" type="scan_to_cloud_filter_chain" machine="c2" respawn="true" name="base_shadow_filter" >
     <remap from="scan" to="base_scan" />
     <remap from="cloud_filtered" to="base_scan_shadow_filtered" />
     <param name="target_frame" value="base_footprint" />
-    <rosparam command="load" file="$(find pr2_navigation_perception)/config/shadow_filter.yaml" />
+    <rosparam command="load" file="$(find jsk_pr2_startup)/jsk_pr2_sensors/shadow_filter.yaml" />
     <rosparam command="load" file="$(find pr2_navigation_perception)/config/point_cloud_footprint_filter.yaml" />
   </node>
 

--- a/jsk_pr2_startup/jsk_pr2_sensors/shadow_filter.yaml
+++ b/jsk_pr2_startup/jsk_pr2_sensors/shadow_filter.yaml
@@ -1,0 +1,14 @@
+scan_filter_chain:
+- name: shadows
+  type: ScanShadowsFilter
+  params:
+    min_angle: 0
+    max_angle: 170
+    neighbors: 5
+    window: 1
+- name: dark_shadows
+  type: LaserScanIntensityFilter
+  params: 
+    lower_threshold: 100
+    upper_threshold: 10000
+    disp_histogram: 0


### PR DESCRIPTION
base scan のノイズ判定を緩めました。
具体的にはshadow filter のneighborを２０から５にしました。
その結果、自己位置推定がかなりの精度でよくなりました。
以下画像です。

*raw_data
![raw_laser](https://cloud.githubusercontent.com/assets/7262021/4526932/b01b6cfe-4d63-11e4-9784-34e3ae20d11f.png)
- neighbor=1 
  ![filtered_neigbor_1](https://cloud.githubusercontent.com/assets/7262021/4526880/3d281a12-4d63-11e4-8c5f-f171b4c0515e.png)
- neighbor=5
  ![filterd_neighber_5](https://cloud.githubusercontent.com/assets/7262021/4526883/428e1c36-4d63-11e4-9c3a-2f9ffdc21b18.png)
- neighbor=10
  ![filtered_neighber_10](https://cloud.githubusercontent.com/assets/7262021/4526884/46745126-4d63-11e4-90a4-b92cd02ffd55.png)
- neighbor=15
  ![filterd_neighber_15](https://cloud.githubusercontent.com/assets/7262021/4526887/4a0217ba-4d63-11e4-8c05-515593de0e65.png)

*neighbor=20
![filtered_neighber_20](https://cloud.githubusercontent.com/assets/7262021/4526890/5004263a-4d63-11e4-829d-1575bfc5a13a.png)
