### PR TITLE
Delete one of nao-inits (bug fixed)

### DIFF
--- a/jsk_nao_robot/naoeus/euslisp/nao-interface.l
+++ b/jsk_nao_robot/naoeus/euslisp/nao-interface.l
@@ -154,18 +154,6 @@
    (send self :angle-vector #f(105.292 13.8845 -94.3102 -26.1893 -18.3718 103.363 -15.2077 102.919 29.3582 -30.5008 -2.107 -2.72224 -55.721 121.039 -67.9785 2.02391 -2.107 -7.29261 -55.1105 121.039 -67.97 5.01224 -4.74855 -5.89115) 3000)
    )
   )
-(defun nao-init (&optional (create-viewer))
-  (unless (boundp '*nao*) (nao))
-  (unless (ros::ok) (ros::roseus "nao_eus_interface"))
-  (unless (boundp '*ni*) (setq *ni* (instance nao-interface :init)))
-  
-  (ros::spin-once)
-  (send *ni* :spin-once)
-  
-  (send *nao* :angle-vector (send *ni* :state :potentio-vector))
-  (when create-viewer (objects (list *nao*)))
-  )
-
 
 (defun nao-init (&optional (create-viewer))
   (unless (boundp '*nao*) (nao))


### PR DESCRIPTION
nao-init が２つできてしまっていたため１つを消しました。

原因は、自分のmasterブランチのnao-interface.lを誤って変更したまま、jsk-ros-pkg/jsk_robotの内容に合わせる方法が分からずそのままにしていたことだと思います。大変申し訳ございません。
（git pull origin masterで大丈夫でした。）
