### PR TITLE
add jsk_robot_common/jsk_robot_startup

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
+++ b/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(jsk_robot_startup)
+
+find_package(catkin REQUIRED COMPONENTS
+  mongodb_store
+  roscpp
+  rospy
+)
+
+catkin_package(
+)
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)

--- a/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
@@ -1,0 +1,7 @@
+<launch>
+  <!-- MongoDB -->
+  <launch>
+    <param name="mongodb_port" value="62345"/>
+    <include file="$(find mongodb_store)/mongodb_store.launch"/>
+  </launch>
+</launch>

--- a/jsk_robot_common/jsk_robot_startup/package.xml
+++ b/jsk_robot_common/jsk_robot_startup/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package>
+  <name>jsk_robot_startup</name>
+  <version>0.0.0</version>
+  <description>The jsk_robot_startup package</description>
+  <maintainer email="inagaki@todo.todo">inagaki</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>mongodb_store</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <run_depend>mongodb_store</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>rospy</run_depend>
+
+  <export>
+  </export>
+</package>


### PR DESCRIPTION
for #145 
This package will contain tweets or mongodb launches which may be in common with robots.
Now this only contain mongodb startup launch.
