### PR TITLE
repiar mongodb.launch

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
@@ -1,7 +1,21 @@
 <launch>
   <!-- MongoDB -->
-  <arg name="mongodb_port" default="62345"/>
+  <arg name="db_path" default="/opt/strands/mongodb_store"/>
+  <arg name="port" default="62345" />
+  <arg name="defaults_path" default=""/>
+  
+  <param name="mongodb_port" value="$(arg port)" />
+  <param name="mongodb_host" value="$(optenv HOSTNAME localhost)" />
 
-  <param name="mongodb_port" value="$(arg mongodb_port)"/>
-  <include file="$(find mongodb_store)/mongodb_store.launch"/>
+  <node name="mongo_server" pkg="mongodb_store" type="mongodb_server.py" output="screen">
+    <param name="database_path" value="$(arg db_path)"/>
+  </node>
+
+  <node name="config_manager" pkg="mongodb_store" type="config_manager.py" output="screen">
+        <param name="defaults_path" value="$(arg defaults_path)"/>
+  </node>
+
+  <node name="message_store" pkg="mongodb_store" type="message_store_node.py" output="screen"/>
+
+  <node name="replicator_node" pkg="mongodb_store" type="replicator_node.py" output="screen"/>
 </launch>


### PR DESCRIPTION
mongodb_store/mongodb_store.launch included the machine tag,
Maybe the launch file we had included intends to be used like http://wiki.ros.org/mongodb_store#Launching . 

It conflict with openni's rgbd_launch's machine (localhost ) tag and 
it make the error "Machine [localhost] already added and does not match duplicate entry".
So I copied most of the line from the mongodb_store.launch.
