### PR TITLE
clean up :init method

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -26,12 +26,9 @@
 					 control_msgs::GripperCommandAction
 					 ))
 
-     (setq joint-action-enable t)
-     
      (dolist (action (list right-gripper-action left-gripper-action))
        (unless (and joint-action-enable (send action :wait-for-server 3))
-	 (setq joint-action-enable nil)
-	 (ros::ros-warn "~A is not respond, baxter-interface is disabled" action)
+	 (ros::ros-warn "~A is not respond" action)
 	 (return)))
 
      (setq gripper-sequence-id 0)


### PR DESCRIPTION
need to conform on realrobot, gazebo, eus simulation, see #171 for discussion
-  do not need to add-controler, that is done in robot-interface :init
- do not disable joint-action-enable if gripper action is not found, gazebo did not provide gripper joint action for now
