### PR TITLE
[jsk_pr2_startup] Disable collider node

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_sensors/tilt_scan_cloud.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_sensors/tilt_scan_cloud.launch
@@ -36,6 +36,7 @@
   </node>
 
   <node pkg="collider" type="collider_node" name="collider_node"
+        if="false"
 	respawn="true" output="screen" machine="c2">
     <param name="fixed_frame" type="string" value="base_link" />
     <param name="resolution" type="double" value="0.01" />


### PR DESCRIPTION
it's out of date

We can find collider [here](https://github.com/willowgarage/arm_navigation_experimental), but in order
to re-work it, we need to exert a lot of effort.