### PR TITLE
repair tweet lifelog

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/active_user.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/active_user.l
@@ -5,8 +5,8 @@
 (ros::load-ros-manifest "sensor_msgs")
 (ros::load-ros-manifest "diagnostic_msgs")
 
-(setq *start-distance* 0)
-(setq *start-angle* 0)
+(setq *start-distance* nil)
+(setq *start-angle* nil)
 (setq *servo-on* nil)
 
 (ros::roseus "active_user_statistics")
@@ -17,15 +17,15 @@
 
 (defun odom-cb (msg)
   (ros::ros-debug "odom_state -> distance ~A, angle ~A" (send msg :distance) (send msg :angle))
-  (if (or (= *start-distance* 0) (= *start-angle* 0))
+  (if (or (equal *start-distance* nil) (equal *start-angle* nil))
       (setq *start-distance*  (send msg :distance)
-	    *start-angle*     (send msg :angle)))
-  (setq *distance* (- (send msg :distance) *start-distance*)
-	*angle*    (- (send msg :angle)    *start-angle*)))
+	    *start-angle*     (send msg :angle))
+    (setq *distance* (- (send msg :distance) *start-distance*)
+          *angle*    (- (send msg :angle)    *start-angle*))))
 
 (defun joint-cb (msg)
   (setq *position* (concatenate float-vector (subseq (send msg :position) 12 16) (subseq (send msg :position) 17)))
-  (ros::ros-debug "/joint_states -> ~A" *position*)
+;;  (ros::ros-debug "/joint_states -> ~A" *position*)
   (update-activeness)
   )
 
@@ -54,6 +54,7 @@
 (setq *distance* nil *angle* nil *position* nil)
 
 (setq *status* 'stop)
+(setq *movingp* nil)
 (setq *start-time* (ros::time 0))
 (setq *elapsed-sec* 0)
 (setq *seq* 0)
@@ -73,8 +74,8 @@
 (warn "~%;; start user_name = ~A~%" *user-name*)
 
 (if (and (ros::has-param "/active_user/elapsed_time")
-	 (ros::has-param "/active_user/user_name")
-	 (string= (ros::get-param "/active_user/user_name") *user-name*))
+	 (ros::has-param "/active_user/launch_user_name")
+	 (string= (ros::get-param "/active_user/launch_user_name") *user-name*))
     (setq *elapsed* (ros::time (ros::get-param "/active_user/elapsed_time")))
   (setq *elapsed* (ros::time 0)))
 (warn "~%;; start elapsed_time with ~A sec~%~%" *elapsed*);;
@@ -90,7 +91,9 @@
    ))
 
 (defun update-activeness()
-  (ros::ros-debug "user -> ~A" *user-name*)
+  (ros::ros-debug "user  -> ~A" *user-name*)
+  (ros::ros-debug "status-> ~A" *status*)
+  (ros::ros-debug "moving-> ~A" *movingp*)
   (setq *odom-disable* (not (ros::get-param "/active_user/odom_subscribe")))
   ;; check if the robot is moving
   (when (and *user-name* (or (and *prev-distance* *prev-angle* *prev-position*) *odom-disable*))
@@ -104,12 +107,11 @@
           (ros::ros-debug " move base -> ~A ~A" diff-distance diff-angle))
       ;; check arms
       (ros::ros-debug " joint-angle  -> ~A" diff-position)
-
       ;;for odom-enable machine
       (if (and *servo-on*
-               (or (> diff-distance 0.001) (> diff-angle 0.001) (> diff-position 0.001))
+               (or (> diff-distance 0.001) (> diff-angle 0.001) (> diff-position 0.05))
                (not *odom-disable*))
-          (setq *movingp* t)
+           (setq *movingp* t)
         ;;for odom-disable machine
         (if (and (> diff-position 0.001)
                  *odom-disable*)
@@ -165,7 +167,7 @@
             *prev-position* *position*)
     (setq *prev-position* *position*)
     )
-  (when (and *user-name* *elapsed-sec*)
+  (when (and (> (length *user-name*) 0) *elapsed-sec*)
     (ros::set-param "/active_user/user_name" *user-name*)
     (ros::set-param "/active_user/elapsed_time" *elapsed-sec*))
   )

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_uptime.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_uptime.l
@@ -14,7 +14,7 @@
 
 (ros::rate 0.1)
 (do-until-key
-  (setq *user-name* (ros::get-param "/active_user/user_name")
+  (setq *user-name* (ros::get-param "/active_user/launch_user_name")
         *elapsed-time* (ros::get-param "/active_user/elapsed_time"))
   ;; tweet depend on up time
   (let ((st (ros::get-param "/active_user/start_time")))

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_worktime.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_worktime.l
@@ -11,7 +11,7 @@
 
 (ros::rate 0.1)
 (do-until-key
-  (setq *user-name* (ros::get-param "/active_user/user_name")
+  (setq *user-name* (ros::get-param "/active_user/launch_user_name")
         *elapsed-time* (ros::get-param "/active_user/elapsed_time"))
   (ros::ros-info "user -> ~A, time -> ~A (~A) "
                  *user-name* *elapsed-time* *target-second*)


### PR DESCRIPTION
PR2 tweets many times. But it seems to be because the joint moving judge threshold was too low...
The value PR2 always got was around 0.035, but the threshold was 0.0001 so the all time the time was judged as " move".
(This threshold might be different depending on robot)
