### PR TITLE
[jsk_robot_startup]modfiy CMakeLists.txt to install jsk_robot_startup co...

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
+++ b/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
@@ -13,3 +13,6 @@ catkin_package(
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )
+
+install(DIRECTORY lifelog util
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})


### PR DESCRIPTION
...rrectly

For #261 

```
-- Installing: /home/ros/hydro/install/share/jsk_robot_startup/package.xml
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/lifelog
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/lifelog/tweet_client_tablet.l
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/lifelog/tweet_client_warning.l
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/lifelog/tweet_client_worktime.l
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/lifelog/tweet.l
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/lifelog/tweet_client_uptime.l
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/lifelog/active_user.l
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/lifelog/tweet.launch
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/lifelog/tweet_client.l
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/lifelog/time-signal.l
-- Installing: /home/ros/hydro/install/share/jsk_robot_startup/lifelog/mongodb.launch
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/util
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/util/finish_launch_sound.py
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/util/mongod_watcher.py
-- Installing: /home//ros/hydro/install/share/jsk_robot_startup/util/start_launch_sound.py

```