### PR TITLE
add diagnostic_msgs, pr2_mechanism_controllers, sensor_msgs to build dependencies

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
+++ b/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
@@ -5,6 +5,10 @@ find_package(catkin REQUIRED COMPONENTS
   mongodb_store
   roscpp
   rospy
+  pr2_mechanism_controllers
+  diagnostic_msgs
+  sensor_msgs
+  roseus
 )
 
 catkin_package(

--- a/jsk_robot_common/jsk_robot_startup/package.xml
+++ b/jsk_robot_common/jsk_robot_startup/package.xml
@@ -10,6 +10,10 @@
   <build_depend>mongodb_store</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>roseus</build_depend>
+  <build_depend>diagnostic_msgs</build_depend>
+  <build_depend>pr2_mechanism_controllers</build_depend>
+  <build_depend>sensor_msgs</build_depend>
   <run_depend>mongodb_store</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>


### PR DESCRIPTION
this is necessary for `jsk_robot_startup/lifelog/active_user.l`