### PR TITLE
move baxter-robot-safe class to baxter-util.l, fix :self-collision-check and add test code

### DIFF
--- a/jsk_baxter_robot/baxtereus/CMakeLists.txt
+++ b/jsk_baxter_robot/baxtereus/CMakeLists.txt
@@ -5,6 +5,7 @@ project(baxtereus)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+  rostest
   collada_urdf
   euscollada
 #  baxter_description
@@ -62,3 +63,5 @@ install(DIRECTORY euslisp
   USE_SOURCE_PERMISSIONS)
 
 install(FILES baxter.l baxter-interface.l baxter-moveit.l baxter.yaml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+add_rostest(test/test-baxter.test)

--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -1,5 +1,5 @@
 (load "package://pr2eus/robot-interface.l")
-(require :baxter "package://baxtereus//baxter.l")
+(require :baxter "package://baxtereus//baxter-util.l")
 (load "package://pr2eus/speak.l")
 (ros::load-ros-manifest "control_msgs")
 (ros::load-ros-manifest "baxter_core_msgs")
@@ -247,30 +247,6 @@
 		 (send-super :angle-vector-sequence avs tms ctype start-time :scale scale :min-time min-time))
   )
 
-
-(defclass baxter-robot-safe
-  :super baxter-robot
-  :slots ())
-(defmethod baxter-robot-safe
-  (:init (&rest args)
-         (send-super* :init args)
-         (setq collision-avoidance-links (list (send self :screen_lk)
-                                               (send self :larm :wrist-r :child-link)
-                                               (send self :larm :elbow-p :child-link)
-                                               (send self :larm :elbow-r :child-link)
-                                               (send self :rarm :wrist-r :child-link)
-                                               (send self :rarm :elbow-p :child-link)
-                                               (send self :rarm :elbow-r :child-link)
-					       ))
-         (setq larm-collision-avoidance-links collision-avoidance-links)
-         (setq rarm-collision-avoidance-links collision-avoidance-links)
-         )
-  (:self-collision-check (&rest args)
-			 (if (length args)
-			     (send-super* :self-collision-check args)
-			   (send-super :self-collision-check :pairs
-				       (mapcar #'(lambda (l) (cons (car l) (cadr l)))  (combination collision-avoidance-links 2)))
-			 ))
 
 (defun baxter-init (&key (safe t))
   (if (not (boundp '*ri*))

--- a/jsk_baxter_robot/baxtereus/baxter-util.l
+++ b/jsk_baxter_robot/baxtereus/baxter-util.l
@@ -69,7 +69,7 @@
          (setq larm-collision-avoidance-links collision-avoidance-links)
          (setq rarm-collision-avoidance-links collision-avoidance-links)
          )
-  (:self-collision-check (&key (pairs (mapcar #'(lambda (l) (cons (car l) (cadr l)))  (combination collision-avoidance-links 2))) &rest args &allow-other-keys)
+  (:self-collision-check (&key (pairs (send self :collision-check-pairs :links collision-avoidance-links)) &rest args &allow-other-keys)
                          (send-super* :self-collision-check :pairs pairs args))
   )
 

--- a/jsk_baxter_robot/baxtereus/baxter-util.l
+++ b/jsk_baxter_robot/baxtereus/baxter-util.l
@@ -51,3 +51,28 @@
 (send *baxter* :larm :move-end-pos #f(160 0 0) :world :debug-view nil) ;; ng
 (send *viewer* :draw-objects)
 |#
+
+(defclass baxter-robot-safe
+  :super baxter-robot
+  :slots ())
+(defmethod baxter-robot-safe
+  (:init (&rest args)
+         (send-super* :init args)
+         (setq collision-avoidance-links (list (send self :screen_lk)
+                                               (send self :larm :wrist-r :child-link)
+                                               (send self :larm :elbow-p :child-link)
+                                               (send self :larm :elbow-r :child-link)
+                                               (send self :rarm :wrist-r :child-link)
+                                               (send self :rarm :elbow-p :child-link)
+                                               (send self :rarm :elbow-r :child-link)
+					       ))
+         (setq larm-collision-avoidance-links collision-avoidance-links)
+         (setq rarm-collision-avoidance-links collision-avoidance-links)
+         )
+  (:self-collision-check (&rest args)
+			 (if (length args)
+			     (send-super* :self-collision-check args)
+			   (send-super :self-collision-check :pairs
+				       (mapcar #'(lambda (l) (cons (car l) (cadr l)))  (combination collision-avoidance-links 2)))
+			 ))
+

--- a/jsk_baxter_robot/baxtereus/baxter-util.l
+++ b/jsk_baxter_robot/baxtereus/baxter-util.l
@@ -69,10 +69,7 @@
          (setq larm-collision-avoidance-links collision-avoidance-links)
          (setq rarm-collision-avoidance-links collision-avoidance-links)
          )
-  (:self-collision-check (&rest args)
-			 (if (length args)
-			     (send-super* :self-collision-check args)
-			   (send-super :self-collision-check :pairs
-				       (mapcar #'(lambda (l) (cons (car l) (cadr l)))  (combination collision-avoidance-links 2)))
-			 ))
+  (:self-collision-check (&key (pairs (mapcar #'(lambda (l) (cons (car l) (cadr l)))  (combination collision-avoidance-links 2))) &rest args &allow-other-keys)
+                         (send-super* :self-collision-check :pairs pairs args))
+  )
 

--- a/jsk_baxter_robot/baxtereus/package.xml
+++ b/jsk_baxter_robot/baxtereus/package.xml
@@ -12,6 +12,7 @@
 
   <build_depend>collada_urdf</build_depend>
   <build_depend>euscollada</build_depend>
+  <build_depend>rostest</build_depend>
   <!-- <build_depend>baxter_description</build_depend> -->
 
   <run_depend>collada_urdf</run_depend>
@@ -21,6 +22,7 @@
   <run_depend>baxter_tools</run_depend>
   <run_depend>roseus</run_depend>
   <run_depend>pr2eus</run_depend>
+  <run_depend>rostest</run_depend>
 
   <export>
   </export>

--- a/jsk_baxter_robot/baxtereus/test/test-baxter.l
+++ b/jsk_baxter_robot/baxtereus/test/test-baxter.l
@@ -1,0 +1,28 @@
+#!/usr/bin/env roseus
+(require :unittest "lib/llib/unittest.l")
+(require "package://baxtereus/baxter-util.l")
+
+(init-unit-test)
+
+(deftest test-safe-pose
+  (let (robot)
+    (setq robot (instance baxter-robot-safe :init))
+    (send robot :reset-pose)
+    (assert (null (send robot :self-collision-check)))
+    (send robot :reset-manip-pose)
+    (assert (null (send robot :self-collision-check)))
+    (send robot :tuck-pose)
+    (assert (null (send robot :self-collision-check)))
+    (send robot :untuck-pose)
+    (assert (null (send robot :self-collision-check)))
+    ))
+
+(deftest test-unsafe-pose
+  (let (robot)
+    (setq robot (instance baxter-robot-safe :init))
+    (send robot :angle-vector #f(0.0 74.2987 -79.5074 -174.983 146.163 -63.5022 -67.4432 39.1892 -20.0 -25.0 40.0 60.0 20.0 80.0 0.0))
+    (assert (send robot :self-collision-check))
+    ))
+
+(run-all-tests)
+(exit)

--- a/jsk_baxter_robot/baxtereus/test/test-baxter.test
+++ b/jsk_baxter_robot/baxtereus/test/test-baxter.test
@@ -1,0 +1,3 @@
+<launch>
+  <test pkg="baxtereus" type="test-baxter.l" test-name="baxter_lisp"></test>
+</launch>


### PR DESCRIPTION
@aginika, please review this code and merge if this is ok

- [test/test-baxter.{l,test}] add test code for baxter model  (:self-collision-check)
- [baxter-util.l] use :collision-check-paris to get collision link pair,  instaed of combination
- [baxter-util.l] (length args) always retruns non nil, so it never goes to self-collision-check with pairs
- [baxter-interface.l, baxter-util.l] move baxter-robot-safe class definition to baxter-util.l