### PR TITLE
[baxtereus] Add type option for baxter-init in baxtereus

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -248,9 +248,9 @@
   )
 
 
-(defun baxter-init (&key (safe t))
+(defun baxter-init (&key (safe t) (type :default-controller))
   (if (not (boundp '*ri*))
-      (setq *ri* (instance baxter-interface :init)))
+      (setq *ri* (instance baxter-interface :init :type type)))
   (if (not (boundp '*baxter*))
       (if safe
 	  (setq *baxter* (instance baxter-robot-safe :init))

--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -14,7 +14,7 @@
 			      right-gripper-type left-gripper-type))
 (defmethod baxter-interface
   (:init (&rest args)
-   (prog1 (send-super :init :robot baxter-robot :joint-states-topic "/robot/joint_states" :groupname "baxter_interface")
+   (prog1 (send-super* :init :robot baxter-robot :joint-states-topic "/robot/joint_states" :groupname "baxter_interface" args)
      (send self :add-controller :larm-controller)
      (send self :add-controller :rarm-controller)
      (send self :add-controller :head-controller)


### PR DESCRIPTION
For larm
```
(baxter-init :type :larm-controller)
```

For rarm
```
(baxter-init :type :rarm-controller)
```

For normal
```
(baxter-init)
```

