### PR TITLE
[baxter-interface.l] Overwrite controller-type with default value in angle-vector-sequence

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -244,6 +244,11 @@
 		 (when (= (length avs) 3) ;; when input avs is 1 or 2
 		   (setq avs (append avs (list (elt avs 2))))
 		   (setq tms (append tms (list 50))))
+     ;; place controller-type which was set when initialization above the passed argument
+     (unless (eq controller-type ctype)  ;; warning for unsupported argument
+       (unless (eq controller-type :default-controller)
+         (ros::ros-warn "place default controller-type ~a above the passed argument ~a" controller-type ctype)
+         (setq ctype controller-type)))
 		 (send-super :angle-vector-sequence avs tms ctype start-time :scale scale :min-time min-time))
   )
 


### PR DESCRIPTION
Thanks to https://github.com/jsk-ros-pkg/jsk_robot/pull/325, by `(setq *ri* (instance baxter-interface :init :type :rarm-controller))` we can set default controller-type of the robot. (it will be set to the slots of *ri*)
But at this time, passing ctype to `:angle-vector` or `:angle-vector-sequence` raises a problem. It does not work when the passed ctype is different from default ctype.

I expect passed ctype is overwritten by default ctype (which is passed when initialization).