### PR TITLE
[baxter-interface.l] fix wrong joint name in head_controller head-neck-y -> head_pan

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -76,7 +76,7 @@
      (cons :controller-action "/robot/head/head_action")
      (cons :controller-state "/robot/head/head_state")
      (cons :action-type control_msgs::SingleJointPositionAction)
-     (cons :joint-names (list "head-neck-y")))))
+     (cons :joint-names (list "head_pan")))))
   (:close-head-camera ()
     (send self :close-camera "head_camera")
     )


### PR DESCRIPTION
@aginika please confirm if this is ok with real robot