### PR TITLE
[baxtereus] overwrite ros-state-callback in baxter-interface.l for su…

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -246,6 +246,21 @@
 		   (setq tms (append tms (list 50))))
      (setq ctype (or ctype controller-type))  ;; use default if ctype is nil
 		 (send-super :angle-vector-sequence avs tms ctype start-time :scale scale :min-time min-time))
+  
+  (:ros-state-callback
+   (msg)
+   (let ((robot-state-names (cdr (assoc :name robot-state))) (robot-msg-names (send msg :name)) (torso-index))
+     ;;Remove toros_t0 . We think this is not the rotational-joint
+     (setq torso-index (position "torso_t0" robot-msg-names :test #'string=))
+     (send msg :name ( remove "torso_t0" robot-state-names :test #'string=))
+     (when torso-index
+       (dolist (key '(:position :velocity :effort) )
+         (send msg key (concatenate float-vector 
+                                    (subseq (send msg key) 0 torso-index)
+                                    (subseq (send msg key) (+ torso-index 1))))))
+     ;;End of Removing torso_t0
+
+     (send-super :ros-state-callback msg)
   )
 
 

--- a/jsk_baxter_robot/baxtereus/test/test-baxter.l
+++ b/jsk_baxter_robot/baxtereus/test/test-baxter.l
@@ -55,5 +55,12 @@
         )) ;; do list
     )) ;; let
 
+(require "package://baxtereus/baxter-interface.l")
+(deftest test-baxter-interface
+  (let ()
+    (setq *ri* (instance baxter-interface :init))
+    ))
+
+
 (run-all-tests)
 (exit)


### PR DESCRIPTION
…ppress torso warning


To prevent the warning of 
```
;; #<rotational-joint #X69c5998 torso_t0> :joint-angle(-719.978) violate min-angle(-172.46)
```