### PR TITLE
modify speak method

### DIFF
--- a/jsk_pepper_robot/peppereus/pepper-interface.l
+++ b/jsk_pepper_robot/peppereus/pepper-interface.l
@@ -83,7 +83,7 @@
    (str)
    (let ((speech_msg (instance std_msgs::String :init)))
      (send speech_msg :data str)
-     (ros::publish "/speech" speech_msg))
+     (ros::publish "speech" speech_msg))
    )
   (:stop-grasp
    (&optional (arm :arms))

--- a/jsk_pepper_robot/peppereus/pepper-interface.l
+++ b/jsk_pepper_robot/peppereus/pepper-interface.l
@@ -16,7 +16,7 @@
    (send-super* :init :robot robot :type type :groupname "naoqi_interface" args)
    (ros::advertise "cmd_pose" geometry_msgs::Pose2D 1)
    (ros::advertise "cmd_vel" geometry_msgs::Twist 1)
-   (ros::advertise "speech" std_msgs::String 1)
+   (ros::advertise "/speech" std_msgs::String 1)
    (ros::advertise "joint_angles" naoqi_msgs::JointAnglesWithSpeed 1)
    (setq joint-stiffness-trajectory-action
 	 (instance ros::simple-action-client :init
@@ -83,7 +83,7 @@
    (str)
    (let ((speech_msg (instance std_msgs::String :init)))
      (send speech_msg :data str)
-     (ros::publish "speech" speech_msg))
+     (ros::publish "/speech" speech_msg))
    )
   (:stop-grasp
    (&optional (arm :arms))


### PR DESCRIPTION
I deleted "/" of speech topic in speak method 
in order to keep consistency with advertise topic "speech"

That's because when I executed ```send *ri* :speak "こんにちは"```, this error occurred.
```
[ERROR] [1435115396.024964819]: attempted to publish to topic /speech, which was not previously advertised. call (ros::advertise "/speech") first.
```
Sorry for not finding this error in the first commit.