### PR TITLE
[jsk_pr2_startup/jsk_pr2_move_base] use hydro-after style move_base params

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/costmap_common_params.yaml
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/costmap_common_params.yaml
@@ -1,6 +1,4 @@
-# original : pr2_navigation_config/move_base/costmap_common_params.yaml
-#BEGIN VOXEL STUFF
-map_type: voxel
+publish_frequency: 10.0
 unknown_cost_value: 0
 obstacle_layer:
   origin_z: 0.0
@@ -13,31 +11,9 @@ z_voxels: 16
 z_resolution: 0.1125
 unknown_threshold: 8
 mark_threshold: 0
-#END VOXEL STUFF
-    
-transform_tolerance: 0.2
+transform_tolerance: 1.0 # 0.2
 obstacle_range: 2.5
 raytrace_range: 3.0
 inflation_layer:
   inflation_radius: 0.2
 inflation_radius: 0.2
-
-# BEGIN VOXEL STUFF
-observation_sources: base_scan_marking base_scan tilt_scan ground_object_cloud
-
-base_scan_marking: {sensor_frame: base_laser_link, topic: /base_scan_marking, data_type: PointCloud2, expected_update_rate: 0.2,
-  observation_persistence: 0.0, marking: true, clearing: false, min_obstacle_height: 0.08, max_obstacle_height: 2.0}
-
-base_scan: {sensor_frame: base_laser_link, topic: /base_scan, data_type: LaserScan, expected_update_rate: 0.2,
-             observation_persistence: 0.0, marking: false, clearing: true, min_obstacle_height: -0.10, max_obstacle_height: 2.0, raytrace_range: 10.0}
-# Modified : extend raytrace area (10.0 m)
-
-tilt_scan: {sensor_frame: laser_tilt_link, topic: /tilt_scan, data_type: LaserScan, expected_update_rate: 0.2,
-             observation_persistence: 0.2, marking: false, clearing: true, min_obstacle_height: -20.00, max_obstacle_height: 40.0}
-
-ground_object_cloud: {sensor_frame: laser_tilt_link, topic: /ground_object_cloud_mux, data_type: PointCloud2, expected_update_rate: 0.2,
-                       observation_persistence: 2.3, marking: true, clearing: false, min_obstacle_height: -0.10, max_obstacle_height: 1.80}
-# Modified : ground_object_cloud_mux for switch marking on/off
-# Modified : tilt laser (2.3 sec)
-# Modified : max_obstacle_height (1.8 m) for through doors
-# END VOXEL STUFF

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/global_costmap_params.yaml
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/global_costmap_params.yaml
@@ -1,0 +1,15 @@
+plugins:
+  - {name: footprint,  type: "costmap_2d::FootprintLayer" }
+  - {name: inflation,  type: "costmap_2d::InflationLayer" }
+  - {name: static_map, type: "costmap_2d::StaticLayer" }
+
+footprint: [[-0.325, -0.325], [-0.425, -0.175], [-0.425, 0.175], [-0.325, 0.325], [0.325, 0.325], [0.375, 0.0], [0.325, -0.325]]
+
+# copied from pr2_navigation_global/config/global_costmap_params.yaml
+global_frame: map
+robot_base_frame: base_footprint
+update_frequency: 5.0
+publish_frequency: 0.0
+static_map: true
+rolling_window: false
+

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/local_costmap_params.yaml
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/local_costmap_params.yaml
@@ -1,0 +1,41 @@
+plugins:
+  - {name: inflation,  type: "costmap_2d::InflationLayer" }
+  - {name: obstacles,  type: "costmap_2d::VoxelLayer" }
+  - {name: people,     type: "social_navigation_layers::ProxemicLayer" }
+  - {name: passing,    type: "social_navigation_layers::PassingLayer" }
+
+obstacles:
+  observation_sources: base_scan_marking base_scan tilt_scan ground_object_cloud # people_substruct_cloud
+  base_scan_marking: {sensor_frame: base_laser_link, topic: /base_scan_marking, data_type: PointCloud2, expected_update_rate: 0.2, observation_persistence: 0.1, marking: true, clearing: true, min_obstacle_height: 0.08, max_obstacle_height: 2.0 }
+  base_scan: {topic: /base_scan_filtered, data_type: LaserScan, sensor_frame: /base_laser_link, clearing: true, marking: false, expected_update_rate: 0.1 }
+  tilt_scan: {sensor_frame: laser_tilt_link, topic: /tilt_scan, data_type: LaserScan, expected_update_rate: 0.2, observation_persistence: 0.2, marking: false, clearing: true, min_obstacle_height: -20.00, max_obstacle_height: 40.0 }
+  ground_object_cloud: {sensor_frame: laser_tilt_link, topic: /ground_object_cloud_mux, data_type: PointCloud2, expected_update_rate: 0.2, observation_persistence: 0.7, marking: true, clearing: false, min_obstacle_height: -0.10, max_obstacle_height: 1.80}
+#  people_substruct_cloud: {sensor_frame: base_link, topic: /people_substruct_cloud, data_type: PointCloud2, expected_update_rate: 10, observation_persistence: 0.0, marking: false, clearing: true, min_obstacle_height: 0.08, max_obstacle_height: 2.0}
+people:
+  enabled: true
+  cutoff: 16.0
+  amplitude: 20.0
+  covariance: 0.25
+  factor: 5.0
+  keep_time: 0.2
+passing:
+  enabled: true
+  cutoff: 17.0
+  amplitude: 20.0
+  covariance: 0.15
+  factor: 5.0
+  keep_time: 0.2
+
+# copied from pr2_navigation_global/config/local_costmap_params.yaml
+publish_voxel_map: true
+global_frame: odom_combined
+robot_base_frame: base_footprint
+# update_frequency: 5.0
+# publish_frequency: 2.0
+static_map: false
+rolling_window: true
+width: 6.0 # 3.0
+height: 6.0 # 3.0
+resolution: 0.025 # 0.06
+origin_x: 0.0
+origin_y: 0.0

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/move_base.xml
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/move_base.xml
@@ -8,18 +8,20 @@
   <!-- Throttle the voxel grid that is being published for rviz -->
   <node ns="move_base_node/local_costmap" name="voxel_grid_throttle" pkg="topic_tools" type="throttle" machine="c2" args="messages voxel_grid 3.0 voxel_grid_throttled" />
 
-  <node pkg="move_base" type="move_base" name="move_base_node" machine="c2">
+  <node pkg="move_base" type="move_base" name="move_base_node" machine="c2"
+        launch-prefix="nice -n +10" clear_params="true">
     <remap from="odom" to="base_odometry/odom" />
     <remap from="cmd_vel" to="navigation/cmd_vel" />
 
     <!-- Use the dwa local planner for the PR2 -->
     <param name="base_local_planner" value="dwa_local_planner/DWAPlannerROS" />
+    <rosparam file="$(find jsk_pr2_startup)/jsk_pr2_move_base/dwa_local_planner.yaml" command="load" ns="DWAPlannerROS" />
 
     <!-- Load common configuration files -->
     <rosparam file="$(find jsk_pr2_startup)/jsk_pr2_move_base/move_base_params.yaml" command="load" />
     <rosparam file="$(find jsk_pr2_startup)/jsk_pr2_move_base/costmap_common_params.yaml" command="load" ns="global_costmap" />
     <rosparam file="$(find jsk_pr2_startup)/jsk_pr2_move_base/costmap_common_params.yaml" command="load" ns="local_costmap" />
-    <rosparam file="$(find jsk_pr2_startup)/jsk_pr2_move_base/dwa_local_planner.yaml" command="load" ns="DWAPlannerROS" />
+
     <rosparam file="$(find pr2_navigation_config)/move_base/recovery_behaviors.yaml" command="load" />
 
     <!-- Load global navigation specific parameters -->

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/move_base.xml
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/move_base.xml
@@ -19,14 +19,15 @@
 
     <!-- Load common configuration files -->
     <rosparam file="$(find jsk_pr2_startup)/jsk_pr2_move_base/move_base_params.yaml" command="load" />
-    <rosparam file="$(find jsk_pr2_startup)/jsk_pr2_move_base/costmap_common_params.yaml" command="load" ns="global_costmap" />
-    <rosparam file="$(find jsk_pr2_startup)/jsk_pr2_move_base/costmap_common_params.yaml" command="load" ns="local_costmap" />
-
     <rosparam file="$(find pr2_navigation_config)/move_base/recovery_behaviors.yaml" command="load" />
 
     <!-- Load global navigation specific parameters -->
-    <rosparam file="$(find pr2_navigation_global)/config/local_costmap_params.yaml" command="load"  />
-    <rosparam file="$(find pr2_navigation_global)/config/global_costmap_params.yaml" command="load" />
+    <rosparam file="$(find jsk_pr2_startup)/jsk_pr2_move_base/costmap_common_params.yaml" command="load" ns="global_costmap" />
+    <rosparam file="$(find jsk_pr2_startup)/jsk_pr2_move_base/global_costmap_params.yaml" command="load" ns="global_costmap" />
+
+    <!-- Load local navigation specific parameters -->
+    <rosparam file="$(find jsk_pr2_startup)/jsk_pr2_move_base/costmap_common_params.yaml" command="load" ns="local_costmap" />
+    <rosparam file="$(find jsk_pr2_startup)/jsk_pr2_move_base/local_costmap_params.yaml" command="load" ns="local_costmap" />
 
   </node>
 

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/move_base_params.yaml
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/move_base_params.yaml
@@ -1,11 +1,5 @@
 # this file is a copy of pr2_navigation_config/move_base/move_base_params.yaml 
 
-#footprint: [[-0.325, -0.325], [-0.325, 0.325], [0.325, 0.325], [0.46, 0.0], [0.325, -0.325]]
-local_costmap:
-  footprint: [[-0.325, -0.325], [-0.425, -0.175], [-0.425, 0.175], [-0.325, 0.325], [0.325, 0.325], [0.375, 0.0], [0.325, -0.325]]
-global_costmap:
-  footprint: [[-0.325, -0.325], [-0.425, -0.175], [-0.425, 0.175], [-0.325, 0.325], [0.325, 0.325], [0.375, 0.0], [0.325, -0.325]]
-
 controller_frequency: 10.0
 controller_patience: 15.0
 clearing_radius: 0.59


### PR DESCRIPTION
**NOTE:** please merge after https://github.com/jsk-ros-pkg/jsk_robot/pull/356

This pull req upgrades to hydro-above style move_base params, which contains multi-layered costmap, optional costmap function, and some features.

This was tested to work fine with PR1012.