### PR TITLE
modify send-stiffness-controller method for pepper

### DIFF
--- a/jsk_pepper_robot/peppereus/pepper-interface.l
+++ b/jsk_pepper_robot/peppereus/pepper-interface.l
@@ -146,6 +146,33 @@
 (defmethod pepper-interface
   (:init (&rest args)
    (send-super* :init :robot pepper-robot args))
+  (:send-stiffness-controller
+   (joint  stiffness)
+   (let ((goal (send joint-stiffness-trajectory-action :make-goal-instance))
+	 joint-name)
+     (send goal :header :seq 1)
+     (send goal :header :stamp (ros::time-now))
+     (case joint  
+       (:larm
+	(setq joint-name (list "LArm")))
+       (:rarm 
+	(setq joint-name (list "RArm")))
+       (:head
+	(setq joint-name (list "Head")))
+       (:lhand
+	(setq joint-name (list "LHand")))
+       (:rhand
+	(setq joint-name (list "RHand")))
+       )
+     (send goal :goal :trajectory :joint_names joint-name)
+     (send goal :goal :trajectory :header :stamp (ros::time-now))
+     (send goal :goal :trajectory :points
+	   (list (instance trajectory_msgs::JointTrajectoryPoint
+			   :init
+			   :positions (fill (instantiate float-vector (length joint-name)) stiffness)
+			   :time_from_start (ros::time 1))))
+     (send joint-stiffness-trajectory-action :send-goal goal)
+     ))
   (:servo-on () (call-empty-service "wakeup"))
   (:servo-off () (call-empty-service "rest"))
   )


### PR DESCRIPTION
According to http://doc.aldebaran.com/2-1/naoqi/motion/control-stiffness.html#control-stiffness,
stiffness of joints of the Pepper can be changed in only Head, LArm, RArm, LHand and RHand.
I wrote modified method of ```:send-stiffness-controller```   to change stiffness of one of these joints.
I checked all of them are changed by using this new method, but if there is a problem, please let me know.