### PR TITLE
[jsk_pr2_startup] fix typo in pr2.launch

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
@@ -1,7 +1,7 @@
 <launch>
   <node pkg="jsk_robot_startup" type="start_launch_sound.py"
         name="start_launch_sound" />
-  <arg name="map_frame" defualt="eng2" />
+  <arg name="map_frame" default="eng2" />
   <arg name="launch_openni" default="false" />
   <arg name="launch_move_base" default="true" />
   <arg name="launch_imagesift" default="false" />


### PR DESCRIPTION
In #368 , 
typo
defualt --> default