### PR TITLE
add sed command of correct spell

### DIFF
--- a/jsk_pepper_robot/peppereus/CMakeLists.txt
+++ b/jsk_pepper_robot/peppereus/CMakeLists.txt
@@ -19,6 +19,7 @@ if (EXISTS ${pepper_urdf})
   message(STATUS "Found pepper.urdf at ${pepper_urdf}")
   add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/pepper.l
     COMMAND rosrun euscollada collada2eus pepper.dae pepper.yaml pepper.l
+    COMMAND sed -i 's@JulietteY20MP@pepper@g' pepper.l
     COMMAND sed -i 's@julietteY20MP@pepper@g' pepper.l
     COMMAND sed -i 's@juliettey20mp@pepper@g' pepper.l
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_robot/tree/master/jsk_pepper_robot

After setting up environment of Pepper according to this URL, error occured when loading pepper-interface.l. This is error message.

```
/opt/ros/indigo/share/euslisp/jskeus/eus/Linux64/bin/irteusgl 0 error: unbound \
variable pepper-robot in (defmethod pepper-robot (:reset-pose nil (send self :a\
ngle-vector #f(2.0 -2.0 -5.0 85.0 10.0 -70.0 -20.0 -40.0 85.0 -10.0 70.0 20.0 4\
0.0 0.0 0.0))))
```

I think it is due to invalid replacement of string in pepper.l.
This error has not occured after modifying CMakeLists.txt.