### PR TITLE
[jsk_robot_startup] support daemon mode mongod; enable replication to jsk robot-database

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -1,0 +1,18 @@
+jsk_robot_startup
+===
+
+# lifelog/mongodb.launch
+
+Launch file for logging data of robots.
+
+## setup
+
+### specify robot identifier
+
+- open `~/.bashrc` and write your own robot identifier:
+
+```bash
+export ROBOT_NAME=pr1012 # pr1040, baxter, pepper, etc...
+```
+
+- include `launch/mongodb.launch` in your robot startup launch file.

--- a/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
@@ -2,11 +2,26 @@
   <arg name="db_path" default="/var/lib/robot/mongodb_store"/>
   <arg name="port" default="62345" />
   <arg name="repl_set_mode" default="false" />
+  <arg name="use_daemon" default="false" />
+  <arg name="replicate" default="true" />
+  <arg name="db_name" default="jsk_robot_lifelog"/>
+  <arg name="robot_name" default="$(env ROBOT_NAME)" />
+
+  <!-- Replication -->
+  <group if="$(arg replicate)">
+    <rosparam command="load"
+              file="$(find jsk_robot_startup)/lifelog/mongodb_replication_params.yaml" />
+    <node name="replication_client"
+          pkg="mongodb_store" type="replicator_client.py"
+          args="$(arg db_name) $(arg robot_name)"
+          output="screen"/>
+  </group>
 
   <!-- MongoDB -->
   <include file="$(find mongodb_store)/launch/mongodb_store.launch">
     <arg name="db_path" value="$(arg db_path)" />
     <arg name="port" value="$(arg port)" />
+    <arg name="use_daemon" value="$(arg use_daemon)" />
     <arg name="use_machine" value="false" />
     <arg name="use_repl_set" value="true"
          if="$(arg repl_set_mode)" />

--- a/jsk_robot_common/jsk_robot_startup/lifelog/mongodb_replication_params.yaml
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/mongodb_replication_params.yaml
@@ -1,0 +1,1 @@
+mongodb_store_extras: [["robot-database.jsk.imi.i.u-tokyo.ac.jp", 27017]]


### PR DESCRIPTION
- This feature enables to launch mongodb interfaces for ros using existing mongod instead of launching `mongodb_server.py`(which launches `mongod` as subprocess. this seems to be troublesome on multiusers environment.)
  This feature is assumed to be used with `mongodb_store` after merged https://github.com/strands-project/mongodb_store/pull/139

- automatically replicate to jsk robot-database server when launching `mongo.launch`