### PR TITLE
[jsk_pr2_startup] add rosinstall for jsk pr2

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2.rosinstall
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2.rosinstall
@@ -1,0 +1,19 @@
+- git: {local-name: jsk-ros-pkg/jsk_demos, uri: 'https://github.com/jsk-ros-pkg/jsk_demos.git'}
+
+# temporally added for specific reason
+## jsk-ros-pkg/jsk_smart_apps: not released this repo
+- git: {local-name: jsk-ros-pkg/jsk_smart_apps, uri: 'https://github.com/jsk-ros-pkg/jsk_smart_apps.git'}
+## jsk-ros-pkg/jsk_robot: not yet released latest version
+- git: {local-name: jsk-ros-pkg/jsk_robot, uri: 'https://github.com/jsk-ros-pkg/jsk_robot.git'}
+## jsk-ros-pkg/jsk_recognition: it fails creating PointCloud from kinect depth image with apt version
+- git: {local-name: jsk-ros-pkg/jsk_recognition, uri: 'https://github.com/jsk-ros-pkg/jsk_recognition.git'}
+## pr2_navigation: PR2/pr2_navigation#18 not released -> PR2/pr2_navigation#19
+- git: {local-name: pr2_navigation, uri: 'https://github.com/pr2/pr2_navigation',
+    version: hydro-devel}
+## jsk-ros-pkg/jsk_common: not yet released latest version (jsk-ros-pkg/jsk_common#1028)
+- git: {local-name: jsk-ros-pkg/jsk_common, uri: 'https://github.com/jsk-ros-pkg/jsk_common'}
+## SharedAutonomyToolkit/shared_autonomy_manipulation: not released this repo
+- git: {local-name: SharedAutonomyToolkit/shared_autonomy_manipulation, uri: 'https://github.com/SharedAutonomyToolkit/shared_autonomy_manipulation'}
+## snap_map_icp: not released this repo
+- git: {local-name: snap_map_icp, uri: 'https://github.com/code-iai/snap_map_icp.git',
+    version: hydro-devel}


### PR DESCRIPTION
This PR adds .rosinstall to install packages needed for executing below:
- `robot start`
- `roslaunch jsk_pr2_startup pr2.launch`
- `roslaunch detect_cans_in_fridge201202 startup.launch`
- `rosrun detect_cans_in_fridge201202 main.l`

This rosinstall file includes some packages added temporally for various reason, which should be removed after resolving problems.