### PR TITLE
[jsk_pr2_startup] add gazebo param to pr2.launch to switch laser_scan…

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
@@ -18,6 +18,7 @@
   <arg name="launch_people_detection" default="true" />
   <arg name="slow_camera_framerate" default="true" />
   <arg name="launch_c3_startup" default="false" />
+  <arg name="gazebo" default="false" />
   <arg name="USER_NAME" default="false" />
   <include file="$(find jsk_pr2_startup)/jsk_pr2.machine"
            if="$(arg launch_c3_startup)" />
@@ -27,7 +28,9 @@
 
   <!-- launch jsk-defined pr2_2dnav that respawn for change inflation_radius -->
   <include if="$(arg launch_move_base)"
-           file="$(find jsk_pr2_startup)/jsk_pr2_move_base/pr2_2dnav.launch" />
+           file="$(find jsk_pr2_startup)/jsk_pr2_move_base/pr2_2dnav.launch">
+    <arg name="gazebo" value="$(arg gazebo)"/>
+  </include>
 
   <!-- special start: use when launuch_move_base is false-->
   <group unless="$(arg launch_move_base)" >

--- a/jsk_pr2_robot/jsk_pr2_startup/pr2_gazebo.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2_gazebo.launch
@@ -102,5 +102,6 @@
     <arg name="launch_gripper_sensor" value="false" />
     <arg name="slow_camera_framerate" value="false" />
     <arg name="launch_c3_startup" value="false" />
+    <arg name="gazebo" value="true" />
   </include>
 </launch>


### PR DESCRIPTION
… chain

In `jsk_pr2_startup/jsk_pr2_sensors`, there is a tilt_laser_filters_for_gazebo.xml.
Withouth this, the gazebo pr2's tilt_laser and base_laser node will crash and respawn...
The difference between the normal tilt_laser_filters.xml (pr2_navigation_perception/config/) and this one is below
```
- name: dark_shadows
  type: LaserScanIntensityFilter
  params:
    lower_threshold: 100
    upper_threshold: 10000
    disp_histogram: 0
```

So I added the gazebo param.