### PR TITLE
do not add naoqi_driver in find_package

### DIFF
--- a/jsk_nao_robot/jsk_nao_startup/CMakeLists.txt
+++ b/jsk_nao_robot/jsk_nao_startup/CMakeLists.txt
@@ -4,11 +4,7 @@ project(jsk_nao_startup)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
-  naoqi_driver
-  roseus
-  rostwitter
-)
+find_package(catkin REQUIRED COMPONENTS roseus)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/jsk_pepper_robot/peppereus/CMakeLists.txt
+++ b/jsk_pepper_robot/peppereus/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(peppereus)
 
-find_package(catkin REQUIRED pepper_description pepper_bringup nao_interaction_msgs naoqi_driver roseus rostest)
+find_package(catkin REQUIRED pepper_description roseus rostest)
 
 catkin_package()
 


### PR DESCRIPTION
this is blonking , for example , https://travis-ci.org/jsk-ros-pkg/jsk_robot/jobs/75220393

```
[peppereus] -- Found Threads: TRUE                                              
[peppereus] -- Found gtest sources under '/usr/src/gtest': gtests will be built 
[peppereus] -- Using Python nosetests: /usr/bin/nosetests-2.7                   
[peppereus] -- catkin 0.6.14                                                    
[peppereus] -- Using these message generators: gencpp;geneus;genlisp;genpy      
[peppereus] CMake Error at /opt/ros/indigo/share/naoqi_driver/cmake/naoqi_driverConfig.cmake:141 (message): 
[peppereus]   Project 'peppereus' tried to find library 'naoqi_driver_node'.  The library 
[peppereus]   is neither a target nor built/installed properly.  Did you compile project 
[peppereus]   'naoqi_driver'? Did you find_package() it before the subdirectory 
[peppereus]   containing its code is included?                                  
[peppereus] Call Stack (most recent call first):                                
[peppereus]   /opt/ros/indigo/share/catkin/cmake/catkinConfig.cmake:75 (find_package) 
[peppereus]   CMakeLists.txt:4 (find_package)                                   
[peppereus]                                                                     
[peppereus]                                                                     
[peppereus] -- Configuring incomplete, errors occurred!                         
```