### PR TITLE
[jsk_pr2_startup] change the order of local costmap plugin

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/local_costmap_params.yaml
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/local_costmap_params.yaml
@@ -1,6 +1,6 @@
 plugins:
-  - {name: inflation,  type: "costmap_2d::InflationLayer" }
   - {name: obstacles,  type: "costmap_2d::VoxelLayer" }
+  - {name: inflation,  type: "costmap_2d::InflationLayer" }
   - {name: people,     type: "social_navigation_layers::ProxemicLayer" }
   - {name: passing,    type: "social_navigation_layers::PassingLayer" }
 


### PR DESCRIPTION
As we can see in https://github.com/search?q=costmap+plugins+name&type=Code&utf8=%E2%9C%93 and http://wiki.ros.org/hydro/Migration#Navigation_-_Costmap2D,
costmap plugin's inflation should be after the obstacles.

This will change the below (Only Obstacles you can see)
![infrationlayerproblem](https://cloud.githubusercontent.com/assets/3803922/9659900/db421e16-528d-11e5-9c13-2b43492e7343.png)


To (You can see both obstacles and costmap)
![localcostmapproblem](https://cloud.githubusercontent.com/assets/3803922/9659903/dfd80b52-528d-11e5-844c-46053a268e92.png)
