### PR TITLE
[jsk_pr2_startup/jsk_pr2_lifelog/objectdetection_db.py] store NOT '_agg' topics instead of '_agg'

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/objectdetection_db.py
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/objectdetection_db.py
@@ -78,7 +78,7 @@ class ObjectDetectionDB(object):
 
     def _update_subscribers(self):
         current_subscribers = rospy.client.get_published_topics()
-        targets = [x for x in current_subscribers if x[1]=='posedetection_msgs/ObjectDetection' and ('_agg' in x[0])]
+        targets = [x for x in current_subscribers if x[1]=='posedetection_msgs/ObjectDetection' and (not ('_agg' in x[0]))]
         for sub in self.subscribers:
             if sub.get_num_connections() == 0:
                 sub.unregister()


### PR DESCRIPTION
for support applications that publish msgs without "_agg" topic