### PR TITLE
[jsk_pr2_startup/pr2_bringup.launch] use replication dump temp path on /removable instead of /tmp

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/pr2_bringup.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2_bringup.launch
@@ -165,5 +165,6 @@
     <arg name="use_daemon" value="true"/>
     <arg name="port" value="27017" />
     <arg name="repl_set_mode" value="false" />
+    <arg name="replicator_dump_path" value="/removable/replicator_dumps" />
   </include>
 </launch>


### PR DESCRIPTION
because dump-ing replication data on /tmp exceeds pr2 internal hdd.