### PR TITLE
[jsk_pr2_startup] Wording in plugin description

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/plugin.xml
+++ b/jsk_pr2_robot/jsk_pr2_startup/plugin.xml
@@ -3,12 +3,22 @@
          type="jsk_pr2_startup.image_snapshot.ImageSnapShotGUI"
          base_class_type="rqt_gui_py::Plugin">
     <description>
-      hogehogehoge
+      ImageSnapShotGUI descriptions
     </description>
     <qtgui>
-      <label>Hoge</label>
+      <group>
+        <label>Robot</label>
+        <icon type="theme">folder</icon>
+        <statustip>Plugins related to specific robots.</statustip>
+      </group>
+      <group>
+        <label>PR2</label>
+         <icon type="theme">folder</icon>
+        <statustip>PR2 specific rqt plugins</statustip>
+      </group>
+      <label>ImageSnapShotGUI</label>
       <icon type="theme">utilities-system-monitor</icon>
-      <statustip>hogehoge</statustip>
+      <statustip>ImageSnapShotGUI descriptions</statustip>
     </qtgui>
   </class>
 </library>


### PR DESCRIPTION
Without this PR, on the top level of the list of all rqt plugins there's `Hoge`.