### PR TITLE
Integrate odometry when feedback

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/config/OdometryFeedbackWrapperReconfigure.cfg
+++ b/jsk_robot_common/jsk_robot_startup/config/OdometryFeedbackWrapperReconfigure.cfg
@@ -11,6 +11,7 @@ gen.add("sigma_z", double_t, 0, "sigma of distribution on z velocity", 0.3, 0.00
 gen.add("sigma_roll", double_t, 0, "sigma of distribution on roll angular velocity", 0.3, 0.0001, 10.0)
 gen.add("sigma_pitch", double_t, 0, "sigma of distribution on pitch angular velocity", 0.3, 0.0001, 10.0)
 gen.add("sigma_yaw", double_t, 0, "sigma of distribution on yaw angular velocity", 0.3, 0.0001, 10.0)
-gen.add("feedback_enabled_sigma", double_t, 0, "Odometry feedback is enabled when sigma is larger than this value", 0.0001, 0.3, 10.0)
+gen.add("force_feedback_sigma", double_t, 0, "Odometry feedback is forcely enabled when sigma is larger than this value", 0.0001, 0.3, 10.0)
+gen.add("distribution_feedback_minimum_sigma", double_t, 0, "Distribution check is enabled when sigma is larger than this value", 0.0001, 0.3, 10.0)
 
 exit(gen.generate(PACKAGE, "odometry_feedback_wrapper_reconfigure", "OdometryFeedbackWrapperReconfigure"))

--- a/jsk_robot_common/jsk_robot_startup/launch/odometry_integration.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/odometry_integration.launch
@@ -7,43 +7,67 @@
     <arg name="publish_viso_tf" default="true" />
     <arg name="invert_viso_tf" default="true" /> 
   </include>
+
+  <!-- odometry offset for odom_init -->
+  <node pkg="jsk_robot_startup" type="odometry_offset.py" name="biped_odometry_offset"
+        output="screen" >
+    <remap from="~source_odom" to="/odom" />
+    <remap from="~output" to="/biped_odom_offset" />
+    <remap from="~init_signal" to="/odom_init_trigger" />
+    <param name="~base_odom_frame" value="/odom_init" />
+    <param name="~odom_frame" value="biped_odom_offset" />
+    <param name="~base_link_frame" value="BODY" />     
+  </node>
+  <node pkg="jsk_robot_startup" type="odometry_offset.py" name="viso_odometry_offset"
+        output="screen" >
+    <remap from="~source_odom" to="/viso_odom" />
+    <remap from="~output" to="/viso_odom_offset" />
+    <remap from="~init_signal" to="/odom_init_trigger" />    
+    <param name="~base_odom_frame" value="/odom_init" />
+    <param name="~odom_frame" value="viso_odom_offset" />
+    <param name="~base_link_frame" value="BODY" />
+  </node>
   
   <!-- wrapper for feedback -->
   <node pkg="jsk_robot_startup" type="odom_feedback_wrapper.py" name="biped_odom_calculator"
         output="screen" >
     <remap from="~init_signal" to="/odom_init_trigger" />
-    <remap from="~source_odom" to="/odom" />
+    <remap from="~source_odom" to="/biped_odom_offset" />
     <remap from="~feedback_odom" to="/integrated_odom" />
     <remap from="~output" to="/biped_odom_integrated" />
-    <param name="~odom_init_frame" value="/odom_init" />
     <param name="~odom_frame" value="biped_odom_integrated" />
     <param name="~base_link_frame" value="BODY" />
     <param name="~rate" value="10" />
-    <param name="~sigma_x" value="0.2" />
-    <param name="~sigma_y" value="0.2" />
-    <param name="~sigma_z" value="0.0001" />
-    <param name="~sigma_roll" value="0.0001" />
-    <param name="~sigma_pitch" value="0.0001" />
-    <param name="~sigma_yaw" value="0.2" />
-    <param name="~feedback_enabled_sigma" value="0.5" />
+    <param name="~sigma_x" value="3.0" />
+    <param name="~sigma_y" value="3.0" />
+    <param name="~sigma_z" value="0.001" />
+    <param name="~sigma_roll" value="0.001" />
+    <param name="~sigma_pitch" value="0.001" />
+    <param name="~sigma_yaw" value="2.0" />
+    <param name="~twist_proportional_sigma" value="true" />
+    <param name="~force_feedback_sigma" value="1.0" />
+    <param name="~distribution_feedback_minimum_sigma" value="0.3" />
+    <param name="~max_feedback_time" value="180" />    
   </node>
   <node pkg="jsk_robot_startup" type="odom_feedback_wrapper.py" name="viso_odom_calculator"
         output="screen" >
     <remap from="~init_signal" to="/odom_init_trigger" />
-    <remap from="~source_odom" to="/viso_odom" />
+    <remap from="~source_odom" to="/viso_odom_offset" />
     <remap from="~feedback_odom" to="/integrated_odom" />
     <remap from="~output" to="/viso_odom_integrated" />
-    <param name="~odom_init_frame" value="/odom_init" />
     <param name="~odom_frame" value="viso_odom_integrated" />
     <param name="~base_link_frame" value="BODY" /> 
     <param name="~rate" value="5" />
-    <param name="~sigma_x" value="0.1" />
-    <param name="~sigma_y" value="0.1" />
-    <param name="~sigma_z" value="0.1" />
-    <param name="~sigma_roll" value="0.2" />
-    <param name="~sigma_pitch" value="0.2" />
-    <param name="~sigma_yaw" value="0.2" />
-    <param name="~feedback_enabled_sigma" value="1.0" />
+    <param name="~sigma_x" value="3.0" />
+    <param name="~sigma_y" value="3.0" />
+    <param name="~sigma_z" value="3.0" />
+    <param name="~sigma_roll" value="2.0" />
+    <param name="~sigma_pitch" value="2.0" />
+    <param name="~sigma_yaw" value="2.0" />
+    <param name="~twist_proportional_sigma" value="true" />
+    <param name="~force_feedback_sigma" value="1.0" />    
+    <param name="~distribution_feedback_minimum_sigma" value="0.3" />
+    <param name="~max_feedback_time" value="180" />    
   </node>
 
   <!-- integration node -->  
@@ -53,7 +77,7 @@
     <remap from="~source_odom_1" to="/viso_odom_integrated" />
     <remap from="~output" to="/integrated_odom" />
     <param name="~rate" value="1" />
-    <param name="~time_threshould" value="1.0" />
+    <param name="~time_threshould" value="3.0" />
   </node>
 
 </launch>

--- a/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
@@ -47,8 +47,9 @@
     <param name="~sigma_roll" value="2.0" />
     <param name="~sigma_pitch" value="2.0" />
     <param name="~sigma_yaw" value="2.0" />
-    <param name="~feedback_enabled_sigma" value="1.0" />
     <param name="~twist_proportional_sigma" value="true" />
+    <param name="~force_feedback_sigma" value="1.0" />
+    <param name="~distribution_feedback_minimum_sigma" value="1.0" />
   </node>
   
   <node pkg="jsk_robot_startup" type="particle_odometry.py" name="biped_particle_odometry"

--- a/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
@@ -50,7 +50,7 @@
     <param name="~twist_proportional_sigma" value="true" />
     <param name="~force_feedback_sigma" value="1.0" />
     <param name="~distribution_feedback_minimum_sigma" value="0.3" />
-    <param name="~max_feedback_time" value="180" />    
+    <param name="~max_feedback_time" value="0" />    
   </node>
 
   <!-- odometry integration with particle filter -->  

--- a/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
@@ -18,7 +18,6 @@
     <param name="~base_odom_frame" value="/odom_init" />
     <param name="~odom_frame" value="biped_odom_offset" />
     <param name="~base_link_frame" value="BODY" />     
-    <param name="~rate" value="100" />
   </node>
 
   <node pkg="jsk_robot_startup" type="odometry_offset.py" name="viso_odometry_offset"
@@ -29,7 +28,6 @@
     <param name="~base_odom_frame" value="/odom_init" />
     <param name="~odom_frame" value="viso_odom_offset" />
     <param name="~base_link_frame" value="BODY" />
-    <param name="~rate" value="100" />
   </node>
 
   <node pkg="jsk_robot_startup" type="odom_feedback_wrapper.py" name="viso_odom_calculator"
@@ -63,7 +61,7 @@
     <param name="~odom_init_frame" value="/odom_init" />
     <param name="~odom_frame" value="biped_odom_particle" />
     <param name="~base_link_frame" value="BODY" />
-    <param name="~rate" value="10" />
+    <param name="~rate" value="20" />
     <param name="~use_imu" value="$(arg use_imu)" />
   </node>
   

--- a/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
@@ -49,7 +49,8 @@
     <param name="~sigma_yaw" value="2.0" />
     <param name="~twist_proportional_sigma" value="true" />
     <param name="~force_feedback_sigma" value="1.0" />
-    <param name="~distribution_feedback_minimum_sigma" value="1.0" />
+    <param name="~distribution_feedback_minimum_sigma" value="0.3" />
+    <param name="~max_feedback_time" value="180" />    
   </node>
   
   <node pkg="jsk_robot_startup" type="particle_odometry.py" name="biped_particle_odometry"

--- a/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
@@ -21,7 +21,6 @@
     <param name="~rate" value="100" />
   </node>
 
-  <!--
   <node pkg="jsk_robot_startup" type="odometry_offset.py" name="viso_odometry_offset"
         output="screen" >
     <remap from="~source_odom" to="/viso_odom" />
@@ -32,16 +31,13 @@
     <param name="~base_link_frame" value="BODY" />
     <param name="~rate" value="100" />
   </node>
-  -->
 
   <node pkg="jsk_robot_startup" type="odom_feedback_wrapper.py" name="viso_odom_calculator"
         output="screen" >
     <remap from="~init_signal" to="/odom_init_trigger" />
-    <remap from="~init_odom" to="/odom" />    
     <remap from="~source_odom" to="/viso_odom" />
     <remap from="~feedback_odom" to="/biped_odom_particle" />
     <remap from="~output" to="/viso_odom_integrated" />
-    <param name="~odom_init_frame" value="/odom_init" />
     <param name="~odom_frame" value="viso_odom_integrated" />
     <param name="~base_link_frame" value="BODY" /> 
     <param name="~rate" value="10" />

--- a/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
@@ -9,7 +9,8 @@
     <arg name="publish_viso_tf" default="true" />
     <arg name="invert_viso_tf" default="true" /> 
   </include>
-  
+
+  <!-- odometry offset to adjust origin to odom_init -->
   <node pkg="jsk_robot_startup" type="odometry_offset.py" name="biped_odometry_offset"
         output="screen" >
     <remap from="~source_odom" to="/odom" />
@@ -30,6 +31,7 @@
     <param name="~base_link_frame" value="BODY" />
   </node>
 
+  <!-- odometry feedback to prevent drift -->
   <node pkg="jsk_robot_startup" type="odom_feedback_wrapper.py" name="viso_odom_calculator"
         output="screen" >
     <remap from="~init_signal" to="/odom_init_trigger" />
@@ -50,7 +52,8 @@
     <param name="~distribution_feedback_minimum_sigma" value="0.3" />
     <param name="~max_feedback_time" value="180" />    
   </node>
-  
+
+  <!-- odometry integration with particle filter -->  
   <node pkg="jsk_robot_startup" type="particle_odometry.py" name="biped_particle_odometry"
         output="screen">
     <remap from="~source_odom" to="/biped_odom_offset" />

--- a/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/particle_odometry.launch
@@ -1,6 +1,15 @@
 <launch>
   <arg name="use_imu" default="false"/>
   
+  <!-- viso -->
+  <include file="$(find jsk_robot_startup)/launch/viso.launch">
+    <arg name="stereo" default="multisense" />
+    <arg name="image" default="image_rect" />
+    <arg name="use_robot_pose_ekf" default="false" />
+    <arg name="publish_viso_tf" default="true" />
+    <arg name="invert_viso_tf" default="true" /> 
+  </include>
+  
   <node pkg="jsk_robot_startup" type="odometry_offset.py" name="biped_odometry_offset"
         output="screen" >
     <remap from="~source_odom" to="/odom" />
@@ -12,6 +21,7 @@
     <param name="~rate" value="100" />
   </node>
 
+  <!--
   <node pkg="jsk_robot_startup" type="odometry_offset.py" name="viso_odometry_offset"
         output="screen" >
     <remap from="~source_odom" to="/viso_odom" />
@@ -22,11 +32,33 @@
     <param name="~base_link_frame" value="BODY" />
     <param name="~rate" value="100" />
   </node>
+  -->
 
+  <node pkg="jsk_robot_startup" type="odom_feedback_wrapper.py" name="viso_odom_calculator"
+        output="screen" >
+    <remap from="~init_signal" to="/odom_init_trigger" />
+    <remap from="~init_odom" to="/odom" />    
+    <remap from="~source_odom" to="/viso_odom" />
+    <remap from="~feedback_odom" to="/biped_odom_particle" />
+    <remap from="~output" to="/viso_odom_integrated" />
+    <param name="~odom_init_frame" value="/odom_init" />
+    <param name="~odom_frame" value="viso_odom_integrated" />
+    <param name="~base_link_frame" value="BODY" /> 
+    <param name="~rate" value="10" />
+    <param name="~sigma_x" value="3.0" />
+    <param name="~sigma_y" value="3.0" />
+    <param name="~sigma_z" value="3.0" />
+    <param name="~sigma_roll" value="2.0" />
+    <param name="~sigma_pitch" value="2.0" />
+    <param name="~sigma_yaw" value="2.0" />
+    <param name="~feedback_enabled_sigma" value="1.0" />
+    <param name="~twist_proportional_sigma" value="true" />
+  </node>
+  
   <node pkg="jsk_robot_startup" type="particle_odometry.py" name="biped_particle_odometry"
         output="screen">
     <remap from="~source_odom" to="/biped_odom_offset" />
-    <remap from="~measure_odom" to="/viso_odom_offset" />
+    <remap from="~measure_odom" to="/viso_odom_integrated" />
     <remap from="~output" to="/biped_odom_particle" />
     <remap from="~init_signal" to="/odom_init_trigger" />
     <remap from="~imu" to="/imu" />

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/OdometryFeedbackWrapper.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/OdometryFeedbackWrapper.py
@@ -265,18 +265,26 @@ class OdometryFeedbackWrapper(object):
         pose.pose.position.z += global_twist.linear.z * dt
         pose.pose.orientation = self.calculate_quaternion_transform(pose.pose.orientation, twist.twist.angular, dt)
 
-    def calculate_quaternion_transform(self, orientation, angular, dt):
+    def calculate_quaternion_transform(self, orientation, angular, dt): # angular is assumed to be global
         # quaternion calculation
-        # cf. https://repository.exst.jaxa.jp/dspace/bitstream/a-is/23926/1/naltm00636.pdf
         quat_vec = numpy.array([[orientation.x],
                                 [orientation.y],
                                 [orientation.z],
                                 [orientation.w]])
-        skew_omega = numpy.matrix([[0, angular.z, -angular.y, angular.x],
-                                   [-angular.z, 0, angular.x, angular.y],
-                                   [angular.y, -angular.x, 0, angular.z],
+        # skew_omega = numpy.matrix([[0, angular.z, -angular.y, angular.x],
+        #                            [-angular.z, 0, angular.x, angular.y],
+        #                            [angular.y, -angular.x, 0, angular.z],
+        #                            [-angular.x, -angular.y, -angular.z, 0]])
+        skew_omega = numpy.matrix([[0, -angular.z, angular.y, angular.x],
+                                   [angular.z, 0, -angular.x, angular.y],
+                                   [-angular.y, angular.x, 0, angular.z],
                                    [-angular.x, -angular.y, -angular.z, 0]])
         new_quat_vec = quat_vec + 0.5 * numpy.dot(skew_omega, quat_vec) * dt
+        norm = numpy.linalg.norm(new_quat_vec)
+        if norm == 0:
+            rospy.logwarn("norm of quaternion is zero")
+        else:
+            new_quat_vec = new_quat_vec / norm # normalize
         return Quaternion(*numpy.array(new_quat_vec).reshape(-1,).tolist())
         
     def update_twist_covariance(self, twist):

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/OdometryFeedbackWrapper.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/OdometryFeedbackWrapper.py
@@ -1,5 +1,8 @@
 #! /usr/bin/env python
 
+# This script only calculate offset caused by odometry feedback and do not consider initial offset.
+# Initial offset should be calculated by OdometryOffset.py (source_odom is assumed to be offseted already) 
+
 import rospy
 import numpy
 from nav_msgs.msg import Odometry

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/OdometryFeedbackWrapper.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/OdometryFeedbackWrapper.py
@@ -45,11 +45,11 @@ class OdometryFeedbackWrapper(object):
                         rospy.get_param("~sigma_yaw", 0.01)]
         self.force_feedback_sigma = rospy.get_param("~force_feedback_sigma", 0.5)
         self.distribution_feedback_minimum_sigma = rospy.get_param("~distribution_feedback_minimum_sigma", 0.5)
-        self.pub = rospy.Publisher("~output", Odometry)
+        self.pub = rospy.Publisher("~output", Odometry, queue_size = 1)
         self.initialize_odometry()
-        self.init_signal_sub = rospy.Subscriber("~init_signal", Empty, self.init_signal_callback)
-        self.source_odom_sub = rospy.Subscriber("~source_odom", Odometry, self.source_odom_callback)
-        self.feedback_odom_sub = rospy.Subscriber("~feedback_odom", Odometry, self.feedback_odom_callback)
+        self.init_signal_sub = rospy.Subscriber("~init_signal", Empty, self.init_signal_callback, queue_size = 10)
+        self.source_odom_sub = rospy.Subscriber("~source_odom", Odometry, self.source_odom_callback, queue_size = 10)
+        self.feedback_odom_sub = rospy.Subscriber("~feedback_odom", Odometry, self.feedback_odom_callback, queue_size = 10)
         self.reconfigure_server = Server(OdometryFeedbackWrapperReconfigureConfig, self.reconfigure_callback)
 
     def execute(self):

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/OdometryOffset.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/OdometryOffset.py
@@ -27,7 +27,7 @@ class OdometryOffset(object):
         self.lock = threading.Lock()
         self.source_odom_sub = rospy.Subscriber("~source_odom", Odometry, self.source_odom_callback)
         self.init_signal_sub = rospy.Subscriber("~init_signal", Empty, self.init_signal_callback)
-        self.pub = rospy.Publisher("~output", Odometry)        
+        self.pub = rospy.Publisher("~output", Odometry, queue_size = 1)
 
     def execute(self):
         while not rospy.is_shutdown():

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/ParticleOdometry.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/ParticleOdometry.py
@@ -67,23 +67,23 @@ class ParticleOdometry(object):
         self.particles = None
         self.weights = []
         self.measurement_updated = False
-        self.init_sigma = [rospy.get_param("~init_sigma_x", 0.3),
-                           rospy.get_param("~init_sigma_y", 0.3),
+        self.init_sigma = [rospy.get_param("~init_sigma_x", 0.1),
+                           rospy.get_param("~init_sigma_y", 0.1),
                            rospy.get_param("~init_sigma_z", 0.0001),
                            rospy.get_param("~init_sigma_roll", 0.0001),
                            rospy.get_param("~init_sigma_pitch", 0.0001),
-                           rospy.get_param("~init_sigma_yaw", 0.2)]
+                           rospy.get_param("~init_sigma_yaw", 0.05)]
         # tf
         self.listener = tf.TransformListener(True, rospy.Duration(10))
         self.broadcast = tf.TransformBroadcaster()
         self.publish_tf = rospy.get_param("~publish_tf", True)
         self.invert_tf = rospy.get_param("~invert_tf", True)
         # publisher
-        self.pub = rospy.Publisher("~output", Odometry, queue_size=10)
+        self.pub = rospy.Publisher("~output", Odometry, queue_size = 1)
         # subscriber
-        self.source_odom_sub = rospy.Subscriber("~source_odom", Odometry, self.source_odom_callback, queue_size = 100)
-        self.measure_odom_sub = rospy.Subscriber("~measure_odom", Odometry, self.measure_odom_callback, queue_size = 100)
-        self.imu_sub = rospy.Subscriber("~imu", Imu, self.imu_callback, queue_size = 100)
+        self.source_odom_sub = rospy.Subscriber("~source_odom", Odometry, self.source_odom_callback, queue_size = 10)
+        self.measure_odom_sub = rospy.Subscriber("~measure_odom", Odometry, self.measure_odom_callback, queue_size = 10)
+        self.imu_sub = rospy.Subscriber("~imu", Imu, self.imu_callback, queue_size = 10)
         self.init_signal_sub = rospy.Subscriber("~init_signal", Empty, self.init_signal_callback, queue_size = 10)
         # init
         self.initialize_odometry()


### PR DESCRIPTION
I'm sorry for large PR.

- Use odometry integration when feedback odometry
  - simple overwrite caused particle degeneracy in ParticleOdometry.
- Calculate transformation instead of integrate velocity from odometry sources.
  - accumulating errors of velocity integration was not small enough to be ignored.
- Fix calculation method for rotation
  - previous method used euler angle but its singularity causes angle jump around pi rotation in yaw angle.
