### PR TITLE
[naoqieus] :enable-life, :disable-life, :get-life are added

### DIFF
--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -145,7 +145,9 @@
   (:disable-life () (call-empty-service (format nil "~A/pose/life/disable" naoqi-namespace)))
   (:get-life ()
 	     (ros::wait-for-service (format nil "~A/pose/life/getState" naoqi-namespace))
-	     (setq ret (instance naoqi_bridge_msgs::GetAlifeStateRequest :init))
-	     (ros::service-call (format nil "~A/pose/life/getState" naoqi-namespace) ret))
+	     (setq req (instance naoqi_bridge_msgs::GetAlifeStateRequest :init))
+	     (setq res (ros::service-call (format nil "~A/pose/life/getState" naoqi-namespace) req))
+	     (send res :status :data)
+	     )
   )
 ;;

--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -141,6 +141,11 @@
      (setq ret (instance nao_interaction_msgs::AudioMasterVolumeRequest :init))
      (send ret :master_volume :data volume)
      (setq ret (ros::service-call "nao_audio/master_volume" ret))))
+  (:enable-life () (call-empty-service (format nil "~A/pose/life/enable" naoqi-namespace)))	
+  (:disable-life () (call-empty-service (format nil "~A/pose/life/disable" naoqi-namespace)))
+  (:get-life ()
+	     (ros::wait-for-service (format nil "~A/pose/life/getState" naoqi-namespace))
+	     (setq ret (instance naoqi_bridge_msgs::GetAlifeStateRequest :init))
+	     (ros::service-call (format nil "~A/pose/life/getState" naoqi-namespace) ret))
   )
-
 ;;


### PR DESCRIPTION
I added three methods related to AutonomousLife.
<example>
```
roslaunch jsk_pepper_startup jsk_pepper_startup.launch 
roseus pepper-interface.l
(send *ri* :enable-life) => ALife is set to solitary
(send *ri* :disable-life) => ALife is set to disabled
(send *ri* :get-life) => "[INFO] [WallTime: 1456383415.933722] Current Life State: solitary" appeared in the launched terminal
```

前のプルリクエストで☓がついているのに顧みず，新しいものを送ってしまい申し訳ございません．