### PR TITLE
[fetcheus] Fix arm end coords of 'fetch.l'

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch.yaml
+++ b/jsk_fetch_robot/fetcheus/fetch.yaml
@@ -18,3 +18,8 @@ head:
 
 angle-vector:
   reset-pose : [2.86479, 75.6304, 80.2141, -11.4592, 98.5487, 0.0, 95.111, 0.0, 0.0, 0.0]
+
+rarm-end-coords:
+  parent : gripper_link
+  translate : [0, 0, 0]
+  rotate : [0, 0, 1, 0]


### PR DESCRIPTION
**before**
![before](https://cloud.githubusercontent.com/assets/4310419/14348401/320bff14-fcf7-11e5-87bf-b5cded3ddca8.png)

**after**
![after](https://cloud.githubusercontent.com/assets/4310419/14348554/38053876-fcf8-11e5-93d9-a69b14b84d29.png)

Modified:
  - jsk_fetch_robot/fetcheus/fetch.yaml