### PR TITLE
fix too long file name in deb build

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/CMakeLists.txt
+++ b/jsk_pr2_robot/jsk_pr2_startup/CMakeLists.txt
@@ -17,9 +17,11 @@ install(DIRECTORY config jsk_pr2_image_transport
   jsk_pr2_sensors jsk_pr2_warning src sample
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-install(DIRECTORY .
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-  FILES_MATCHING PATTERN "*.launch")
+file(GLOB _LAUNCH_FILES ${PROJECT_SOURCE_DIR}/ *.launch) # add / to avoid to get current directory
+foreach(_LAUNCH_FILE ${_LAUNCH_FILES})
+    install(FILES ${_LAUNCH_FILE}
+      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+endforeach()
 
 install(FILES install_pr1040_description.sh jsk_pr2.machine plugin.xml startup.app
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/jsk_pr2_robot/jsk_pr2_startup/package.xml
+++ b/jsk_pr2_robot/jsk_pr2_startup/package.xml
@@ -4,7 +4,8 @@
   <description>
      jsk_pr2_startup
   </description>
-  <maintainer email="ueda@jsk.t.u-tokyo.ac.jp">Ryohei Ueda</maintainer>
+  <maintainer email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</maintainer>
+  <maintainer email="furushchev@jsk.imi.i.u-tokyo.ac.jp">Yuki Furuta</maintainer>
   <license>BSD</license>
   <url>http://ros.org/wiki/jsk_pr2_startup</url>
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
c.f. : https://github.com/jsk-ros-pkg/jsk_robot/pull/591 

this cause failing on deb builder -> http://build.ros.org/view/Ibin_uT64/job/Ibin_uT64__jsk_pr2_startup__ubuntu_trusty_amd64__binary/90/console