### PR TITLE
[baxter-interface.l] fix removing torso joint in :ros-state-callback

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -249,10 +249,10 @@
   
   (:ros-state-callback
    (msg)
-   (let ((robot-state-names (cdr (assoc :name robot-state))) (robot-msg-names (send msg :name)) (torso-index))
+   (let ((robot-msg-names (send msg :name)) (torso-index))
      ;;Remove toros_t0 . We think this is not the rotational-joint
      (setq torso-index (position "torso_t0" robot-msg-names :test #'string=))
-     (send msg :name ( remove "torso_t0" robot-state-names :test #'string=))
+     (send msg :name ( remove "torso_t0" robot-msg-names :test #'string=))
      (when torso-index
        (dolist (key '(:position :velocity :effort) )
          (send msg key (concatenate float-vector 

--- a/jsk_baxter_robot/baxtereus/test/test-baxter.l
+++ b/jsk_baxter_robot/baxtereus/test/test-baxter.l
@@ -211,6 +211,8 @@
     (send msg :velocity (instantiate float-vector (length (send msg :name))))
     (send msg :effort (instantiate float-vector (length (send msg :name))))
     (send ri :ros-state-callback msg)
+    ;; torso_t0 should not be contained in robot-state
+    (assert (not (member "torso_t0" (cdr (assoc :name (assoc 'robot-state (send ri :slots)))) :test #'string=)))
     ))
 
 (deftest test-baxter-init


### PR DESCRIPTION
fixes https://github.com/jsk-ros-pkg/jsk_robot/issues/621

baxterは`:ros-state-callback`の中で，
joint_statesトピックで受け取ったデータから`torso_t0`ジョイントを除去していますが，
そこにバグがあるようなので修正しました．
スロット変数の`robot-state`はいらないように思います．

実機でエラーなく正しく`torso_t0`ジョイントが除去されることを確認しました．
BaxterユーザのどなたかにReviewいただいた上でマージして欲しいです．
