### PR TITLE
[baxter-interface.l] Wait until all joint states are updated before moving

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -233,7 +233,7 @@
   (:angle-vector-sequence (avs &optional (tms :fast) (ctype controller-type) (start-time 0) &key (scale 2.2) (min-time 0.05))
 		 ;; force add current position to the top of avs
 		 (if (atom tms) (setq tms (list tms)))
-		 (push (send self :state :potentio-vector) avs)
+		 (push (send self :state :potentio-vector :wait-until-update t) avs)
 		 (push 50 tms)
 		 (when (= (length avs) 2) ;; when input avs is 1
 		   (setq avs (list (elt avs 0) (midpoint 0.5 (elt avs 0) (elt avs 1)) (elt avs 1)))


### PR DESCRIPTION
Thanks to #622 
This PR is for baxter joint trajectory action server which needs the initial joint states.
Without this PR, arms sometimes move suddenly when several types of `/robot/joint_states` exist.