### PR TITLE
[baxter-interface.l] Wait until all joint states are updated before moving #627

### DIFF
--- a/jsk_baxter_robot/baxtereus/CMakeLists.txt
+++ b/jsk_baxter_robot/baxtereus/CMakeLists.txt
@@ -6,7 +6,6 @@ project(baxtereus)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   roseus
-  rostest
   collada_urdf
   euscollada
 #  baxter_description
@@ -65,4 +64,7 @@ install(DIRECTORY euslisp test
 
 install(FILES baxter.l baxter-interface.l baxter-util.l baxter-moveit.l baxter.yaml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-add_rostest(test/test-baxter.test)
+if(CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS rostest)
+  add_rostest(test/test-baxter.test)
+endif()

--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -233,7 +233,7 @@
   (:angle-vector-sequence (avs &optional (tms :fast) (ctype controller-type) (start-time 0) &key (scale 2.2) (min-time 0.05))
 		 ;; force add current position to the top of avs
 		 (if (atom tms) (setq tms (list tms)))
-		 (push (send self :state :potentio-vector) avs)
+		 (push (send self :state :potentio-vector :wait-until-update t) avs)
 		 (push 50 tms)
 		 (when (= (length avs) 2) ;; when input avs is 1
 		   (setq avs (list (elt avs 0) (midpoint 0.5 (elt avs 0) (elt avs 1)) (elt avs 1)))

--- a/jsk_baxter_robot/baxtereus/test/test-baxter.l
+++ b/jsk_baxter_robot/baxtereus/test/test-baxter.l
@@ -197,6 +197,7 @@
       (assert (= (elt (send robot :rarm :angle-vector) i) (elt reversed i))))
     ))
 
+(when (string> (unix::getenv "ROS_DISTRO") "hydro")
 (load "package://baxtereus/baxter-interface.l")
 (deftest test-baxter-interface
   (let (robot ri msg)
@@ -217,6 +218,7 @@
 
 (deftest test-baxter-init
   (baxter-init))
+) ;; when
 
 
 (run-all-tests)


### PR DESCRIPTION
@pazeshun #627
```
Thanks to #622 
This PR is for baxter joint trajectory action server which needs the initial joint states.
Without this PR, arms sometimes move suddenly when several types of /robot/joint_states exist.
```

This PR should fail for all distro since robot-state is not update until we explicitly 
call :robot-interface-simulation-callback within :wait-until-update-all-joints (https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/238)

- baxtereus: run test only for hydro
- Wait until all joint states are updated before moving