### PR TITLE
[jsk_robot_common/jsk_robot_startup/util/start_launch_sound.py] PLAY_START -> PLAY_ONCE

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/util/finish_launch_sound.py
+++ b/jsk_robot_common/jsk_robot_startup/util/finish_launch_sound.py
@@ -10,6 +10,6 @@ p = rospy.Publisher("/robotsound", SoundRequest)
 rospy.sleep(5)                  # sleep to wait for connection
 msg = SoundRequest()
 msg.sound = SoundRequest.SAY
-msg.command = SoundRequest.PLAY_START
+msg.command = SoundRequest.PLAY_ONCE
 msg.arg = "Now I am ready"
 p.publish(msg)

--- a/jsk_robot_common/jsk_robot_startup/util/start_launch_sound.py
+++ b/jsk_robot_common/jsk_robot_startup/util/start_launch_sound.py
@@ -10,6 +10,6 @@ p = rospy.Publisher("/robotsound", SoundRequest)
 rospy.sleep(5)                  # sleep to wait for connection
 msg = SoundRequest()
 msg.sound = SoundRequest.SAY
-msg.command = SoundRequest.PLAY_START
+msg.command = SoundRequest.PLAY_ONCE
 msg.arg = "Launching"
 p.publish(msg)


### PR DESCRIPTION
`PLAY_START` means starting repeating.
Current codes in `sound_play` does not support repeating, so it plays only once at now. 
I fixed the upstream, so this code should also be fixed.
https://github.com/ros-drivers/audio_common/pull/77