### PR TITLE
[naoqieus] add set-external-collision-protection-status method

### DIFF
--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -213,5 +213,13 @@
 	     (setq res (ros::service-call (format nil "~A/pose/life/getState" naoqi-namespace) req))
 	     (send res :status :data)
 	     )
+  (:set-external-collision-protection-status 
+   (type status)
+   (ros::wait-for-service "/set_external_collision_protection_status")
+   (setq req (instance naoqi_bridge_msgs::SetExternalCollisionProtectionEnabledRequest :init))
+   (send req :name (instance naoqi_bridge_msgs::ExternalCollisionProtectionNames :init :data type))
+   (send req :status status)
+   (setq res (ros::service-call "/set_external_collision_protection_status" req))
+   (send res :success))
   )
 ;;

--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -221,5 +221,13 @@
    (send req :status status)
    (setq res (ros::service-call "/set_external_collision_protection_status" req))
    (send res :success))
+  (:get-external-collision-protection-status 
+   (type)
+   (ros::wait-for-service "/get_external_collision_protection_status")
+   (setq req (instance naoqi_bridge_msgs::GetExternalCollisionProtectionEnabledRequest :init))
+   (send req :name (instance naoqi_bridge_msgs::ExternalCollisionProtectionNames :init :data type))
+   (setq res (ros::service-call "/get_external_collision_protection_status" req))
+   (send res :status)
+   )
   )
 ;;


### PR DESCRIPTION
This is euslisp method for https://github.com/ros-naoqi/naoqi_bridge/pull/48
(enable/disable safety reflex of some body parts)

how to use
```
roslaunch jsk_pepper_startup jsk_pepper_startup.launch
roslaunch naoqi_apps externalCollisionAvoidance.launch nao_ip:=<Pepper's IP>
roseus pepper-interface.l
(send *ri* ::set-external-collision-protection-status 2 nil) ;; 2: Arms nil: disabled
```

related msg and srv files
https://github.com/ros-naoqi/naoqi_bridge_msgs/pull/6

(Note: for ```:get-external-collision-protection-status``` I'll change the pull-request of naoqi_bridge.)