### PR TITLE
[peppereus] add head, larm, rarm, rleg end coords to yaml file

### DIFF
--- a/jsk_naoqi_robot/peppereus/pepper.yaml
+++ b/jsk_naoqi_robot/peppereus/pepper.yaml
@@ -26,3 +26,24 @@ angle-vector:
 
 ## TODO: end-coords tokuni base
 ## FIXME: base_linkが浮いてる
+## end-coords
+##
+head-end-coords:
+  parent : CameraTop_frame
+  translate : [0, 0, 0]
+  rotate    : [0, 1, 0, 90]
+
+rarm-end-coords:
+  parent : r_gripper
+  translate : [0.02, 0, 0]
+  rotate    : [1, 0, 0, -90]
+
+larm-end-coords:
+  parent : l_gripper
+  translate : [0.02, 0, 0]
+  rotate    : [1, 0, 0, 90]	
+  
+rleg-end-coords:
+  parent : base_footprint
+  translate : [0, 0, 0]
+  rotate    : [0, 1, 0, 90]


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_roseus/issues/470
使ったリンクは CameraTop_frame, r_gripper, l_gripper, base_footprint
![pepper-tf](https://cloud.githubusercontent.com/assets/7259671/16951073/661b56f8-4dfe-11e6-99dc-e28d44c7d940.png)
base_footprint と CameraTop_frameの座標の向きは同じなため、座標系回転も同じにしました。
![pepper-tf2](https://cloud.githubusercontent.com/assets/7259671/16951081/73cc6e0e-4dfe-11e6-9e91-41fc901c8d2d.png)

手先 end-coords の平行移動は目分量です。
![new-end-coords](https://cloud.githubusercontent.com/assets/7259671/16951265/360abda4-4dff-11e6-9d42-a36f0d28c7e2.png)

