### PR TITLE
[peppereus] rotation of rleg endcoords modified

### DIFF
--- a/jsk_naoqi_robot/peppereus/pepper.yaml
+++ b/jsk_naoqi_robot/peppereus/pepper.yaml
@@ -46,4 +46,4 @@ larm-end-coords:
 rleg-end-coords:
   parent : base_footprint
   translate : [0, 0, 0]
-  rotate    : [0, 1, 0, 90]
+  rotate    : [0, 1, 0, 0]


### PR DESCRIPTION
#637 のrlegのendcoordsをz軸上向きに直しました。

ただ、
``` (send *pepper* :fix-leg-to-coords (make-coords) :rleg)```
``` (send *pepper* :fix-leg-to-coords (make-coords))```
``` (send *pepper* :fix-leg-to-coords (make-coords :pos #f(100 0 0)))```
``` (send *pepper* :fix-leg-to-coords (make-coords :pos #f(100 0 0)) :rleg)```
等してもIRT viewerは更新されず、どうすれば直るのかはこれから考えます。


```
send *pepper* :arms :shoulder-p :joint-angle 10
load "models/arrow-object.l"
setq *arrow1* (arrow)
setq *arrow2* (arrow)
setq *arrow3* (arrow)
setq *arrow4* (arrow)
send *arrow1* :move-to (send (send *pepper* :head :end-coords) :worldcoords)
send *arrow2* :move-to (send (send *pepper* :larm :end-coords) :worldcoords)
send *arrow3* :move-to (send (send *pepper* :rarm :end-coords) :worldcoords)
send *arrow4* :move-to (send (send *pepper* :rleg :end-coords) :worldcoords)
objects (list *arrow1* *arrow2* *arrow3* *arrow4* *pepper*)
```

![modified-end-coords](https://cloud.githubusercontent.com/assets/7259671/17583706/3ba0af58-5fed-11e6-8c68-e33b75d33d3f.png)
