### PR TITLE
[jsk_naoqi_robot/README.md] delete unnecessary local name "pepper_robot"

### DIFF
--- a/jsk_naoqi_robot/README.md
+++ b/jsk_naoqi_robot/README.md
@@ -45,7 +45,7 @@ for developers
 add following source code for debugging.
 ```
 cd  catkin_ws/src
-wstool set pepper_robot --git pepper_robot http://github.com/ros-naoqi/pepper_robot
+wstool set pepper_robot --git http://github.com/ros-naoqi/pepper_robot
 ```
 
 naoeus


### PR DESCRIPTION
When I ran the command in "for developers" below, it returned the error.

```
wstool set pepper_robot --git pepper_robot http://github.com/ros-naoqi/pepper_robot
=>
Error: Too many arguments.
wstool set [localname] [[SCM-URI] --(svn|hg|git|bzr) [--version=VERSION]?]?
```
I changed it as follows.
```
wstool set pepper_robot --git http://github.com/ros-naoqi/pepper_robot

=>
     Add new elements:
  pepper_robot   	git  http://github.com/ros-naoqi/pepper_robot   

Continue: (y)es, (n)o: y
Overwriting /home/kochigami/catkin_ws/src/.rosinstall
Config changed, remember to run 'wstool update pepper_robot' to update the folder from git

```