### PR TITLE
[peppereus] add gazebo controller method

### DIFF
--- a/jsk_naoqi_robot/naoeus/nao-interface.l
+++ b/jsk_naoqi_robot/naoeus/nao-interface.l
@@ -15,9 +15,54 @@
 
 (defmethod nao-interface
   (:init (&rest args)
-   (send-super* :init :robot nao-robot :naoqi-namespace "nao_robot" args))
+   (send-super* :init :robot nao-robot :naoqi-namespace "nao_robot" :dcm-namespace "nao_dcm" args)
+   (when (ros::get-param "use_sim_time" nil)
+     ;; add controllers for gazebo 
+     (dolist (l (list
+		 (cons :dcm-head-controller "/nao_dcm/Head_controller/follow_joint_trajectory")
+		 (cons :dcm-larm-controller "/nao_dcm/LeftArm_controller/follow_joint_trajectory")
+		 (cons :dcm-lfoot-controller "/nao_dcm/LeftFoot_controller/follow_joint_trajectory")
+		 (cons :dcm-lleg-controller "/nao_dcm/LeftLeg_controller/follow_joint_trajectory")
+		 (cons :dcm-lhand-controller "/nao_dcm/LeftHand_controller/follow_joint_trajectory")
+		 (cons :dcm-pelvis-controller "/nao_dcm/Pelvis_controller/follow_joint_trajectory")
+		 (cons :dcm-rarm-controller "/nao_dcm/RightArm_controller/follow_joint_trajectory")
+		 (cons :dcm-rfoot-controller "/nao_dcm/RightFoot_controller/follow_joint_trajectory")
+		 (cons :dcm-rleg-controller "/nao_dcm/RightLeg_controller/follow_joint_trajectory")
+		 (cons :dcm-rhand-controller "/nao_dcm/RightHand_controller/follow_joint_trajectory")))
+       (let ((type (car l))
+	     (name (cdr l))
+	     action)
+	 (setq action (find-if #'(lambda (ac) (string= name (send ac :name)))
+			       controller-actions))
+	 (setf (gethash type controller-table) (list action))
+	 )))
+   )
+  (:naoqi-controller
+   ()
+   (if (ros::get-param "use_sim_time" nil)
+       (progn
+	 ;; only for simulation
+	 (append
+	  (send self :dcm-head-controller)
+	  (send self :dcm-larm-controller)
+	  (send self :dcm-lfoot-controller)
+	  (send self :dcm-lleg-controller)
+	  (send self :dcm-pelvis-controller)
+	  (send self :dcm-rarm-controller)
+	  (send self :dcm-rfoot-controller)
+	  (send self :dcm-rleg-controller)
+	  ))
+     (progn
+       (list
+	(list
+	 (cons :controller-action (format nil "~A/pose/joint_trajectory" naoqi-namespace))
+	 ;;(cons :controller-state "joint_trajectory")
+	 (cons :controller-state "dummy_state") ;; this is dummy
+	 (cons :action-type naoqi_bridge_msgs::JointTrajectoryAction)
+	 (cons :joint-names (mapcar #'(lambda (n) (if (symbolp n) (symbol-name n) n)) (send-all (send robot :joint-list) :name))))
+	)))
+   )
   )
-
 ;; current nao version H25V50
 (defclass nao-robot
   :super naoH25V50-robot)

--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -24,6 +24,23 @@
 	 (instance ros::simple-action-client :init
 		   (format nil "~A/pose/joint_stiffness_trajectory" naoqi-namespace)
 		   naoqi_bridge_msgs::JointTrajectoryAction))
+   (ros::advertise "/pepper_dcm/Head_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/pepper_dcm/LeftArm_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/pepper_dcm/LeftHand_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/pepper_dcm/Pelvis_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/pepper_dcm/RightArm_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/pepper_dcm/RightHand_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/pepper_dcm/Wheels_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/nao_dcm/Head_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/nao_dcm/LeftArm_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/nao_dcm/LeftFoot_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/nao_dcm/LeftHand_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/nao_dcm/LeftLeg_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/nao_dcm/Pelvis_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/nao_dcm/RightArm_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/nao_dcm/RightFoot_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/nao_dcm/RightHand_controller/command" trajectory_msgs::JointTrajectory 1)
+   (ros::advertise "/nao_dcm/RightLeg_controller/command" trajectory_msgs::JointTrajectory 1)
    self)
   ;;
   (:naoqi-controller
@@ -36,6 +53,89 @@
      (cons :action-type naoqi_bridge_msgs::JointTrajectoryAction)
      (cons :joint-names (mapcar #'(lambda (n) (if (symbolp n) (symbol-name n) n)) (send-all (send robot :joint-list) :name))))
     ))
+  ;;
+  (:angle-vector
+   (av &optional (tm nil) (ctype controller-type) (start-time 0) &key (scale 1) (min-time 1.0))
+   "Send joind angle to robot, this method retuns immediately, so use :wait-interpolation to block until the motion stops.
+- av : joint angle vector [rad]
+- tm : (time to goal in [msec])
+   if designated tm is faster than fastest speed, use fastest speed
+   if not specified, it will use 1/scale of the fastest speed .
+   if :fastest is specefied use fastest speed calcurated from max speed
+- ctype : controller method name
+- start-time : time to start moving
+- scale : if tm is not specified, it will use 1/scale of the fastest speed
+- min-time : minimum time to for time to goal
+"
+   (setq ctype (or ctype controller-type))  ;; use default controller-type if ctype is nil
+   (unless (gethash ctype controller-table)
+     (warn ";; controller-type: ~A not found" ctype)
+     (return-from :angle-vector))
+   ;;Check and decide tm
+   (let ((fastest-tm (* 1000 (send self :angle-vector-duration 
+                                   (send self :state :potentio-vector) av scale min-time ctype))))
+     (cond
+      ;;Fastest time Mode
+      ((equal tm :fast)
+       (setq tm fastest-tm))
+      ;;Normal Number disgnated Mode
+      ((numberp tm)
+       (if (< tm fastest-tm)
+           (setq tm fastest-tm)))
+      ;;Safe Mode (Speed will be 5 * fastest-time)
+      ((null tm)
+       (setq tm (* 5 fastest-tm)))
+      ;;Error Not Good Input
+      (t
+       (ros::ros-error ":angle-vector tm is invalid.  args: ~A" tm)
+       (error ":angle-vector tm is invalid. args: ~A" tm)))
+     )
+   ;; for simulation mode
+   (when (send self :simulation-modep)
+     (if av (send self :angle-vector-simulation av tm ctype)))
+   ;; for gazebo mode
+   (when (send *ri* :robot-interface-simulation-callback) 
+     (if (boundp '*pepper*) 
+	 (progn
+	   (let* ((angle-list (send *pepper* :angle-vector)))
+	     (dotimes (i (length angle-list)) (setf (elt angle-list i) (deg2rad (elt angle-list i))))
+	     (send *ri* :gazebo-head-controller (list (elt angle-list 13) (elt angle-list 14))) 
+	     (send *ri* :gazebo-left-arm-controller (list (elt angle-list 3) (elt angle-list 4) (elt angle-list 5) (elt angle-list 6) (elt angle-list 7)))
+	     (send *ri* :gazebo-pelvis-controller (list (elt angle-list 1) (elt angle-list 2) (elt angle-list 0)))
+	     (send *ri* :gazebo-right-arm-controller (list (elt angle-list 8) (elt angle-list 9) (elt angle-list 10) (elt angle-list 11) (elt angle-list 12)))
+	     ;;(send *ri* :gazebo-left-hand-controller (list ))
+	     ;;(send *ri* :gazebo-right-hand-controller (list ))
+	     ;;(send *ri* :gazebo-wheels-controller (list ))
+	     )))
+     (if (boundp '*nao*) 
+	 (progn
+	   (let* ((angle-list (send *nao* :angle-vector)))
+	     (dotimes (i (length angle-list)) (setf (elt angle-list i) (deg2rad (elt angle-list i))))
+	     (send *ri* :gazebo-head-controller (list (elt angle-list 22) (elt angle-list 23))) 
+	     (send *ri* :gazebo-left-arm-controller (list (elt angle-list 0) (elt angle-list 1) (elt angle-list 2) (elt angle-list 3) (elt angle-list 4)))
+	     (send *ri* :gazebo-right-arm-controller (list (elt angle-list 5) (elt angle-list 6) (elt angle-list 7) (elt angle-list 8) (elt angle-list 9)))
+	     (send *ri* :gazebo-left-foot-controller (list (elt angle-list 14) (elt angle-list 15)))
+	     (send *ri* :gazebo-left-leg-controller (list (elt angle-list 11) (elt angle-list 12) (elt angle-list 13)))
+	     (send *ri* :gazebo-right-foot-controller (list (elt angle-list 20) (elt angle-list 21)))
+	     (send *ri* :gazebo-right-leg-controller (list (elt angle-list 17) (elt angle-list 18) (elt angle-list 19)))
+	     (send *ri* :gazebo-pelvis-controller (list (elt angle-list 10)))
+	     ;;(send *ri* :gazebo-left-hand-controller (list ))
+	     ;;(send *ri* :gazebo-right-hand-controller (list ))
+	     )))
+     )
+   (send robot :angle-vector av)
+   (let ((cacts (gethash ctype controller-table)))
+     (mapcar
+      #'(lambda (action param)
+	  (send self :send-ros-controller
+		action (cdr (assoc :joint-names param)) ;; action server and joint-names
+		start-time  ;; start time
+		(list
+		 (list av                                     ;; positions
+		       (instantiate float-vector (length av)) ;; velocities
+		       (/ tm 1000.0)))))                      ;; duration
+      cacts (send self ctype)))
+   av)
   ;;
   (:error-vector () (map float-vector #'rad2deg (send self :state :effort)))
   ;;
@@ -213,5 +313,191 @@
 	     (setq res (ros::service-call (format nil "~A/pose/life/getState" naoqi-namespace) req))
 	     (send res :status :data)
 	     )
+  (:gazebo-head-controller 
+   (angle-list)
+   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
+	 joint-name)
+     (send goal :header :seq 1)
+     (send goal :header :stamp (ros::time-now))
+     (setq joint-name (list "HeadYaw" "HeadPitch")) 
+     (send goal :joint_names joint-name)
+     (send goal :points
+	   (list (instance trajectory_msgs::JointTrajectoryPoint
+			   :init
+			   :positions angle-list
+			   :time_from_start (ros::time 1))))
+     (if (boundp '*nao*) 
+	 (ros::publish "/nao_dcm/Head_controller/command" goal))
+     (if (boundp '*pepper*) 
+	 (ros::publish "/pepper_dcm/Head_controller/command" goal))
+     ))
+  (:gazebo-left-arm-controller 
+   (angle-list)
+   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
+	 joint-name)
+     (send goal :header :seq 1)
+     (send goal :header :stamp (ros::time-now))
+     (setq joint-name (list "LShoulderPitch" "LShoulderRoll" "LElbowYaw" "LElbowRoll" "LWristYaw"))
+     (send goal :joint_names joint-name)
+     (send goal :points
+	   (list (instance trajectory_msgs::JointTrajectoryPoint
+			   :init
+			   :positions angle-list
+			   :time_from_start (ros::time 1))))
+     (if (boundp '*nao*) 
+	 (ros::publish "/nao_dcm/LeftArm_controller/command" goal))
+     (if (boundp '*pepper*)
+	 (ros::publish "/pepper_dcm/LeftArm_controller/command" goal))
+     ))
+  (:gazebo-left-hand-controller 
+   (angle-list)
+   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
+	 joint-name)
+     (send goal :header :seq 1)
+     (send goal :header :stamp (ros::time-now))
+     (setq joint-name (list "LHand")) 
+     (send goal :joint_names joint-name)
+     (send goal :points
+	   (list (instance trajectory_msgs::JointTrajectoryPoint
+			   :init
+			   :positions angle-list
+			   :time_from_start (ros::time 1))))
+     (if (boundp '*nao*) 
+	 (ros::publish "/nao_dcm/LeftHand_controller/command" goal))
+     (if (boundp '*pepper*)
+	 (ros::publish "/pepper_dcm/LeftHand_controller/command" goal))
+     ))
+  (:gazebo-pelvis-controller 
+   (angle-list)
+   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
+	 joint-name)     
+     (send goal :header :seq 1)
+     (send goal :header :stamp (ros::time-now))
+     (if (boundp '*nao*)
+	 (setq joint-name (list "LHipYawPitch")))       
+     (if (boundp `*pepper*)
+	 (setq joint-name (list "HipRoll" "HipPitch" "KneePitch")))
+     (send goal :joint_names joint-name)
+     (send goal :points
+	   (list (instance trajectory_msgs::JointTrajectoryPoint
+			   :init
+			   :positions angle-list
+			   :time_from_start (ros::time 1))))
+     (if (boundp '*nao*)
+	 (ros::publish "/nao_dcm/Pelvis_controller/command" goal))
+     (if (boundp '*pepper*)
+	 (ros::publish "/pepper_dcm/Pelvis_controller/command" goal))
+     ))
+  (:gazebo-right-arm-controller 
+   (angle-list)
+   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
+	 joint-name)
+     (send goal :header :seq 1)
+     (send goal :header :stamp (ros::time-now))
+     (setq joint-name (list "RShoulderPitch" "RShoulderRoll" "RElbowYaw" "RElbowRoll" "RWristYaw")) 
+     (send goal :joint_names joint-name)
+     (send goal :points
+	   (list (instance trajectory_msgs::JointTrajectoryPoint
+			   :init
+			   :positions angle-list
+			   :time_from_start (ros::time 1))))
+     (if (boundp '*nao*)
+	 (ros::publish "/nao_dcm/RightArm_controller/command" goal))
+     (if (boundp '*pepper*)
+	 (ros::publish "/pepper_dcm/RightArm_controller/command" goal))
+     ))
+  (:gazebo-right-hand-controller 
+   (angle-list)
+   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
+	 joint-name)
+     (send goal :header :seq 1)
+     (send goal :header :stamp (ros::time-now))
+     (setq joint-name (list "RHand")) 
+     (send goal :joint_names joint-name)
+     (send goal :points
+	   (list (instance trajectory_msgs::JointTrajectoryPoint
+			   :init
+			   :positions angle-list
+			   :time_from_start (ros::time 1))))
+     (if (boundp '*nao*)
+	 (ros::publish "/nao_dcm/RightHand_controller/command" goal))
+     (if (boundp '*pepper*)
+	 (ros::publish "/pepper_dcm/RightHand_controller/command" goal))
+     ))
+  (:gazebo-wheels-controller 
+   (angle-list)
+   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
+	 joint-name)
+     (send goal :header :seq 1)
+     (send goal :header :stamp (ros::time-now))
+     (setq joint-name (list "WheelFL" "WheelB" "WheelFR")) 
+     (send goal :joint_names joint-name)
+     (send goal :points
+	   (list (instance trajectory_msgs::JointTrajectoryPoint
+			   :init
+			   :positions angle-list
+			   :time_from_start (ros::time 1))))
+     (ros::publish "/pepper_dcm/Wheels_controller/command" goal)
+     ))
+  (:gazebo-left-foot-controller 
+   (angle-list)
+   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
+	 joint-name)
+     (send goal :header :seq 1)
+     (send goal :header :stamp (ros::time-now))
+     (setq joint-name (list "LAnklePitch" "LAnkleRoll")) 
+     (send goal :joint_names joint-name)
+     (send goal :points
+	   (list (instance trajectory_msgs::JointTrajectoryPoint
+			   :init
+			   :positions angle-list
+			   :time_from_start (ros::time 1))))
+     (ros::publish "/nao_dcm/LeftFoot_controller/command" goal)
+     ))
+  (:gazebo-left-leg-controller 
+   (angle-list)
+   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
+	 joint-name)
+     (send goal :header :seq 1)
+     (send goal :header :stamp (ros::time-now))
+     (setq joint-name (list "LHipRoll" "LHipPitch" "LKneePitch")) 
+     (send goal :joint_names joint-name)
+     (send goal :points
+	   (list (instance trajectory_msgs::JointTrajectoryPoint
+			   :init
+			   :positions angle-list
+			   :time_from_start (ros::time 1))))
+     (ros::publish "/nao_dcm/LeftLeg_controller/command" goal)
+     ))
+  (:gazebo-right-foot-controller 
+   (angle-list)
+   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
+	 joint-name)
+     (send goal :header :seq 1)
+     (send goal :header :stamp (ros::time-now))
+     (setq joint-name (list "RAnklePitch" "RAnkleRoll")) 
+     (send goal :joint_names joint-name)
+     (send goal :points
+	   (list (instance trajectory_msgs::JointTrajectoryPoint
+			   :init
+			   :positions angle-list
+			   :time_from_start (ros::time 1))))
+     (ros::publish "/nao_dcm/RightFoot_controller/command" goal)
+     ))
+  (:gazebo-right-leg-controller 
+   (angle-list)
+   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
+	 joint-name)
+     (send goal :header :seq 1)
+     (send goal :header :stamp (ros::time-now))
+     (setq joint-name (list "RHipRoll" "RHipPitch" "RKneePitch")) 
+     (send goal :joint_names joint-name)
+     (send goal :points
+	   (list (instance trajectory_msgs::JointTrajectoryPoint
+			   :init
+			   :positions angle-list
+			   :time_from_start (ros::time 1))))
+     (ros::publish "/nao_dcm/RightLeg_controller/command" goal)
+     ))
   )
 ;;

--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -6,13 +6,14 @@
 
 (defclass naoqi-interface
   :super robot-interface
-  :slots (naoqi-namespace joint-stiffness-trajectory-action)
+  :slots (naoqi-namespace dcm-namespace joint-stiffness-trajectory-action)
   )
 
 (defmethod naoqi-interface
   (:init
-   (&rest args &key ((:naoqi-namespace ns) "naoqi_robot") (robot) (type :naoqi-controller) &allow-other-keys)
+   (&rest args &key ((:naoqi-namespace ns) "naoqi_robot") ((:dcm-namespace dns) "naoqi_dcm") (robot) (type :naoqi-controller) &allow-other-keys)
    (setq naoqi-namespace ns)
+   (setq dcm-namespace dns)
    (print args)
    (send-super* :init :robot robot :type type :groupname "naoqi_interface" args)
    (ros::advertise "/move_base_simple/goal" geometry_msgs::PoseStamped 1)
@@ -24,118 +25,120 @@
 	 (instance ros::simple-action-client :init
 		   (format nil "~A/pose/joint_stiffness_trajectory" naoqi-namespace)
 		   naoqi_bridge_msgs::JointTrajectoryAction))
-   (ros::advertise "/pepper_dcm/Head_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/pepper_dcm/LeftArm_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/pepper_dcm/LeftHand_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/pepper_dcm/Pelvis_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/pepper_dcm/RightArm_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/pepper_dcm/RightHand_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/pepper_dcm/Wheels_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/nao_dcm/Head_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/nao_dcm/LeftArm_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/nao_dcm/LeftFoot_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/nao_dcm/LeftHand_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/nao_dcm/LeftLeg_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/nao_dcm/Pelvis_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/nao_dcm/RightArm_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/nao_dcm/RightFoot_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/nao_dcm/RightHand_controller/command" trajectory_msgs::JointTrajectory 1)
-   (ros::advertise "/nao_dcm/RightLeg_controller/command" trajectory_msgs::JointTrajectory 1)
    self)
+  ;;
+  (:dcm-head-controller
+   ()
+   (list
+    (list
+     (cons :controller-action 
+	   (format nil "~A/Head_controller/follow_joint_trajectory" dcm-namespace))
+     (cons :controller-state 
+	   (format nil "~A/Head_controller/state" dcm-namespace))
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (list "HeadYaw" "HeadPitch")))))
+  (:dcm-larm-controller
+   ()
+   (list
+    (list
+     (cons :controller-action 
+	   (format nil "~A/LeftArm_controller/follow_joint_trajectory" dcm-namespace))
+     (cons :controller-state 
+	   (format nil "~A/LeftArm_controller/state" dcm-namespace))
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (list "LShoulderPitch" "LShoulderRoll" "LElbowYaw" "LElbowRoll" "LWristYaw")))))
+  (:dcm-lhand-controller
+   ()
+   (list
+    (list
+     (cons :controller-action 
+	   (format nil "~A/LeftHand_controller/follow_joint_trajectory" dcm-namespace))
+     (cons :controller-state 
+	   (format nil "~A/LeftHand_controller/state" dcm-namespace))
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (list "LHand")))))
+  (:dcm-rarm-controller
+   ()
+   (list
+    (list
+     (cons :controller-action 
+	   (format nil "~A/RightArm_controller/follow_joint_trajectory" dcm-namespace))
+     (cons :controller-state 
+	   (format nil "~A/RightArm_controller/state" dcm-namespace))
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (list "RShoulderPitch" "RShoulderRoll" "RElbowYaw" "RElbowRoll" "RWristYaw")))))
+  (:dcm-rhand-controller
+   ()
+   (list
+    (list
+     (cons :controller-action 
+	   (format nil "~A/RightHand_controller/follow_joint_trajectory" dcm-namespace))
+     (cons :controller-state 
+	   (format nil "~A/RightHand_controller/state" dcm-namespace))
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (list "RHand")))))
+  (:dcm-pelvis-controller
+   ;; Nao: RHipYawPitch is mimic joint, Pepper: this method is overridden
+   ()
+   (list
+    (list
+     (cons :controller-action 
+	   (format nil "~A/Pelvis_controller/follow_joint_trajectory" dcm-namespace))
+     (cons :controller-state 
+	   (format nil "~A/Pelvis_controller/state" dcm-namespace))
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (list "LHipYawPitch")))))
+  (:dcm-lfoot-controller
+   ()
+   (list
+    (list
+     (cons :controller-action "/nao_dcm/LeftFoot_controller/follow_joint_trajectory")
+     (cons :controller-state "/nao_dcm/LeftFoot_controller/state")
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (list "LAnklePitch" "LAnkleRoll")))))
+  (:dcm-lleg-controller
+   ()
+   (list
+    (list
+     (cons :controller-action "/nao_dcm/LeftLeg_controller/follow_joint_trajectory")
+     (cons :controller-state "/nao_dcm/LeftLeg_controller/state")
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (list "LHipRoll" "LHipPitch" "LKneePitch"))))) 
+  (:dcm-rfoot-controller
+   ()
+   (list
+    (list
+     (cons :controller-action "/nao_dcm/RightFoot_controller/follow_joint_trajectory")
+     (cons :controller-state "/nao_dcm/RightFoot_controller/state")
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (list "RAnklePitch" "RAnkleRoll")))))
+  (:dcm-rleg-controller
+   ()
+   (list
+    (list
+     (cons :controller-action "/nao_dcm/RightLeg_controller/follow_joint_trajectory")
+     (cons :controller-state "/nao_dcm/RightLeg_controller/state")
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (list "RHipRoll" "RHipPitch" "RKneePitch"))))) 
+  (:dcm-wheels-controller
+   ()
+   (list
+    (list
+     (cons :controller-action "/pepper_dcm/Wheels_controller/follow_joint_trajectory")
+     (cons :controller-state "/pepper_dcm/Wheels_controller/state")
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (list "WheelFL" "WheelB" "WheelFR")))))
   ;;
   (:naoqi-controller
    ()
    (list
     (list
      (cons :controller-action (format nil "~A/pose/joint_trajectory" naoqi-namespace))
-    ;;(cons :controller-state "joint_trajectory")
+     ;;(cons :controller-state "joint_trajectory")
      (cons :controller-state "dummy_state") ;; this is dummy
      (cons :action-type naoqi_bridge_msgs::JointTrajectoryAction)
      (cons :joint-names (mapcar #'(lambda (n) (if (symbolp n) (symbol-name n) n)) (send-all (send robot :joint-list) :name))))
     ))
-  ;;
-  (:angle-vector
-   (av &optional (tm nil) (ctype controller-type) (start-time 0) &key (scale 1) (min-time 1.0))
-   "Send joind angle to robot, this method retuns immediately, so use :wait-interpolation to block until the motion stops.
-- av : joint angle vector [rad]
-- tm : (time to goal in [msec])
-   if designated tm is faster than fastest speed, use fastest speed
-   if not specified, it will use 1/scale of the fastest speed .
-   if :fastest is specefied use fastest speed calcurated from max speed
-- ctype : controller method name
-- start-time : time to start moving
-- scale : if tm is not specified, it will use 1/scale of the fastest speed
-- min-time : minimum time to for time to goal
-"
-   (setq ctype (or ctype controller-type))  ;; use default controller-type if ctype is nil
-   (unless (gethash ctype controller-table)
-     (warn ";; controller-type: ~A not found" ctype)
-     (return-from :angle-vector))
-   ;;Check and decide tm
-   (let ((fastest-tm (* 1000 (send self :angle-vector-duration 
-                                   (send self :state :potentio-vector) av scale min-time ctype))))
-     (cond
-      ;;Fastest time Mode
-      ((equal tm :fast)
-       (setq tm fastest-tm))
-      ;;Normal Number disgnated Mode
-      ((numberp tm)
-       (if (< tm fastest-tm)
-           (setq tm fastest-tm)))
-      ;;Safe Mode (Speed will be 5 * fastest-time)
-      ((null tm)
-       (setq tm (* 5 fastest-tm)))
-      ;;Error Not Good Input
-      (t
-       (ros::ros-error ":angle-vector tm is invalid.  args: ~A" tm)
-       (error ":angle-vector tm is invalid. args: ~A" tm)))
-     )
-   ;; for simulation mode
-   (when (send self :simulation-modep)
-     (if av (send self :angle-vector-simulation av tm ctype)))
-   ;; for gazebo mode
-   (when (send *ri* :robot-interface-simulation-callback) 
-     (if (boundp '*pepper*) 
-	 (progn
-	   (let* ((angle-list (send *pepper* :angle-vector)))
-	     (dotimes (i (length angle-list)) (setf (elt angle-list i) (deg2rad (elt angle-list i))))
-	     (send *ri* :gazebo-head-controller (list (elt angle-list 13) (elt angle-list 14))) 
-	     (send *ri* :gazebo-left-arm-controller (list (elt angle-list 3) (elt angle-list 4) (elt angle-list 5) (elt angle-list 6) (elt angle-list 7)))
-	     (send *ri* :gazebo-pelvis-controller (list (elt angle-list 1) (elt angle-list 2) (elt angle-list 0)))
-	     (send *ri* :gazebo-right-arm-controller (list (elt angle-list 8) (elt angle-list 9) (elt angle-list 10) (elt angle-list 11) (elt angle-list 12)))
-	     ;;(send *ri* :gazebo-left-hand-controller (list ))
-	     ;;(send *ri* :gazebo-right-hand-controller (list ))
-	     ;;(send *ri* :gazebo-wheels-controller (list ))
-	     )))
-     (if (boundp '*nao*) 
-	 (progn
-	   (let* ((angle-list (send *nao* :angle-vector)))
-	     (dotimes (i (length angle-list)) (setf (elt angle-list i) (deg2rad (elt angle-list i))))
-	     (send *ri* :gazebo-head-controller (list (elt angle-list 22) (elt angle-list 23))) 
-	     (send *ri* :gazebo-left-arm-controller (list (elt angle-list 0) (elt angle-list 1) (elt angle-list 2) (elt angle-list 3) (elt angle-list 4)))
-	     (send *ri* :gazebo-right-arm-controller (list (elt angle-list 5) (elt angle-list 6) (elt angle-list 7) (elt angle-list 8) (elt angle-list 9)))
-	     (send *ri* :gazebo-left-foot-controller (list (elt angle-list 14) (elt angle-list 15)))
-	     (send *ri* :gazebo-left-leg-controller (list (elt angle-list 11) (elt angle-list 12) (elt angle-list 13)))
-	     (send *ri* :gazebo-right-foot-controller (list (elt angle-list 20) (elt angle-list 21)))
-	     (send *ri* :gazebo-right-leg-controller (list (elt angle-list 17) (elt angle-list 18) (elt angle-list 19)))
-	     (send *ri* :gazebo-pelvis-controller (list (elt angle-list 10)))
-	     ;;(send *ri* :gazebo-left-hand-controller (list ))
-	     ;;(send *ri* :gazebo-right-hand-controller (list ))
-	     )))
-     )
-   (send robot :angle-vector av)
-   (let ((cacts (gethash ctype controller-table)))
-     (mapcar
-      #'(lambda (action param)
-	  (send self :send-ros-controller
-		action (cdr (assoc :joint-names param)) ;; action server and joint-names
-		start-time  ;; start time
-		(list
-		 (list av                                     ;; positions
-		       (instantiate float-vector (length av)) ;; velocities
-		       (/ tm 1000.0)))))                      ;; duration
-      cacts (send self ctype)))
-   av)
   ;;
   (:error-vector () (map float-vector #'rad2deg (send self :state :effort)))
   ;;
@@ -313,191 +316,5 @@
 	     (setq res (ros::service-call (format nil "~A/pose/life/getState" naoqi-namespace) req))
 	     (send res :status :data)
 	     )
-  (:gazebo-head-controller 
-   (angle-list)
-   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
-	 joint-name)
-     (send goal :header :seq 1)
-     (send goal :header :stamp (ros::time-now))
-     (setq joint-name (list "HeadYaw" "HeadPitch")) 
-     (send goal :joint_names joint-name)
-     (send goal :points
-	   (list (instance trajectory_msgs::JointTrajectoryPoint
-			   :init
-			   :positions angle-list
-			   :time_from_start (ros::time 1))))
-     (if (boundp '*nao*) 
-	 (ros::publish "/nao_dcm/Head_controller/command" goal))
-     (if (boundp '*pepper*) 
-	 (ros::publish "/pepper_dcm/Head_controller/command" goal))
-     ))
-  (:gazebo-left-arm-controller 
-   (angle-list)
-   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
-	 joint-name)
-     (send goal :header :seq 1)
-     (send goal :header :stamp (ros::time-now))
-     (setq joint-name (list "LShoulderPitch" "LShoulderRoll" "LElbowYaw" "LElbowRoll" "LWristYaw"))
-     (send goal :joint_names joint-name)
-     (send goal :points
-	   (list (instance trajectory_msgs::JointTrajectoryPoint
-			   :init
-			   :positions angle-list
-			   :time_from_start (ros::time 1))))
-     (if (boundp '*nao*) 
-	 (ros::publish "/nao_dcm/LeftArm_controller/command" goal))
-     (if (boundp '*pepper*)
-	 (ros::publish "/pepper_dcm/LeftArm_controller/command" goal))
-     ))
-  (:gazebo-left-hand-controller 
-   (angle-list)
-   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
-	 joint-name)
-     (send goal :header :seq 1)
-     (send goal :header :stamp (ros::time-now))
-     (setq joint-name (list "LHand")) 
-     (send goal :joint_names joint-name)
-     (send goal :points
-	   (list (instance trajectory_msgs::JointTrajectoryPoint
-			   :init
-			   :positions angle-list
-			   :time_from_start (ros::time 1))))
-     (if (boundp '*nao*) 
-	 (ros::publish "/nao_dcm/LeftHand_controller/command" goal))
-     (if (boundp '*pepper*)
-	 (ros::publish "/pepper_dcm/LeftHand_controller/command" goal))
-     ))
-  (:gazebo-pelvis-controller 
-   (angle-list)
-   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
-	 joint-name)     
-     (send goal :header :seq 1)
-     (send goal :header :stamp (ros::time-now))
-     (if (boundp '*nao*)
-	 (setq joint-name (list "LHipYawPitch")))       
-     (if (boundp `*pepper*)
-	 (setq joint-name (list "HipRoll" "HipPitch" "KneePitch")))
-     (send goal :joint_names joint-name)
-     (send goal :points
-	   (list (instance trajectory_msgs::JointTrajectoryPoint
-			   :init
-			   :positions angle-list
-			   :time_from_start (ros::time 1))))
-     (if (boundp '*nao*)
-	 (ros::publish "/nao_dcm/Pelvis_controller/command" goal))
-     (if (boundp '*pepper*)
-	 (ros::publish "/pepper_dcm/Pelvis_controller/command" goal))
-     ))
-  (:gazebo-right-arm-controller 
-   (angle-list)
-   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
-	 joint-name)
-     (send goal :header :seq 1)
-     (send goal :header :stamp (ros::time-now))
-     (setq joint-name (list "RShoulderPitch" "RShoulderRoll" "RElbowYaw" "RElbowRoll" "RWristYaw")) 
-     (send goal :joint_names joint-name)
-     (send goal :points
-	   (list (instance trajectory_msgs::JointTrajectoryPoint
-			   :init
-			   :positions angle-list
-			   :time_from_start (ros::time 1))))
-     (if (boundp '*nao*)
-	 (ros::publish "/nao_dcm/RightArm_controller/command" goal))
-     (if (boundp '*pepper*)
-	 (ros::publish "/pepper_dcm/RightArm_controller/command" goal))
-     ))
-  (:gazebo-right-hand-controller 
-   (angle-list)
-   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
-	 joint-name)
-     (send goal :header :seq 1)
-     (send goal :header :stamp (ros::time-now))
-     (setq joint-name (list "RHand")) 
-     (send goal :joint_names joint-name)
-     (send goal :points
-	   (list (instance trajectory_msgs::JointTrajectoryPoint
-			   :init
-			   :positions angle-list
-			   :time_from_start (ros::time 1))))
-     (if (boundp '*nao*)
-	 (ros::publish "/nao_dcm/RightHand_controller/command" goal))
-     (if (boundp '*pepper*)
-	 (ros::publish "/pepper_dcm/RightHand_controller/command" goal))
-     ))
-  (:gazebo-wheels-controller 
-   (angle-list)
-   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
-	 joint-name)
-     (send goal :header :seq 1)
-     (send goal :header :stamp (ros::time-now))
-     (setq joint-name (list "WheelFL" "WheelB" "WheelFR")) 
-     (send goal :joint_names joint-name)
-     (send goal :points
-	   (list (instance trajectory_msgs::JointTrajectoryPoint
-			   :init
-			   :positions angle-list
-			   :time_from_start (ros::time 1))))
-     (ros::publish "/pepper_dcm/Wheels_controller/command" goal)
-     ))
-  (:gazebo-left-foot-controller 
-   (angle-list)
-   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
-	 joint-name)
-     (send goal :header :seq 1)
-     (send goal :header :stamp (ros::time-now))
-     (setq joint-name (list "LAnklePitch" "LAnkleRoll")) 
-     (send goal :joint_names joint-name)
-     (send goal :points
-	   (list (instance trajectory_msgs::JointTrajectoryPoint
-			   :init
-			   :positions angle-list
-			   :time_from_start (ros::time 1))))
-     (ros::publish "/nao_dcm/LeftFoot_controller/command" goal)
-     ))
-  (:gazebo-left-leg-controller 
-   (angle-list)
-   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
-	 joint-name)
-     (send goal :header :seq 1)
-     (send goal :header :stamp (ros::time-now))
-     (setq joint-name (list "LHipRoll" "LHipPitch" "LKneePitch")) 
-     (send goal :joint_names joint-name)
-     (send goal :points
-	   (list (instance trajectory_msgs::JointTrajectoryPoint
-			   :init
-			   :positions angle-list
-			   :time_from_start (ros::time 1))))
-     (ros::publish "/nao_dcm/LeftLeg_controller/command" goal)
-     ))
-  (:gazebo-right-foot-controller 
-   (angle-list)
-   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
-	 joint-name)
-     (send goal :header :seq 1)
-     (send goal :header :stamp (ros::time-now))
-     (setq joint-name (list "RAnklePitch" "RAnkleRoll")) 
-     (send goal :joint_names joint-name)
-     (send goal :points
-	   (list (instance trajectory_msgs::JointTrajectoryPoint
-			   :init
-			   :positions angle-list
-			   :time_from_start (ros::time 1))))
-     (ros::publish "/nao_dcm/RightFoot_controller/command" goal)
-     ))
-  (:gazebo-right-leg-controller 
-   (angle-list)
-   (let ((goal (instance trajectory_msgs::JointTrajectory :init))
-	 joint-name)
-     (send goal :header :seq 1)
-     (send goal :header :stamp (ros::time-now))
-     (setq joint-name (list "RHipRoll" "RHipPitch" "RKneePitch")) 
-     (send goal :joint_names joint-name)
-     (send goal :points
-	   (list (instance trajectory_msgs::JointTrajectoryPoint
-			   :init
-			   :positions angle-list
-			   :time_from_start (ros::time 1))))
-     (ros::publish "/nao_dcm/RightLeg_controller/command" goal)
-     ))
   )
 ;;

--- a/jsk_naoqi_robot/peppereus/pepper-interface.l
+++ b/jsk_naoqi_robot/peppereus/pepper-interface.l
@@ -10,7 +10,54 @@
 
 (defmethod pepper-interface
   (:init (&rest args)
-   (send-super* :init :robot pepper-robot :naoqi-namespace "pepper_robot" args))
+   (send-super* :init :robot pepper-robot :naoqi-namespace "pepper_robot" :dcm-namespace "pepper_dcm" args)
+   (when (ros::get-param "use_sim_time" nil)
+     ;; add controllers for gazebo
+     (dolist (l (list
+		 (cons :dcm-head-controller "/pepper_dcm/Head_controller/follow_joint_trajectory")
+		 (cons :dcm-larm-controller "/pepper_dcm/LeftArm_controller/follow_joint_trajectory")
+		 (cons :dcm-lhand-controller "/pepper_dcm/LeftHand_controller/follow_joint_trajectory")
+		 (cons :dcm-pelvis-controller "/pepper_dcm/Pelvis_controller/follow_joint_trajectory")
+		 (cons :dcm-rarm-controller "/pepper_dcm/RightArm_controller/follow_joint_trajectory")
+		 (cons :dcm-rhand-controller "/pepper_dcm/RightHand_controller/follow_joint_trajectory")
+		 (cons :dcm-wheels-controller "/pepper_dcm/Wheels_controller/follow_joint_trajectory")))
+       (let ((type (car l))
+	     (name (cdr l))
+	     action)
+	 (setq action (find-if #'(lambda (ac) (string= name (send ac :name)))
+			       controller-actions))
+	 (setf (gethash type controller-table) (list action))
+	 )))
+   )
+  (:dcm-pelvis-controller
+   ()
+   (list
+    (list
+     (cons :controller-action "/pepper_dcm/Pelvis_controller/follow_joint_trajectory")
+     (cons :controller-state "/pepper_dcm/Pelvis_controller/state")
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (list "HipRoll" "HipPitch" "KneePitch")))))
+  (:naoqi-controller
+   ()
+   (if (ros::get-param "use_sim_time" nil)
+       (progn
+	 ;; only for simulation
+	 (append
+	  (send self :dcm-head-controller)
+	  (send self :dcm-larm-controller)
+	  (send self :dcm-pelvis-controller)
+	  (send self :dcm-rarm-controller)
+	  )
+	 )
+     (progn
+       (list
+	(list
+	 (cons :controller-action (format nil "~A/pose/joint_trajectory" naoqi-namespace))
+	 ;;(cons :controller-state "joint_trajectory")
+	 (cons :controller-state "dummy_state") ;; this is dummy
+	 (cons :action-type naoqi_bridge_msgs::JointTrajectoryAction)
+	 (cons :joint-names (mapcar #'(lambda (n) (if (symbolp n) (symbol-name n) n)) (send-all (send robot :joint-list) :name)))))
+       )))
   (:show-image 
    (file)
    (let (ret)


### PR DESCRIPTION
```
send *pepper* :head :neck-p :joint-angle 20
send *ri* :angle-vector (send *pepper* :angle-vector)
```
でgazeboでもペッパーを動かすようにしました。手と、ホイールはまだ非対応です。
やり方が正しい自信がなく、何かご意見を頂けるとありがたいです。

問題：
１．実装の仕方について
そもそも``` :angle-vector``` をオーバーライドするので良いのか。他のロボットではどうしているのでしょうか。
２．gazeboを立ち上げていることをどうやって判断するのか
今は ```*ri*``` としてシミュレータが上がっていたら、gazeboのトピックも無条件に出すようになっています。

行ったこと：
``` send *pepper* :head :neck-p :joint-angle 10 ```などで
角度列 ```send *pepper* :angle-vector``` は上書きされていくが、

```send *ri* :angle-vector (send *pepper* :angle-vector) ``` がシミュレーションモードで呼び出された時点で、角度列の要素を各コントローラのトピックを出すメソッド ( ```:gazebo-head-controller``` など) に渡す

（参考）コントローラで担当する関節名の並び
```
rosparam get /pepper_dcm/Head_controller/joints　[HeadYaw, HeadPitch]
rosparam get /pepper_dcm/LeftArm_controller/joints  [LShoulderPitch, LShoulderRoll, LElbowYaw, LElbowRoll, LWristYaw]
rosparam get /pepper_dcm/LeftHand_controller/joints  [LHand]
rosparam get /pepper_dcm/Pelvis_controller/joints  [HipRoll, HipPitch, KneePitch]
rosparam get /pepper_dcm/RightArm_controller/joints  [RShoulderPitch, RShoulderRoll, RElbowYaw, RElbowRoll, RWristYaw]
rosparam get /pepper_dcm/RightHand_controller/joints  [RHand]
rosparam get /pepper_dcm/Wheels_controller/joints  [WheelFL, WheelB, WheelFR]
```
イメージ画像
![gazebo_and_kinematics_simulator](https://cloud.githubusercontent.com/assets/7259671/18374256/553ede76-7686-11e6-9445-78684d880728.png)
