### PR TITLE
[naoqieus] add get(set)-move-arms-enabled methods

### DIFF
--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -213,5 +213,40 @@
 	     (setq res (ros::service-call (format nil "~A/pose/life/getState" naoqi-namespace) req))
 	     (send res :status :data)
 	     )
+  (:get-move-arms-enabled
+   (&optional (arm :arms))
+   (let ((ret (instance naoqi_bridge_msgs::GetArmsEnabledRequest :init))
+	 (arm_msg (instance naoqi_bridge_msgs::Arms :init)) res)
+     (ros::wait-for-service "/get_move_arms_enabled")
+     (case arm
+	   (:larm 
+	    (send arm_msg :data 0))
+	   (:rarm 
+	    (send arm_msg :data 1))
+	   (:arms 
+	    (send arm_msg :data 2)))
+     (send ret :arm arm_msg)
+     (setq res (ros::service-call "/get_move_arms_enabled" ret))
+     (send res :status))
+   )
+  (:set-move-arms-enabled 
+   (status &optional (arm :arms))
+   (let ((ret (instance naoqi_bridge_msgs::SetArmsEnabledRequest :init))
+	 (another-arm-status))
+     (ros::wait-for-service "/set_move_arms_enabled")
+     (case arm
+	   (:arms 
+	    (send ret :left_arm status)
+	    (send ret :right_arm status))
+	   (:rarm
+	    (setq another-arm-status (send *ri* :get-move-arms-enabled 0))
+ 	    (send ret :right_arm status)
+	    (send ret :left_arm another-arm-status))
+	   (:larm 
+	    (setq another-arm-status (send *ri* :get-move-arms-enabled 1))
+	    (send ret :right_arm another-arm-status)
+	    (send ret :left_arm status)))
+     (ros::service-call "/set_move_arms_enabled" ret))
+   )
   )
 ;;


### PR DESCRIPTION
進んでいる時に手を振って進むかどうかを切り替えるメソッドです。
https://github.com/ros-naoqi/naoqi_bridge/pull/61 が必要ですが、このメソッドだけでもマージしてくださるととても助かります。
（今後メソッドについてはREADMEなどに説明を書くようにします。）

```
send *ri* :get-move-arms-enabled :larm
t
3.irteusgl$ send *ri* :get-move-arms-enabled :rarm
nil
4.irteusgl$ send *ri* :get-move-arms-enabled :arms
nil
5.irteusgl$ send *ri* :set-move-arms-enabled nil :larm
#<naoqi_bridge_msgs::setarmsenabledresponse #X90b5d80>
6.irteusgl$ send *ri* :get-move-arms-enabled :larm
nil
7.irteusgl$ send *ri* :get-move-arms-enabled :rarm
t
8.irteusgl$ send *ri* :get-move-arms-enabled :arms
nil
```