### PR TITLE
[jsk_robot_startup] removed unnecessary packages from find_package in CMakeLists.txt

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
+++ b/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
@@ -2,13 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(jsk_robot_startup)
 
 find_package(catkin REQUIRED COMPONENTS
-  mongodb_store
-  roscpp
-  rospy
-  pr2_mechanism_controllers
-  diagnostic_msgs
-  sensor_msgs
-  roseus
   dynamic_reconfigure
 )
 


### PR DESCRIPTION
removed roseus from find_package in CMakeLists.txt in order to build successfully.