### PR TITLE
[jsk_naoqi_robot] speak when launch is killed

### DIFF
--- a/jsk_naoqi_robot/jsk_nao_startup/launch/jsk_nao_startup.launch
+++ b/jsk_naoqi_robot/jsk_nao_startup/launch/jsk_nao_startup.launch
@@ -30,4 +30,8 @@
     <param name="save_all_image" value="false" />
     <param name="filename_format" value="/tmp/nao_camera.png" />
   </node>
+
+  <node name="speaking_program_is_started_or_terminated"
+        pkg="roseus" type="roseus"
+        args="$(find jsk_robot_startup)/lifelog/speaking-program-is-started-or-terminated.l &quot;(progn (unix:sleep 2) (good-morning) (do-until-key (ros::spin-once)))&quot;"/>
 </launch>

--- a/jsk_naoqi_robot/jsk_nao_startup/package.xml
+++ b/jsk_naoqi_robot/jsk_nao_startup/package.xml
@@ -49,7 +49,7 @@
   <run_depend>nao_interaction_msgs</run_depend>
   <run_depend>roseus</run_depend>
   <run_depend>rostwitter</run_depend>
-
+  <run_depend>jsk_robot_startup</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/jsk_naoqi_robot/jsk_pepper_startup/launch/jsk_pepper_startup.launch
+++ b/jsk_naoqi_robot/jsk_pepper_startup/launch/jsk_pepper_startup.launch
@@ -54,4 +54,8 @@ enable_turbo_button: 0  # A button
   <include file="$(find naoqi_dashboard)/launch/naoqi_dashboard.launch"/>
 
   <node pkg="jsk_pepper_startup" name="joy_client" type="joy-client.l" />
+
+  <node name="speaking_program_is_started_or_terminated"
+        pkg="roseus" type="roseus"
+        args="$(find jsk_robot_startup)/lifelog/speaking-program-is-started-or-terminated.l &quot;(progn (unix:sleep 15) (good-morning) (do-until-key (ros::spin-once)))&quot;"/>
 </launch>

--- a/jsk_naoqi_robot/jsk_pepper_startup/package.xml
+++ b/jsk_naoqi_robot/jsk_pepper_startup/package.xml
@@ -26,6 +26,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
   <run_depend>teleop_twist_joy</run_depend>
+  <run_depend>jsk_robot_startup</run_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>roslaunch</test_depend>

--- a/jsk_robot_common/jsk_robot_startup/lifelog/speaking-program-is-started-or-terminated.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/speaking-program-is-started-or-terminated.l
@@ -1,0 +1,17 @@
+#!/usr/bin/env roseus
+(ros::roseus "speaking_program_is_started_or_terminated")
+(ros::load-ros-manifest "roseus")
+(ros::advertise "/speech" std_msgs::String 1)
+;; redefine https://github.com/jsk-ros-pkg/jsk_roseus/blob/1.5.3/roseus/euslisp/roseus.l#L17
+(defun ros::roseus-sigint-handler (sig code)
+  (ros::ROS-WARN (format nil "ros::roseus-sigint-handler ~A" sig))
+  (if (or (substringp "pepper" (ros::get-param "/robot/type")) 
+	  (substringp "nao" (ros::get-param "/robot/type")))
+      (ros::publish "/speech" (instance std_msgs::string :init :data "\\vct=150\\うへぇーッ\\pau=100\\プログラムが\\vct=170\\落ちましたッ\\vct=100\\"))
+    (ros::publish "/speech" (instance std_msgs::string :init :data "プログラムが落ちました")))
+  (exit 1))
+(defun good-morning ()
+  (if (or (substringp "pepper" (ros::get-param "/robot/type"))
+	  (substringp "nao" (ros::get-param "/robot/type")))
+      (ros::publish "/speech" (instance std_msgs::string :init :data "\\vct=150\\準備バンタンッ\\pau=100\\プログラムが\\vct=170\\立ち上がりましたッ\\vct=100\\"))
+    (ros::publish "/speech" (instance std_msgs::string :init :data "プログラムが立ち上がりました"))))


### PR DESCRIPTION
This is what I want in https://github.com/jsk-ros-pkg/jsk_robot/issues/664
I think this should be written by a simple way in the future though...

- prepare jsk_naoqi_startup package 
- prepare node about speech
- add function which speaks when launch is killed to ```rospy.on_shutdown```

I tested this with Nao and Pepper
```
roslaunch jsk_nao(pepper)_startup jsk_nao(pepper)_startup.launch 
(press C-c)
Nao (Pepper) speaks "launch is killed" in Japanese
```