### PR TITLE
[jsk_naoqi_robot] change http to https

### DIFF
--- a/jsk_naoqi_robot/pepper.rosinstall
+++ b/jsk_naoqi_robot/pepper.rosinstall
@@ -1,5 +1,5 @@
 - git:
     local-name: jsk_robot
-    uri: http://github.com/jsk-ros-pkg/jsk_robot.git
+    uri: https://github.com/jsk-ros-pkg/jsk_robot.git
     version: master
 


### PR DESCRIPTION
Based on the changing history of pepper.rosinstall, I think ```http``` is typo.
If it is not necessary, I'll close this. Sorry for my trouble.
