### PR TITLE
[jsk_naoqi_robot] add roseus in find_package

### DIFF
--- a/jsk_naoqi_robot/naoeus/CMakeLists.txt
+++ b/jsk_naoqi_robot/naoeus/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(naoeus)
 
-find_package(catkin REQUIRED nao_description naoqieus rostest)
+find_package(catkin REQUIRED nao_description naoqieus roseus rostest)
 
 catkin_package()
 

--- a/jsk_naoqi_robot/peppereus/CMakeLists.txt
+++ b/jsk_naoqi_robot/peppereus/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(peppereus)
 
-find_package(catkin REQUIRED pepper_description naoqieus rostest)
+find_package(catkin REQUIRED pepper_description naoqieus roseus rostest)
 
 catkin_package()
 


### PR DESCRIPTION
I'd like to have manifest.l of peppereus by just executing ```catkin b peppereus```. (reference: #678)

(Even though I can't test it on Nao (jsk_nao_startup) because Nao goes to travel now, I added same change like peppereus.)

If there is any problem, please let me know. Sorry for my trouble.