### PR TITLE
[jsk_nao_startup] add nao_bringup to run depend

### DIFF
--- a/jsk_naoqi_robot/jsk_nao_startup/package.xml
+++ b/jsk_naoqi_robot/jsk_nao_startup/package.xml
@@ -50,6 +50,7 @@
   <run_depend>roseus</run_depend>
   <run_depend>rostwitter</run_depend>
   <run_depend>jsk_robot_startup</run_depend>
+  <run_depend>nao_bringup</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
I think the problem below may be solved by the pull request.
```
roslaunch jsk_nao_startup jsk_nao_startup.launch 
... logging to /home/kochigami/.ros/log/218f6800-9a78-11e6-8cbd-507b9d20c4fb/roslaunch-kochigami-ThinkPad-T450-20314.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

Traceback (most recent call last):
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/__init__.py", line 307, in main
    p.start()
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/parent.py", line 268, in start
    self._start_infrastructure()
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/parent.py", line 217, in _start_infrastructure
    self._load_config()
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/parent.py", line 132, in _load_config
    roslaunch_strs=self.roslaunch_strs, verbose=self.verbose)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/config.py", line 451, in load_config_default
    loader.load(f, config, verbose=verbose)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 746, in load
    self._load_launch(launch, ros_config, is_core=core, filename=filename, argv=argv, verbose=verbose)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 718, in _load_launch
    self._recurse_load(ros_config, launch.childNodes, self.root_context, None, is_core, verbose)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 682, in _recurse_load
    val = self._include_tag(tag, context, ros_config, default_machine, is_core, verbose)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 95, in call
    return f(*args, **kwds)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 587, in _include_tag
    inc_filename = self.resolve_args(tag.attributes['file'].value, context)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 183, in resolve_args
    return substitution_args.resolve_args(args, context=context.resolve_dict, resolve_anon=self.resolve_anon)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/substitution_args.py", line 312, in resolve_args
    resolved = _resolve_args(resolved, context, resolve_anon, commands)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/substitution_args.py", line 325, in _resolve_args
    resolved = commands[command](resolved, a, args, context)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/substitution_args.py", line 141, in _find
    source_path_to_packages=source_path_to_packages)
  File "/opt/ros/indigo/lib/python2.7/dist-packages/roslaunch/substitution_args.py", line 184, in _find_executable
    full_path = _get_executable_path(rp.get_path(args[0]), path)
  File "/usr/lib/python2.7/dist-packages/rospkg/rospack.py", line 200, in get_path
    raise ResourceNotFound(name, ros_paths=self._ros_paths)
ResourceNotFound: nao_bringup
ROS path [0]=/opt/ros/indigo/share/ros
ROS path [1]=/home/kochigami/catkin_ws/src/euslib/demo/terasawa/catkin_ws/src/baseball
ROS path [2]=/home/kochigami/catkin_ws/src/euslib/demo/s-noda/tmp-ros-package/baxter_bartender
ROS path [3]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_baxter_robot/baxtereus
ROS path [4]=/home/kochigami/catkin_ws/src/euslib/demo/k-kimura/pedaling/hrp2/bicycle_move_base
ROS path [5]=/home/kochigami/catkin_ws/src/euslib/demo/kenji/catkin_ws/src/detect_rim
ROS path [6]=/home/kochigami/catkin_ws/src/euslib/demo/kenji/catkin_ws/src/dynamic_graphcut
ROS path [7]=/home/kochigami/catkin_ws/src/euslib/demo/nozawa/eus_cddplus
ROS path [8]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_fetch_robot/fetcheus
ROS path [9]=/home/kochigami/catkin_ws/src/euslib/demo/s-fujii/ompugao-ros-pkgs/fx8_ros_driver
ROS path [10]=/home/kochigami/catkin_ws/src/gazebo_ros_pkgs/gazebo_msgs
ROS path [11]=/home/kochigami/catkin_ws/src/gazebo_ros_pkgs/gazebo_plugins
ROS path [12]=/home/kochigami/catkin_ws/src/gazebo_ros_pkgs/gazebo_ros
ROS path [13]=/home/kochigami/catkin_ws/src/gazebo_ros_pkgs/gazebo_ros_control
ROS path [14]=/home/kochigami/catkin_ws/src/gazebo_ros_pkgs/gazebo_ros_pkgs
ROS path [15]=/home/kochigami/catkin_ws/src/euslib/demo/chou/ros_workspace_catkin/src/hydra_moveit_config
ROS path [16]=/home/kochigami/catkin_ws/src/iai_kinect2/iai_kinect2
ROS path [17]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_baxter_robot/jsk_baxter_startup
ROS path [18]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_baxter_robot/jsk_baxter_desktop
ROS path [19]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_baxter_robot/jsk_baxter_web
ROS path [20]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_fetch_robot/jsk_fetch_startup
ROS path [21]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_naoqi_robot/jsk_pepper_startup
ROS path [22]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_pr2_robot/jsk_pr2_calibration
ROS path [23]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_robot
ROS path [24]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_robot_common/jsk_robot_startup
ROS path [25]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_robot_common/jsk_robot_utils
ROS path [26]=/home/kochigami/catkin_ws/src/euslib/demo/s-noda/tmp-ros-package/kao_project
ROS path [27]=/home/kochigami/catkin_ws/src/iai_kinect2/kinect2_registration
ROS path [28]=/home/kochigami/catkin_ws/src/iai_kinect2/kinect2_bridge
ROS path [29]=/home/kochigami/catkin_ws/src/iai_kinect2/kinect2_calibration
ROS path [30]=/home/kochigami/catkin_ws/src/iai_kinect2/kinect2_viewer
ROS path [31]=/home/kochigami/catkin_ws/src/euslib/demo/mizohana/tmp-ros-pkg/manip_test
ROS path [32]=/home/kochigami/catkin_ws/src/naoqi_bridge/naoqi_apps
ROS path [33]=/home/kochigami/catkin_ws/src/naoqi_bridge/naoqi_bridge
ROS path [34]=/home/kochigami/catkin_ws/src/naoqi_bridge_msgs
ROS path [35]=/home/kochigami/catkin_ws/src/naoqi_driver
ROS path [36]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_naoqi_robot/jsk_nao_startup
ROS path [37]=/home/kochigami/catkin_ws/src/naoqi_bridge/naoqi_driver_py
ROS path [38]=/home/kochigami/catkin_ws/src/naoqi_bridge/naoqi_pose
ROS path [39]=/home/kochigami/catkin_ws/src/naoqi_bridge/naoqi_sensors_py
ROS path [40]=/home/kochigami/catkin_ws/src/naoqi_bridge/naoqi_tools
ROS path [41]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_naoqi_robot/naoqieus
ROS path [42]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_naoqi_robot/naoeus
ROS path [43]=/home/kochigami/catkin_ws/src/pepper_robot/pepper_bringup
ROS path [44]=/home/kochigami/catkin_ws/src/pepper_virtual/pepper_control
ROS path [45]=/home/kochigami/catkin_ws/src/pepper_robot/pepper_description
ROS path [46]=/home/kochigami/catkin_ws/src/pepper_virtual/pepper_gazebo_plugin
ROS path [47]=/home/kochigami/catkin_ws/src/pepper_robot/pepper_robot
ROS path [48]=/home/kochigami/catkin_ws/src/pepper_robot/pepper_sensors_py
ROS path [49]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_naoqi_robot/peppereus
ROS path [50]=/home/kochigami/catkin_ws/src/grub_toy
ROS path [51]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_naoqi_robot/jsk_201504_miraikan
ROS path [52]=/home/kochigami/catkin_ws/src/euslib/demo/youhei/pfilter_test
ROS path [53]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_pr2_robot/pr2_base_trajectory_action
ROS path [54]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_pr2_robot/jsk_pr2_startup
ROS path [55]=/home/kochigami/catkin_ws/src/rgbdslam_v2-indigo
ROS path [56]=/home/kochigami/catkin_ws/src/roboticsgroup_gazebo_plugins
ROS path [57]=/home/kochigami/catkin_ws/src/jsk_robot/jsk_robot_common/roseus_remote
ROS path [58]=/home/kochigami/catkin_ws/src/euslib/demo/sasabuchi/ssb_srvs_msgs
ROS path [59]=/home/kochigami/catkin_ws/src/euslib/demo/sasabuchi/ssb_tutorials
ROS path [60]=/home/kochigami/catkin_ws/src/euslib/demo/terasawa/B4/my_catkin_ws/src/stereo
ROS path [61]=/home/kochigami/catkin_ws/src/euslib/demo/inagaki/test_pcl
ROS path [62]=/home/kochigami/catkin_ws/src/euslib/demo/s-noda/tmp-ros-package/tmp_hrpsys_util
ROS path [63]=/home/kochigami/catkin_ws/src/walk_together
ROS path [64]=/home/kochigami/catkin_ws/src/euslib/demo/s-noda/tmp-ros-package/world2scene
ROS path [65]=/opt/ros/indigo/share
ROS path [66]=/opt/ros/indigo/stacks
```
```