### PR TITLE
[jsk_fetch_startup] add fetch bringup launch files for gazebo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -1,8 +1,13 @@
 <launch>
-  <include file="$(find jsk_fetch_startup)/jsk_fetch.machine" />
   <arg name="launch_moveit" default="true" />
   <arg name="launch_move_base" default="true" />
   <arg name="boot_sound" default="false" />
+  <arg name="map_frame" default="map" />
+
+  <param name="robot/name" value="fetch" />
+
+  <include file="$(find jsk_fetch_startup)/jsk_fetch.machine" />
+
   <!-- add jsk startups -->
   <node pkg="jsk_fetch_startup" name="warning" type="warning.py" respawn="true" />
   <node pkg="jsk_fetch_startup" name="nav_speak" type="nav_speak.py" respawn="true" />
@@ -13,9 +18,7 @@
     <param name="buffer_size" value="120.0"/>
   </node>
 
-  <!-- jsk_pr2_startup/jsk_pr2_lifelog/db_client.launch -->
   <!-- mongodb -->
-  <param name="robot/name" value="fetch" />
   <include file="$(find jsk_robot_startup)/lifelog/mongodb.launch" >
     <arg name="use_daemon" value="true"/>
     <arg name="port" value="27017" />
@@ -23,7 +26,6 @@
     <arg name="replicate" default="false" />
   </include>
   <!-- logging and resoring pr2 position data -->
-  <arg name="map_frame" value="map" />
   <node name="move_base_db"
         pkg="jsk_pr2_startup" type="move_base_db.py" >
     <param name="map_frame" value="$(arg map_frame)"/>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -1,6 +1,7 @@
 <launch>
   <include file="$(find jsk_fetch_startup)/jsk_fetch.machine" />
   <arg name="launch_moveit" default="true" />
+  <arg name="launch_move_base" default="true" />
   <arg name="boot_sound" default="false" />
   <!-- add jsk startups -->
   <node pkg="jsk_fetch_startup" name="warning" type="warning.py" respawn="true" />
@@ -34,24 +35,25 @@
   <include file="$(find fetch_moveit_config)/launch/move_group.launch"
            if="$(arg launch_moveit)" />
 
-  <!-- include fetch_navigation -->
-  <include file="$(find fetch_navigation)/launch/fetch_nav.launch" >
-    <arg name="map_file" default="$(find jsk_maps)/raw_maps/eng2-7f-0.05.yaml" />
-    <arg name="map_keepout_file" default="$(find jsk_maps)/raw_maps/eng2-7f-0.05_keepout.yaml" />
-    <arg name="use_keepout" default="true" />
-  </include>
-  <rosparam ns="move_base/global_costmap">
+  <group if="$(arg launch_move_base)">
+    <!-- include fetch_navigation -->
+    <include file="$(find fetch_navigation)/launch/fetch_nav.launch" >
+      <arg name="map_file" default="$(find jsk_maps)/raw_maps/eng2-7f-0.05.yaml" />
+      <arg name="map_keepout_file" default="$(find jsk_maps)/raw_maps/eng2-7f-0.05_keepout.yaml" />
+      <arg name="use_keepout" default="true" />
+    </include>
+    <rosparam ns="move_base/global_costmap">
 inflater:
   inflation_radius: 0.80 # 0.7
   cost_scaling_factor: 10.0 # 10.0
-  </rosparam>
-  <rosparam ns="move_base/local_costmap">
+    </rosparam>
+    <rosparam ns="move_base/local_costmap">
 inflater:
   inflation_radius: 0.30 # 0.7
   cost_scaling_factor: 100.0 # 25.0 default 10, increasing factor decrease the cost value
 update_frequency: 10.0 # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
-  </rosparam>
-  <rosparam ns="move_base">
+    </rosparam>
+    <rosparam ns="move_base">
 base_local_planner: base_local_planner/TrajectoryPlannerROS
 TrajectoryPlannerROS:
   escape_vel: -0.1 # -0.1
@@ -68,5 +70,6 @@ recovery_behaviors:
 conservative_reset: {reset_distance: 1.0} # 3.0
 aggressive_reset: {reset_distance: 0.2} # 0.5
 move_slow_and_clear: {clearing_distance: 0.5, limited_distance: 0.3, limited_rot_speed: 0.45, limited_trans_speed: 0.25}
-  </rosparam>
+    </rosparam>
+  </group>
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_gazebo_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_gazebo_bringup.launch
@@ -1,0 +1,39 @@
+<launch>
+  <arg name="launch_gazebo" default="true" />
+  <arg name="launch_gui" default="true" />
+  <arg name="launch_moveit" default="true" />
+  <arg name="launch_move_base" default="true" />
+  <arg name="paused" default="false" />
+  <arg name="world" default="worlds/empty.world" />
+  <arg name="map_frame" default="map" />
+
+  <arg name="INITIAL_POSE_X" default="0.0" />
+  <arg name="INITIAL_POSE_Y" default="0.0" />
+  <arg name="INITIAL_POSE_Z" default="0.0" />
+  <arg name="INITIAL_POSE_YAW" default="0.0" />
+
+  <group if="$(arg launch_gazebo)">
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+      <arg name="gui" value="$(arg launch_gui)" />
+      <arg name="headless" value="false" if="$(arg launch_gui)" />
+      <arg name="headless" value="true" unless="$(arg launch_gui)" />
+      <arg name="paused" value="$(arg paused)" />
+      <arg name="world_name" value="$(arg world)" />
+      <arg name="use_sim_time" value="true" />
+    </include>
+    <include file="$(find fetch_gazebo)/launch/include/fetch.launch.xml">
+      <arg name="x" value="$(arg INITIAL_POSE_X)" />
+      <arg name="y" value="$(arg INITIAL_POSE_Y)" />
+      <!-- wait for https://github.com/fetchrobotics/fetch_gazebo/pull/16 -->
+      <!-- <arg name="z" value="$(arg INITIAL_POSE_Z)" /> -->
+      <!-- <arg name="yaw" value="$(arg INITIAL_POSE_YAW)" /> -->
+    </include>
+  </group>
+
+  <include file="$(find jsk_fetch_startup)/launch/fetch_bringup.launch">
+    <arg name="launch_moveit" value="$(arg launch_moveit)" />
+    <arg name="launch_move_base" value="$(arg launch_move_base)" />
+    <arg name="map_frame" value="$(arg map_frame)" />
+    <arg name="boot_sound" value="false" />
+  </include>
+</launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/gazebo/fetch_gazebo_73b2.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/gazebo/fetch_gazebo_73b2.launch
@@ -1,0 +1,22 @@
+<launch>
+  <arg name="INITIAL_POSE_X" default="1.0" />
+  <arg name="INITIAL_POSE_Y" default="0.0" />
+  <arg name="INITIAL_POSE_YAW" default="0.0" />
+
+  <include file="$(find jsk_fetch_startup)/launch/fetch_gazebo_bringup.launch">
+    <arg name="world" value="$(find eusurdf)/worlds/room73b2.world" />
+    <arg name="map_frame" value="eng2" />
+    <arg name="INITIAL_POSE_X" value="$(arg INITIAL_POSE_X)" />
+    <arg name="INITIAL_POSE_Y" value="$(arg INITIAL_POSE_Y)" />
+  </include>
+
+  <node name="initial_pose_publisher" output="screen"
+        pkg="jsk_robot_startup" type="initialpose_publisher.l">
+    <rosparam subst_value="true">
+      initial_pose_frame: /eng2/7f/73B2
+      initial_pose_x: $(arg INITIAL_POSE_X)
+      initial_pose_y: $(arg INITIAL_POSE_Y)
+      initial_pose_yaw: $(arg INITIAL_POSE_YAW)
+    </rosparam>
+  </node>
+</launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/package.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/package.xml
@@ -15,6 +15,7 @@
   <run_depend>jsk_maps</run_depend>
   <run_depend>jsk_pr2_startup</run_depend>
   <run_depend>fetch_navigation</run_depend>
+  <run_depend>fetch_driver_msgs</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>tf2_ros</run_depend>
 


### PR DESCRIPTION
this is rewrited version of #671, 

still depends on https://github.com/fetchrobotics/fetch_gazebo/pull/16 and https://github.com/jsk-ros-pkg/jsk_demos/pull/1206


```
roslaunch jsk_fetch_startup fetch_gazebo_73b2.launch
```
![screenshot from 2016-10-27 10 32 21](https://cloud.githubusercontent.com/assets/493276/19751149/41cb639c-9c32-11e6-9c67-a165e3397a34.png)

![screenshot from 2016-10-27 10 40 09](https://cloud.githubusercontent.com/assets/493276/19751152/450f6f4e-9c32-11e6-985d-851f87d9a171.png)

(you need to run rviz manually)


- add gazebo/fetch_gazebo_73b2.launch
- add fetch_gazebo_bringup.launch
- fetch_bringup.launch: cleanup launch file
- fetch_bringup.launch: add launch_move_base args
- fetch_bringup.launch: add launch_moveit args
- add fetch_driver_msgs to package.xml