### PR TITLE
[baxtereus] add moveit init option in baxter-interface

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -13,7 +13,9 @@
   :slots (gripper-sequence-id right-gripper-action left-gripper-action
 			      right-gripper-type left-gripper-type moveit-robot))
 (defmethod baxter-interface
-  (:init (&rest args)
+  (:init (&rest args &key ((:moveit-environment mvit-env) (instance baxter-moveit-environment))
+                ((:moveit-robot mvit-rb) (instance baxter-robot :init))
+                &allow-other-keys)
    (prog1 (send-super* :init :robot baxter-robot :joint-states-topic "/robot/joint_states" :groupname "baxter_interface" args)
      (send self :add-controller :larm-controller)
      (send self :add-controller :rarm-controller)
@@ -44,8 +46,8 @@
 
      (setq gripper-sequence-id 0)
      (ros::spin-once)
-     (setq moveit-robot (instance baxter-robot :init))
-     (send self :set-moveit-environment (instance baxter-moveit-environment :init :robot moveit-robot))
+     (if mvit-rb (setq moveit-robot mvit-rb))
+     (if mvit-env (send self :set-moveit-environment (send mvit-env :init :robot moveit-robot)))
      ))
   (:right-property-cb (msg)
    (setq right-gripper-type (send msg :id))

--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -273,7 +273,9 @@
                (cons :joint-list (send robot :larm :joint-list))
                )
          )
-#|
+#| SRDF generated from baxter.srdf.xacro in baxter_moveit_config
+   url: https://github.com/ros-planning/moveit_robots/blob/kinetic-devel/baxter/baxter_moveit_config/config/baxter.srdf.xacro
+
   <group name="left_arm">
     <chain base_link="torso" tip_link="left_gripper"/>
   </group>


### PR DESCRIPTION
- add srdf description
- add baxter config init option in baxter-interface

this option is needed for customize baxter like jsk_baxter_apc


```
$ roscd jsk_2016_01_baxter_apc/euslisp/jsk_2016_01_baxter_apc
$ roseus baxter-interface.l
configuring by "/opt/ros/indigo/share/euslisp/jskeus/eus//lib/eusrt.l"
;; readmacro ;; object ;; packsym ;; common ;; constants ;; stream ;; string ;; loader ;; pprint ;; process ;; hashtab ;; array ;; mathtran ;; eusdebug ;; eusforeign ;; coordinates ;; tty ;; history ;; toplevel ;; trans ;; comp ;; builtins ;; par ;; intersection ;; geoclasses ;; geopack ;; geobody ;; primt ;; compose ;; polygon ;; viewing ;; viewport ;; viewsurface ;; hid ;; shadow ;; bodyrel ;; dda ;; helpsub ;; eushelp ;; xforeign ;; Xdecl ;; Xgraphics ;; Xcolor ;; Xeus ;; Xevent ;; Xpanel ;; Xitem ;; Xtext ;; Xmenu ;; Xscroll ;; Xcanvas ;; Xtop ;; Xapplwin
connected to Xserver DISPLAY=:0
X events are being asynchronously monitored.
;; pixword ;; RGBHLS ;; convolve ;; piximage ;; pbmfile ;; image_correlation ;; oglforeign ;; gldecl ;; glconst ;; glforeign ;; gluconst ;; gluforeign ;; glxconst ;; glxforeign ;; eglforeign ;; eglfunc ;; glutil ;; gltexture ;; glprim ;; gleus ;; glview ;; toiv-undefined ;; fstringdouble irtmath irtutil irtc irtgeoc irtgraph pgsql irtgeo euspqp pqp irtscene irtmodel irtdyna irtrobot irtsensor irtbvh irtcollada irtpointcloud irtx eusjpeg euspng png irtimage irtglrgb
;; extending gcstack 0x6314ba0[16374] --> 0x6776fc0[32748] top=3cc1
irtgl irtglc irtviewer
EusLisp 9.21( 1.0.13) for Linux64 created on ip-172-31-6-90(Mon Sep 5 10:32:52 PDT 2016)
roseus ;; loading roseus("") on euslisp((9.21 ip-172-31-6-90 Mon Sep 5 10:32:52 PDT 2016  1.0.13))
eustf roseus_c_util
;; extending gcstack 0x6776fc0[32738] --> 0x71f1cd0[65476] top=7c7e
1.irteusgl$ jsk_2016_01_baxter_apc::baxter-init

;; extending gcstack 0x71f1cd0[65466] --> 0x1a1f1fe0[130932] top=ffb9
[ WARN] [1478783230.294940953]: [robot/end_effector/right_gripper/gripper_action] action server is not found
[ WARN] [1478783230.295211420]:      goal=0, cancel=0, feedback=0, result=0
[ WARN] [1478783230.295309488]: #<ros::simple-action-client #X6af7508 robot/end_effector/right_gripper/gripper_action> is not respond
[ INFO] [1478783230.295383271]: *** if you do not have gripper, you can ignore this message ***
/opt/ros/indigo/share/euslisp/jskeus/eus/Linux64/bin/irteusgl 0 error: unbound variable right_gripper_lk in (forward-message-to right_gripper_lk args)
```