### PR TITLE
[WIP] [baxtereus] Enable to set customized robot in baxter-interface

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -13,10 +13,11 @@
   :slots (gripper-sequence-id right-gripper-action left-gripper-action
 			      right-gripper-type left-gripper-type moveit-robot))
 (defmethod baxter-interface
-  (:init (&rest args &key ((:moveit-environment mvit-env) (instance baxter-moveit-environment))
+  (:init (&rest args &key ((:robot robot) baxter-robot)
+                ((:moveit-environment mvit-env) (instance baxter-moveit-environment))
                 ((:moveit-robot mvit-rb) (instance baxter-robot :init))
                 &allow-other-keys)
-   (prog1 (send-super* :init :robot baxter-robot :joint-states-topic "/robot/joint_states" :groupname "baxter_interface" args)
+   (prog1 (send-super* :init :robot robot :joint-states-topic "/robot/joint_states" :groupname "baxter_interface" args)
      (send self :add-controller :larm-controller)
      (send self :add-controller :rarm-controller)
      (send self :add-controller :head-controller)


### PR DESCRIPTION
### What I want to do
Set customized baxter-robot (jsk_2016_01_baxter_apc::baxter-robot) as `robot` in `baxter-interface`.
This enables us to use https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/244 without moving gripper joint.
