### PR TITLE
[fetch] Correct head orientation for look-at

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch.yaml
+++ b/jsk_fetch_robot/fetcheus/fetch.yaml
@@ -23,3 +23,6 @@ rarm-end-coords:
   parent : gripper_link
   translate : [0, 0, 0]
   rotate : [0, 0, 1, 0]
+head-end-coords:
+  translate : [0.06, 0, 0.025]
+  rotate : [0, 1, 0, 90]


### PR DESCRIPTION
Rotates head end-coords such that z axis faces forward in order to fix look-at method glitch (always faces down).