### PR TITLE
[fetch] Use args in :angle-vector and add :rarm-angle-vector method

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -40,8 +40,11 @@
      (ros::warn ":angle-vector tm is not a number, use :angle-vector av tm args"))
    (let ((use-torso t))
      (if (and (member :use-torso args) (null (cadr (member :use-torso args)))) (setq use-torso nil))
-     (send self :angle-vector-motion-plan av :move-arm :rarm :total-time tm :start-offset-time 0.01 :use-torso use-torso :clear-velocities t)
+     (send* self :angle-vector-motion-plan av :move-arm :rarm :total-time tm :start-offset-time 0.01 :use-torso use-torso :clear-velocities t args)
    ))
+  (:rarm-angle-vector 
+   (av &optional (tm 3000) &rest args)
+   (send* self :angle-vector av tm :ctype :arm-controller args))
   ;;
   (:default-controller ()
    (append


### PR DESCRIPTION
:rarm-angle-vector is taxed as 'obsolete' in pr2-interface.l , but thought it might be useful so defined it.

Sending rest arguments in :angle-vector to make possible to select controller with motion plan.