### PR TITLE
use language: c++ , to avoid custom python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: generic
+language: c++
 cache:
   apt: true
   pip: true


### PR DESCRIPTION
need to use system python, with travis-python, we can not find python module install by apt

jsk-ros-pkg/jsk_3rdparty#117