### PR TITLE
[naoqieus] add methods of basic awareness

### DIFF
--- a/jsk_naoqi_robot/naoqieus/doc/get_basic_awareness_enabled.md
+++ b/jsk_naoqi_robot/naoqieus/doc/get_basic_awareness_enabled.md
@@ -1,0 +1,23 @@
+## :get-basic-awareness-enabled (naoqi_bridge [`kochigami-develop`])
+
+### What is this?
+
+Return whether basic awareness is enabled. For further details on basic awareness, please refer to [here](http://doc.aldebaran.com/2-5/naoqi/interaction/autonomousabilities/albasicawareness.html#albasicawareness).
+
+### Location
+
+`naoqi_apps/launch/basic_awareness.launch`  
+
+### NAOqi API
+
+[ALBasicAwareness::isEnabled](http://doc.aldebaran.com/2-5/naoqi/interaction/autonomousabilities/albasicawareness-api.html#ALBasicAwarenessProxy::isEnabled)    
+
+Related commits are [here](https://github.com/kochigami/naoqi_bridge/commit/f91bb1ed5598d19d5be4f6186b0710c5b69a5a3d#diff-a526e4a93ddc5f0149214c25d7f13988) and [here](https://github.com/kochigami/naoqi_bridge/commit/8344b35a79e3e465cd43ffc1457254f3b13c6ef1#diff-a526e4a93ddc5f0149214c25d7f13988).  
+
+### Sample
+
+```
+; get basic awareness status
+send *ri* :get-basic-awareness-enabled
+t
+```

--- a/jsk_naoqi_robot/naoqieus/doc/set_basic_awareness_enabled.md
+++ b/jsk_naoqi_robot/naoqieus/doc/set_basic_awareness_enabled.md
@@ -1,0 +1,26 @@
+## :set-basic-awareness-enabled `status` (naoqi_bridge [`kochigami-develop`])
+
+### What is this?
+
+Enable or disable basic awareness. For further details on basic awareness, please refer to [here](http://doc.aldebaran.com/2-5/naoqi/interaction/autonomousabilities/albasicawareness.html#albasicawareness).   
+
+### Parameters
+
+`status`: t/ nil (bool)  
+
+### Location
+
+`naoqi_apps/launch/basic_awareness.launch`  
+
+### NAOqi API
+
+[ALBasicAwareness::setEnabled](http://doc.aldebaran.com/2-5/naoqi/interaction/autonomousabilities/albasicawareness-api.html#ALBasicAwarenessProxy::setEnabled__b)  
+
+Related commits are [here](https://github.com/kochigami/naoqi_bridge/commit/f91bb1ed5598d19d5be4f6186b0710c5b69a5a3d#diff-a526e4a93ddc5f0149214c25d7f13988) and [here](https://github.com/kochigami/naoqi_bridge/commit/8344b35a79e3e465cd43ffc1457254f3b13c6ef1#diff-a526e4a93ddc5f0149214c25d7f13988).  
+
+### Sample
+
+```
+; enable basic awareness
+send *ri* :set-basic-awareness-enabled t
+```

--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -417,6 +417,23 @@
      (send res :success)
      )
    )
+  (:set-basic-awareness-enabled
+   (status)
+   (let ((ret (instance std_srvs::SetBoolRequest :init))
+	 res)
+     (ros::wait-for-service "/basic_awareness/set_enabled")
+     (send ret :data status)
+     (setq res (ros::service-call "/basic_awareness/set_enabled" ret))
+     (send res :success)
+     ))
+  (:get-basic-awareness-enabled
+   ()
+   (let ((ret (instance std_srvs::TriggerRequest :init))
+	 res)
+     (ros::wait-for-service "/basic_awareness/is_enabled")
+     (setq res (ros::service-call "/basic_awareness/is_enabled" ret))
+     (send res :success)
+     ))
   (:fade-leds
    (led_name r g b sec)
    (let* ((fade_rgb_msg (instance naoqi_bridge_msgs::FadeRGB :init))

--- a/jsk_naoqi_robot/naoqieus/test/test-naoqieus.l
+++ b/jsk_naoqi_robot/naoqieus/test/test-naoqieus.l
@@ -87,6 +87,12 @@
 (deftest test-get-background-movement-enabled
   (assert  (instance std_srvs::TriggerRequest :init) "test-get-background-movement-enabled"))
 
+(deftest test-set-basic-awareness-enabled
+  (assert  (instance std_srvs::SetBoolRequest :init) "test-set-basic-awareness-enabled"))
+
+(deftest test-get-basic-awareness-enabled
+  (assert  (instance std_srvs::TriggerRequest :init) "test-get-basic-awareness-enabled"))
+
 (run-all-tests)
 (exit)
 


### PR DESCRIPTION
requires: 
(1) https://github.com/ros-naoqi/naoqi_bridge/pull/72
(2) https://github.com/ros-naoqi/naoqi_bridge/pull/82
(3) https://github.com/ros-naoqi/naoqi_bridge/pull/83

documentation:
(1) http://doc.aldebaran.com/2-5/naoqi/interaction/autonomousabilities/allisteningmovement.html
(2) http://doc.aldebaran.com/2-5/naoqi/interaction/autonomousabilities/albackgroundmovement-api.html#albackgroundmovement-api
(3) http://doc.aldebaran.com/2-5/naoqi/interaction/autonomousabilities/albasicawareness-api.html#albasicawareness-api

(1)
```
2.irteusgl$ send *ri* :set-listening-movement-enabled t
t
3.irteusgl$ send *ri* :get-listening-movement-enabled
t
4.irteusgl$ send *ri* :set-listening-movement-enabled nil
t
5.irteusgl$ send *ri* :get-listening-movement-enabled
nil
```

(2)
```
2.irteusgl$ send *ri* :set-background-movement-enabled t
t
3.irteusgl$ send *ri* :get-background-movement-enabled
t
4.irteusgl$ send *ri* :set-background-movement-enabled nil
t
5.irteusgl$  send *ri* :get-background-movement-enabled
nil
6.irteusgl$ send *ri* :set-background-movement-enabled t
t
```

(3)
```
5.E1-irteusgl$ send *ri* :set-basic-awareness-enabled nil
t
6.E1-irteusgl$ send *ri* :get-basic-awareness-enabled
nil
7.E1-irteusgl$ send *ri* :set-basic-awareness-enabled t
t
8.E1-irteusgl$ send *ri* :get-basic-awareness-enabled
t
```
