### PR TITLE
[peppereus] move head end coords to depth camera side

### DIFF
--- a/jsk_naoqi_robot/peppereus/pepper.yaml
+++ b/jsk_naoqi_robot/peppereus/pepper.yaml
@@ -30,7 +30,7 @@ angle-vector:
 ##
 head-end-coords:
   parent : CameraTop_frame
-  translate : [0, 0, 0]
+  translate : [0, 0, -0.0437]
   rotate    : [0, 1, 0, 90]
 
 rarm-end-coords:


### PR DESCRIPTION
- move head end coords to depth camera side from top camera side (located at forehead)
- reference: http://doc.aldebaran.com/2-5/family/pepper_technical/kinematics_pep.html#pepp-urdf-files
it says
```
<joint name="CameraTop_sensor_fixedjoint" type="fixed">                                                      
<origin xyz="0.0868 0 0.1631" rpy="0 -0 0" />  

<joint name="CameraDepth_sensor_fixedjoint" type="fixed">                                                    
<origin xyz="0.05138 0.039 0.1194" rpy="0 -0 0" />                                                           
```
Therefore I just calculated 0.1631 - 0.1194 = 0.0437

result:
![screenshot from 2017-08-03 19 43 12](https://user-images.githubusercontent.com/7259671/28918563-b45a5704-7884-11e7-80d6-fb8f278f359f.png)
