### PR TITLE
[baxtereus] suppress ros-info output in baxter ik

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-util.l
+++ b/jsk_baxter_robot/baxtereus/baxter-util.l
@@ -17,7 +17,7 @@
       2. Split points between current and target coords from each.
       3. From prepared poses. Poses in `:ik-prepared-poses` methods are used,
           and if it is not defined `:untuck-pose` is used."
-   (ros::ros-info "call ik of ~A" baxter-robot)
+   (ros::ros-debug "call ik of ~A" baxter-robot)
    (let ((r) (prev-av (send self :angle-vector)))
      (setq r (send-super* :inverse-kinematics target-coords :avoid-collision-distance avoid-collision-distance :warnp nil :dump-command nil args))
      (unless r ;;


### PR DESCRIPTION
too many ros::ros-info output when using baxter