### PR TITLE
jsk_fetch_startup: add voice_text and speak-jp

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -130,9 +130,15 @@
       (setq result (send gripper-action :get-result))
       result))
   ;;
-  (:speak (text &rest args)
-    (let ()
-      (apply #'speak-en text :topic-name "/sound_play" args)))
+  (:speak-en (text &rest args)
+    (apply #'speak-en text :topic-name "/sound_play" args))
+  (:speak-jp (text &rest args)
+    (apply #'speak-jp text :topic-name "/robotsound_jp" args))
+  (:speak (text &rest args &key (lang :en) &allow-other-keys)
+    (case lang
+      (:en (send* self :speak-en text (remprop :lang args)))
+      (:ja (send* self :speak-jp text (remprop :lang args)))
+      (t (error "Unsupported language ~A" lang))))
   )
 
 (defun fetch-init (&optional (create-viewer))

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -129,16 +129,6 @@
       (when wait (send gripper-action :wait-for-result))
       (setq result (send gripper-action :get-result))
       result))
-  ;;
-  (:speak-en (text &rest args)
-    (apply #'speak-en text :topic-name "/sound_play" args))
-  (:speak-jp (text &rest args)
-    (apply #'speak-jp text :topic-name "/robotsound_jp" args))
-  (:speak (text &rest args &key (lang :en) &allow-other-keys)
-    (case lang
-      (:en (send* self :speak-en text (remprop :lang args)))
-      (:ja (send* self :speak-jp text (remprop :lang args)))
-      (t (error "Unsupported language ~A" lang))))
   )
 
 (defun fetch-init (&optional (create-viewer))

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -17,6 +17,9 @@
   <node pkg="jsk_fetch_startup" name="nav_speak" type="nav_speak.py" respawn="true" />
   <node if="$(arg boot_sound)" pkg="jsk_fetch_startup" name="boot_sound" type="boot_sound.py" />
 
+  <!-- japanese speech node -->
+  <include file="$(find voice_text)/launch/voice_text.launch" />
+
   <!-- Buffer Server -->
   <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server" output="screen">
     <param name="buffer_size" value="120.0"/>

--- a/jsk_fetch_robot/jsk_fetch_startup/package.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/package.xml
@@ -18,6 +18,7 @@
   <run_depend>fetch_driver_msgs</run_depend>
   <run_depend>rviz</run_depend>
   <run_depend>tf2_ros</run_depend>
+  <run_depend>voice_text</run_depend>
 
   <!-- for fetch_naviation -->
   <run_depend>amcl</run_depend>


### PR DESCRIPTION
- Installed voice text to fetch15.
- Added text to speech nodes to bringup launch file
- Moved `:speak` methods to robot interface (require https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/318 )
 