### PR TITLE
[WIP] [fetch] add interpolation in :angle-vector-raw

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -26,7 +26,17 @@
   (:state (&rest args)
    ":state calls with :wait-until-update by default, since Fetch publishes /joint_states from body and gripper at almost same frequency"
    (send-super* :state (if (member :wait-until-update args) args (append args (list :wait-until-update t)))))
-  (:angle-vector-raw (&rest args) (send-super* :angle-vector args))
+  (:angle-vector-raw (av &optional (tm 3000) &key (devide 4) &rest args)
+   (let (avs tms (minjerk (instance minjerk-interpolator :init)))
+     (send minjerk :reset
+           :position-list (list (send self :state :potentio-vector :wait-until-update t) av)
+           :time-list (list tm))
+     (send minjerk :start-interpolation)
+     (send minjerk :pass-time (/ tm devide))
+     (dotimes (i devide)
+       (setq avs (cons (send minjerk :pass-time (/ tm devide)) avs)))
+     (setq avs (reverse avs))
+     (send* self :angle-vector-sequence-raw avs (/ tm devide) args)))
   (:angle-vector-sequence-raw (&rest args) (send-super* :angle-vector-sequence args))
   (:angle-vector
    (av &optional (tm 3000) &rest args) ;; (ctype controller-type) (start-time 0) &rest args
@@ -271,10 +281,10 @@
   (unless (boundp '*fetch*) (fetch) (send *fetch* :reset-pose))
   (unless (ros::ok) (ros::roseus "fetch_eus_interface"))
   (unless (boundp '*ri*) (setq *ri* (instance fetch-interface :init)))
-  
+
   (ros::spin-once)
   (send *ri* :spin-once)
-  
+
   (send *fetch* :angle-vector (send *ri* :state :potentio-vector))
   (when create-viewer (objects (list *fetch*)))
   )

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -27,7 +27,7 @@
    ":state calls with :wait-until-update by default, since Fetch publishes /joint_states from body and gripper at almost same frequency"
    (send-super* :state (if (member :wait-until-update args) args (append args (list :wait-until-update t)))))
   (:angle-vector-raw (av &optional (tm 3000) &key (divide 4) &rest args)
-   (let (avs tms (minjerk (instance minjerk-interpolator :init)))
+   (let (avs (minjerk (instance minjerk-interpolator :init)))
      (send minjerk :reset
            :position-list (list (send self :state :potentio-vector :wait-until-update t) av)
            :time-list (list tm))

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -26,17 +26,17 @@
   (:state (&rest args)
    ":state calls with :wait-until-update by default, since Fetch publishes /joint_states from body and gripper at almost same frequency"
    (send-super* :state (if (member :wait-until-update args) args (append args (list :wait-until-update t)))))
-  (:angle-vector-raw (av &optional (tm 3000) &key (devide 4) &rest args)
+  (:angle-vector-raw (av &optional (tm 3000) &key (divide 4) &rest args)
    (let (avs tms (minjerk (instance minjerk-interpolator :init)))
      (send minjerk :reset
            :position-list (list (send self :state :potentio-vector :wait-until-update t) av)
            :time-list (list tm))
      (send minjerk :start-interpolation)
-     (send minjerk :pass-time (/ tm devide))
-     (dotimes (i devide)
-       (setq avs (cons (send minjerk :pass-time (/ tm devide)) avs)))
+     (send minjerk :pass-time (/ tm divide))
+     (dotimes (i divide)
+       (setq avs (cons (send minjerk :pass-time (/ tm divide)) avs)))
      (setq avs (reverse avs))
-     (send* self :angle-vector-sequence-raw avs (/ tm devide) args)))
+     (send* self :angle-vector-sequence-raw avs (/ tm divide) args)))
   (:angle-vector-sequence-raw (&rest args) (send-super* :angle-vector-sequence args))
   (:angle-vector
    (av &optional (tm 3000) &rest args) ;; (ctype controller-type) (start-time 0) &rest args

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -35,7 +35,8 @@
      (send minjerk :pass-time (/ tm 10))
      (dotimes (i 10)
        (setq avs (append avs (list (send minjerk :pass-time (/ tm 10))))))
-     (send* self :angle-vector-sequence-raw avs (make-list 10 :initial-element (/ tm 10)) args)))
+     (send* self :angle-vector-sequence-raw avs (make-list 10 :initial-element (/ tm 10)) args)
+     (send robot :angle-vector (car (last avs)))))
   (:angle-vector-sequence-raw (&rest args) (send-super* :angle-vector-sequence args))
   (:angle-vector
    (av &optional (tm 3000) &rest args) ;; (ctype controller-type) (start-time 0) &rest args
@@ -280,10 +281,10 @@
   (unless (boundp '*fetch*) (fetch) (send *fetch* :reset-pose))
   (unless (ros::ok) (ros::roseus "fetch_eus_interface"))
   (unless (boundp '*ri*) (setq *ri* (instance fetch-interface :init)))
-
+  
   (ros::spin-once)
   (send *ri* :spin-once)
-
+  
   (send *fetch* :angle-vector (send *ri* :state :potentio-vector))
   (when create-viewer (objects (list *fetch*)))
   )

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -26,17 +26,17 @@
   (:state (&rest args)
    ":state calls with :wait-until-update by default, since Fetch publishes /joint_states from body and gripper at almost same frequency"
    (send-super* :state (if (member :wait-until-update args) args (append args (list :wait-until-update t)))))
-  (:angle-vector-raw (av &optional (tm 3000) &key (divide 4) &rest args)
+  (:angle-vector-raw (av &optional (tm 3000) &rest args)
    (let (avs (minjerk (instance minjerk-interpolator :init)))
      (send minjerk :reset
            :position-list (list (send self :state :potentio-vector :wait-until-update t) av)
            :time-list (list tm))
      (send minjerk :start-interpolation)
-     (send minjerk :pass-time (/ tm divide))
-     (dotimes (i divide)
-       (setq avs (cons (send minjerk :pass-time (/ tm divide)) avs)))
+     (send minjerk :pass-time (/ tm 10))
+     (dotimes (i 10)
+       (setq avs (cons (send minjerk :pass-time (/ tm 10)) avs)))
      (setq avs (reverse avs))
-     (send* self :angle-vector-sequence-raw avs (/ tm divide) args)))
+     (send* self :angle-vector-sequence-raw avs (/ tm 10) args)))
   (:angle-vector-sequence-raw (&rest args) (send-super* :angle-vector-sequence args))
   (:angle-vector
    (av &optional (tm 3000) &rest args) ;; (ctype controller-type) (start-time 0) &rest args

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -34,9 +34,8 @@
      (send minjerk :start-interpolation)
      (send minjerk :pass-time (/ tm 10))
      (dotimes (i 10)
-       (setq avs (cons (send minjerk :pass-time (/ tm 10)) avs)))
-     (setq avs (reverse avs))
-     (send* self :angle-vector-sequence-raw avs (/ tm 10) args)))
+       (setq avs (append avs (list (send minjerk :pass-time (/ tm 10))))))
+     (send* self :angle-vector-sequence-raw avs (make-list 10 :initial-element (/ tm 10)) args)))
   (:angle-vector-sequence-raw (&rest args) (send-super* :angle-vector-sequence args))
   (:angle-vector
    (av &optional (tm 3000) &rest args) ;; (ctype controller-type) (start-time 0) &rest args


### PR DESCRIPTION
:angle-vector-rawの中で補間点を入れると#839 のような挙動を示さなくなった。

以下の部分で、補間点が少ないと良くないことが起こるらしい。
https://github.com/fetchrobotics/robot_controllers/blob/74970680716f8af29c5ff3e1e8a76ea1089640ff/robot_controllers/src/follow_joint_trajectory.cpp#L381