### PR TITLE
add :wait-interpolation in test

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -1,7 +1,7 @@
 (ros::roseus "fetch")
 
 (require "package://fetcheus/fetch-utils.l")
-(require "package://pr2eus/pr2-interface.l")
+(require "package://pr2eus/robot-interface.l")
 (require "package://pr2eus_moveit/euslisp/robot-moveit.l")
 
 (defclass fetch-interface

--- a/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
+++ b/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
@@ -41,11 +41,13 @@
     ;;
     (send *fetch* :reset-pose)
     (send *ri* :angle-vector (send *fetch* :angle-vector))
+    (send *ri* :wait-interpolation)
     (setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
     (assert (eps= (norm diff-av) 0.0 5.0) (format nil "diff-av ~A" diff-av))
 
     (send *fetch* :inverse-kinematics (make-coords :pos #f(800 0 1300)))
     (send *ri* :angle-vector (send *fetch* :angle-vector))
+    (send *ri* :wait-interpolation)
     (setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
     (assert (eps= (norm diff-av) 0.0 5.0) (format nil "diff-av ~A" diff-av))
     ))

--- a/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
+++ b/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
@@ -42,14 +42,14 @@
     (send *fetch* :reset-pose)
     (send *ri* :angle-vector (send *fetch* :angle-vector))
     (send *ri* :wait-interpolation)
-    (setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
-    (assert (eps= (norm diff-av) 0.0 5.0) (format nil "diff-av ~A" diff-av))
+    (setq diff-av (send *ri* :sub-angle-vector (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
+    (assert (eps= (norm diff-av) 0.0 10.0) (format nil "diff-av ~A" diff-av))
 
     (send *fetch* :inverse-kinematics (make-coords :pos #f(800 0 1300)))
     (send *ri* :angle-vector (send *fetch* :angle-vector))
     (send *ri* :wait-interpolation)
-    (setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
-    (assert (eps= (norm diff-av) 0.0 5.0) (format nil "diff-av ~A" diff-av))
+    (setq diff-av (send *ri* :sub-angle-vector (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
+    (assert (eps= (norm diff-av) 0.0 10.0) (format nil "diff-av ~A" diff-av))
     ))
 
 ;; https://github.com/jsk-ros-pkg/jsk_robot/pull/771/files


### PR DESCRIPTION
`(send *ri* :wait-interpolation)`がないと、
```
(setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
```
の`(send *ri* :state :potentio-vector)`が正しく更新されない気がします。