### PR TITLE
add interpolation in :angle-vector-raw

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -1,7 +1,7 @@
 (ros::roseus "fetch")
 
 (require "package://fetcheus/fetch-utils.l")
-(require "package://pr2eus/pr2-interface.l")
+(require "package://pr2eus/robot-interface.l")
 (require "package://pr2eus_moveit/euslisp/robot-moveit.l")
 
 (defclass fetch-interface

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -26,7 +26,36 @@
   (:state (&rest args)
    ":state calls with :wait-until-update by default, since Fetch publishes /joint_states from body and gripper at almost same frequency"
    (send-super* :state (if (member :wait-until-update args) args (append args (list :wait-until-update t)))))
-  (:angle-vector-raw (&rest args) (send-super* :angle-vector args))
+  (:check-continuous-joint-move-over-180 ;; can be removed if http//github.com/jsk-ros-pkg/jsk_pr2eus/pull/322 merged
+   (diff-av)
+   (let ((i 0) add-new-trajectory-point)
+     (dolist (j (send robot :joint-list))
+       ;; for continuous rotational joint
+       (when (and (> (- (send j :max-angle) (send j :min-angle)) 360)
+                  (> (abs (elt diff-av i)) 180))
+         (ros::ros-warn "continuous joint (~A) moves ~A degree, commanded joint differs from original trajectory to avoid unintentional 360 rotation" (send j :name) (elt diff-av i))
+         (setq add-new-trajectory-point t))
+       (incf i (send j :joint-dof)))
+     add-new-trajectory-point))
+  (:angle-vector-raw (av &optional (tm 3000) &rest args)
+   (let* ((prev-av (send self :state :potentio-vector :wait-until-update t))
+          (diff-av (v- av prev-av)))
+     (when (send self :check-continuous-joint-move-over-180 diff-av)
+       (let* (avs (minjerk (instance minjerk-interpolator :init))
+                  (scale-av (send self :sub-angle-vector av prev-av))
+                  dist div)
+         (setq dist (abs (geo::find-extream (coerce diff-av cons) #'abs #'>=)))
+         (setq div (round (/ dist 120.0)))
+         (send minjerk :reset
+               :position-list (list prev-av (v+ prev-av scale-av))
+               :time-list (list tm))
+         (send minjerk :start-interpolation)
+         (send minjerk :pass-time (/ tm div))
+         (dotimes (i div)
+           (setq avs (append avs (list (send minjerk :pass-time (/ tm div))))))
+         (send* self :angle-vector-sequence-raw avs (make-list div :initial-element (/ tm div)) args)
+         (return-from :angle-vector-raw (car (last avs)))))
+     (send-super* :angle-vector av tm args)))
   (:angle-vector-sequence-raw (&rest args) (send-super* :angle-vector-sequence args))
   (:angle-vector
    (av &optional (tm 3000) &rest args) ;; (ctype controller-type) (start-time 0) &rest args

--- a/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
+++ b/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
@@ -41,11 +41,13 @@
     ;;
     (send *fetch* :reset-pose)
     (send *ri* :angle-vector (send *fetch* :angle-vector))
+    (send *ri* :wait-interpolation)
     (setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
     (assert (eps= (norm diff-av) 0.0 5.0) (format nil "diff-av ~A" diff-av))
 
     (send *fetch* :inverse-kinematics (make-coords :pos #f(800 0 1300)))
     (send *ri* :angle-vector (send *fetch* :angle-vector))
+    (send *ri* :wait-interpolation)
     (setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
     (assert (eps= (norm diff-av) 0.0 5.0) (format nil "diff-av ~A" diff-av))
     ))

--- a/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
+++ b/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
@@ -39,17 +39,69 @@
   (let (diff-av)
     (setq *ri* (instance fetch-interface :init))
     ;;
+    (format t "check reset-pose")
     (send *fetch* :reset-pose)
+    (send *ri* :robot :reset-pose)
     (send *ri* :angle-vector (send *fetch* :angle-vector))
     (send *ri* :wait-interpolation)
+    ;; do not care 360 rotaiton
     (setq diff-av (send *ri* :sub-angle-vector (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
-    (assert (eps= (norm diff-av) 0.0 10.0) (format nil "diff-av ~A" diff-av))
+    (format t ":state ~A, :robot ~A, diff ~A, ~A~%" (send *ri* :robot :rarm :wrist-r :joint-angle) (send *fetch* :rarm :wrist-r :joint-angle)  (norm diff-av) (eps= (norm diff-av) 0.0 10.0))
+    (assert (eps= (norm diff-av) 0.0 10.0) (format nil ":reset-pose, diff-av ~A" diff-av))
 
+    (format t "check :ik #f(800 0 1300), do not care about 360 degree rotation")
     (send *fetch* :inverse-kinematics (make-coords :pos #f(800 0 1300)))
     (send *ri* :angle-vector (send *fetch* :angle-vector))
     (send *ri* :wait-interpolation)
+    ;; do not care 360 rotaiton
     (setq diff-av (send *ri* :sub-angle-vector (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
-    (assert (eps= (norm diff-av) 0.0 10.0) (format nil "diff-av ~A" diff-av))
+    (format t ":state ~A, :robot ~A, diff ~A, ~A~%" (send *ri* :robot :rarm :wrist-r :joint-angle) (send *fetch* :rarm :wrist-r :joint-angle)  (norm diff-av) (eps= (norm diff-av) 0.0 10.0))
+    (assert (eps= (norm diff-av) 0.0 10.0) (format nil ":ik 800 0 1300, diff-av ~A" diff-av))
+
+    ;; do care 360 rotation
+    (format t "check :init-pose")
+    (send *fetch* :init-pose) ;; reset
+    (send *ri* :robot :init-pose)
+    (send *ri* :angle-vector (send *fetch* :angle-vector))
+    (send *ri* :wait-interpolation)
+    (setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
+    (format t ":state ~A, :robot ~A, diff ~A, ~A~%" (send *ri* :robot :rarm :wrist-r :joint-angle) (send *fetch* :rarm :wrist-r :joint-angle)  (norm diff-av) (eps= (norm diff-av) 0.0 10.0))
+    (assert (eps= (norm diff-av) 0.0 10.0) (format nil ":init-pose, diff-av ~A" diff-av))
+
+    ;; 150 is 150
+    (format t "check :joint-angle 150, this should goes to 150")
+    (send *fetch* :rarm :wrist-r :joint-angle 150)
+    (send *ri* :angle-vector (send *fetch* :angle-vector))
+    (send *ri* :wait-interpolation)
+    (setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
+    (format t ":state ~A, :robot ~A, diff ~A, ~A~%" (send *ri* :robot :rarm :wrist-r :joint-angle) (send *fetch* :rarm :wrist-r :joint-angle)  (norm diff-av) (eps= (norm diff-av) 0.0 10.0))
+    (assert (eps= (norm diff-av) 0.0 10.0) (format nil ":joint-angle 150, diff-av ~A" diff-av))
+
+    ;; from 150 to -150, robot moves to 210 by :angle-vector
+    (format t "check :joint-angle -150, this should goes to 210, by selecting minimum motion")
+    (send *fetch* :rarm :wrist-r :joint-angle -150)
+    (send *ri* :angle-vector (send *fetch* :angle-vector))
+    (send *ri* :wait-interpolation)
+    (setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
+    (format t ":state ~A, :robot ~A, diff ~A, ~A~%" (send *ri* :robot :rarm :wrist-r :joint-angle) (send *fetch* :rarm :wrist-r :joint-angle)  (norm diff-av) (eps= (norm diff-av) 0.0 10.0))
+    (assert (null (eps= (norm diff-av) 0.0 10.0)) (format nil ":joint-angle -150, diff-av ~A" diff-av))
+
+    (format t "check :joint-angle-sequence 150 0 -150, this should goes to -150")
+    ;; to send to -150, use :angle-vector-sequence
+    (send *ri* :angle-vector-sequence (list
+                                       (progn
+                                         (send *fetch* :rarm :wrist-r :joint-angle  150)
+                                         (send *fetch* :angle-vector))
+                                       (progn
+                                         (send *fetch* :rarm :wrist-r :joint-angle   0)
+                                         (send *fetch* :angle-vector))
+                                       (progn
+                                         (send *fetch* :rarm :wrist-r :joint-angle -150)
+                                         (send *fetch* :angle-vector))))
+    (send *ri* :wait-interpolation)
+    (setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
+    (format t ":state ~A, :robot ~A, diff ~A, ~A~%" (send *ri* :robot :rarm :wrist-r :joint-angle) (send *fetch* :rarm :wrist-r :joint-angle)  (norm diff-av) (eps= (norm diff-av) 0.0 10.0))
+    (assert (eps= (norm diff-av) 0.0 10.0) (format nil ":angle-vector-sequence, diff-av ~A" diff-av))
     ))
 
 ;; https://github.com/jsk-ros-pkg/jsk_robot/pull/771/files

--- a/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
+++ b/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
@@ -42,14 +42,14 @@
     (send *fetch* :reset-pose)
     (send *ri* :angle-vector (send *fetch* :angle-vector))
     (send *ri* :wait-interpolation)
-    (setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
-    (assert (eps= (norm diff-av) 0.0 5.0) (format nil "diff-av ~A" diff-av))
+    (setq diff-av (send *ri* :sub-angle-vector (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
+    (assert (eps= (norm diff-av) 0.0 10.0) (format nil "diff-av ~A" diff-av))
 
     (send *fetch* :inverse-kinematics (make-coords :pos #f(800 0 1300)))
     (send *ri* :angle-vector (send *fetch* :angle-vector))
     (send *ri* :wait-interpolation)
-    (setq diff-av (v- (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
-    (assert (eps= (norm diff-av) 0.0 5.0) (format nil "diff-av ~A" diff-av))
+    (setq diff-av (send *ri* :sub-angle-vector (send *ri* :state :potentio-vector) (send *fetch* :angle-vector)))
+    (assert (eps= (norm diff-av) 0.0 10.0) (format nil "diff-av ~A" diff-av))
     ))
 
 ;; https://github.com/jsk-ros-pkg/jsk_robot/pull/771/files


### PR DESCRIPTION
Fixes https://github.com/jsk-ros-pkg/jsk_robot/issues/839

rewrited versoin of https://github.com/jsk-ros-pkg/jsk_robot/pull/841

fetch interface have problems on trajectory interpolation after cancel , (maybe) when the original trajectory goes over 180 degree ( https://github.com/fetchrobotics/robot_controllers/issues/33 )

This PR fixes by sending interpolated angle-vector-sequence within :angle-vector-raw