### PR TITLE
Add use-base key in fetch-utils inverse-kinematics

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch-utils.l
+++ b/jsk_fetch_robot/fetcheus/fetch-utils.l
@@ -5,14 +5,57 @@
 
 (defmethod fetch-robot
   (:inverse-kinematics
-   (target-coords &rest args &key link-list move-arm (use-torso t) move-target &allow-other-keys)
-   (unless move-arm (setq move-arm :rarm))
-   (unless move-target (setq move-target (send self :rarm :end-coords)))
-   (unless link-list
-     (setq link-list (send self :link-list (send move-target :parent)
-                           (unless use-torso (car (send self :rarm))))))
-   (send-super* :inverse-kinematics target-coords
-                :move-target move-target
-                :link-list link-list
-                args)
-   ))
+   (target-coords &rest args &key
+		  link-list move-arm (use-torso t) move-target
+                  (use-base nil) (start-coords (send self :copy-worldcoords))
+		  (base-range (list :min #f(-30 -30 -30)
+				    :max #f( 30  30  30)))
+		  additional-weight-list
+		  &allow-other-keys)
+  (let (diff-pos-rot)
+    (unless move-arm (setq move-arm :rarm))
+    (unless move-target (setq move-target (send self :rarm :end-coords)))
+    (unless link-list
+      (setq link-list (send self :link-list (send move-target :parent)
+			    (unless use-torso (car (send self :rarm))))))
+
+    (cond
+      (use-base
+       (setq diff-pos-rot
+             (concatenate float-vector
+                          (send start-coords :difference-position self)
+                          (send start-coords :difference-rotation self)))
+       (send self :move-to start-coords :world)
+       (with-append-root-joint
+	   (ll self link-list
+	       :joint-class omniwheel-joint
+	       :joint-args base-range)
+	 (send (caar ll) :joint :joint-angle
+	       (float-vector (elt diff-pos-rot 0)
+			     (elt diff-pos-rot 1)
+			     (rad2deg (elt diff-pos-rot 5))))
+	 (send-super* :inverse-kinematics target-coords
+		      :additional-weight-list
+		      (append
+		       (list
+			(list (send self :torso_lift_joint :child-link)
+			      (if (numberp use-torso) use-torso 0.005))
+			(list (car (send self :links))
+			      (if (eq use-base t) 0.1 use-base))
+			)
+		       additional-weight-list
+		       )
+		      :link-list ll ;; link-list
+		      :move-target move-target
+		      args)))
+      (t
+       (send-super* :inverse-kinematics target-coords
+                    :additional-weight-list
+                    (list
+                     (list (send self :torso_lift_joint :child-link)
+                           (if (numberp use-torso) use-torso 0.005))
+                     )
+                    :link-list link-list
+                    :move-target move-target
+                    args))))
+    ))


### PR DESCRIPTION
Don't know if should be useful or not, but tried adding :use-base option for fetch's :inverse-kinematics, according to PR2's example [pr2-utils](https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/master/pr2eus/pr2-utils.l/#L106-L151).

Code can be verified with
```
(send *fetch* :inverse-kinematics (make-coords :pos #f(1150 0 786)) :use-base t)
```
or
```
(send *fetch* :inverse-kinematics (make-coords :pos #f(1200 0 786)) :use-base t :base-range (list :min #f(0 0 0) :max #f(100 100 0)))
```