### PR TITLE
[jsk_fetch_robot] use fetch_moveit_config 0.7.13

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall
@@ -9,3 +9,9 @@
 - git:
     local-name: FA-I-sensor
     uri: https://github.com/RoboticMaterials/FA-I-sensor.git
+# when fetch_moveit_config 0.7.13 is released in apt, lines below can be removed.
+# please check http://packages.fetchrobotics.com/ros/ubuntu/pool/main/r/ros-indigo-fetch-moveit-config/
+- tar:
+    local-name: fetch_ros/fetch_moveit_config
+    uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_moveit_config/0.7.13-0.tar.gz
+    version: fetch_ros-release-release-indigo-fetch_moveit_config-0.7.13-0


### PR DESCRIPTION
we need PR: https://github.com/fetchrobotics/fetch_ros/pull/66
`ApplyPlanningScene` is now required for `pr2eus_moveit`.