### PR TITLE
Add :gripper method to fetch-interface

### DIFF
--- a/jsk_fetch_robot/fetcheus/CMakeLists.txt
+++ b/jsk_fetch_robot/fetcheus/CMakeLists.txt
@@ -8,10 +8,8 @@ if($ENV{ROS_DISTRO} STREQUAL "hydro")
 endif()
 
 find_package(catkin REQUIRED
-    collada_urdf
-    euscollada
     fetch_description
-    roseus
+    roseus # required in indigo
 )
 
 catkin_package()

--- a/jsk_fetch_robot/fetcheus/CMakeLists.txt
+++ b/jsk_fetch_robot/fetcheus/CMakeLists.txt
@@ -7,7 +7,12 @@ if($ENV{ROS_DISTRO} STREQUAL "hydro")
   return()
 endif()
 
-find_package(catkin REQUIRED fetch_description)
+find_package(catkin REQUIRED
+    collada_urdf
+    euscollada
+    fetch_description
+    roseus
+)
 
 catkin_package()
 

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -3,7 +3,8 @@
 (require "package://fetcheus/fetch-utils.l")
 (require "package://pr2eus/robot-interface.l")
 (require "package://pr2eus_moveit/euslisp/robot-moveit.l")
-(ros::roseus-add-msgs "fetch_driver_msgs")
+
+(ros::load-ros-manifest "fetcheus")
 
 (defclass fetch-interface
   :super robot-move-base-interface

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -3,6 +3,7 @@
 (require "package://fetcheus/fetch-utils.l")
 (require "package://pr2eus/robot-interface.l")
 (require "package://pr2eus_moveit/euslisp/robot-moveit.l")
+(ros::roseus-add-msgs "fetch_driver_msgs")
 
 (defclass fetch-interface
   :super robot-move-base-interface
@@ -15,6 +16,7 @@
      (send self :add-controller :arm-controller)
      (send self :add-controller :torso-controller)
      (send self :add-controller :head-controller)
+     (ros::subscribe "gripper_state" fetch_driver_msgs::GripperState #'send self :fetch-gripper-state-callback :groupname groupname)
      (setq gripper-action
            (instance ros::simple-action-client :init
                      "/gripper_controller/gripper_action"
@@ -165,6 +167,17 @@
       (when wait (send gripper-action :wait-for-result))
       (setq result (send gripper-action :get-result))
       result))
+  (:fetch-gripper-state-callback
+    (msg)
+    (let ((msg (car (send msg :joints))))
+      (dolist (slot '((position . 2) (velocity . 2) (effort . 1)))
+	(send self :set-robot-state1 (intern (format nil "GRIPPER-~A" (string (car slot))) *keyword-package*) (* (cdr slot) (send msg (intern (string (car slot)) *keyword-package*)))))))
+  (:gripper (key)
+   "get information about gripper
+Arguments:
+ - key (:position :velocity :effort)
+Example: (send self :gripper :position) => 0.00"
+   (send-super :state (intern (format nil "GRIPPER-~A" (string key)) *keyword-package*)))
   ;;
   (:speak (text &rest args)
     (let ()

--- a/jsk_fetch_robot/fetcheus/package.xml
+++ b/jsk_fetch_robot/fetcheus/package.xml
@@ -14,10 +14,12 @@
   <build_depend>pr2eus</build_depend> <!-- for robot interface -->
   <build_depend>pr2eus_moveit</build_depend> <!-- for robot interface -->
   <build_depend>fetch_description</build_depend>
+  <build_depend>fetch_driver_msgs</build_depend>
 
   <run_depend>pr2eus</run_depend> <!-- for robot interface -->
   <run_depend>pr2eus_moveit</run_depend> <!-- for robot interface -->
   <run_depend>fetch_description</run_depend>
+  <run_depend>fetch_driver_msgs</run_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>fetch_gazebo</test_depend>


### PR DESCRIPTION
[robot-interface.l](https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/master/pr2eus/robot-interface.l#L1038-L1042) states clearly that `:gripper` method should be defined in child classes, but `fetch-interface` had none defined.

Wrote based on `pr2-interface.l`, with the difference that it doesn't take `arm` argument, since fetch only has `:rarm`.

**Known problem:** fetch's gazebo simulation does not support /gripper_state topic. Currently inquiring fetch-robotics about this.

@708yamaguchi 