### PR TITLE
[jsk_naoqi_robot] split README because the contents are large

### DIFF
--- a/jsk_naoqi_robot/README.md
+++ b/jsk_naoqi_robot/README.md
@@ -1,110 +1,29 @@
-jsk_pepper_robot
-================
+jsk_naoqi_robot
+===============
 
-setup environment
------------------
-% First, you need to install ros. For ros indigo, please refer to install guide like [here](http://wiki.ros.org/indigo/Installation/Ubuntu)
+JSK original ROS package for NAO and Pepper.
+The package name comes from Naoqi OS they use.
 
-```
-mkdir -p catkin_ws/src
-cd  catkin_ws
-wstool init src
-wstool merge -t src https://raw.githubusercontent.com/jsk-ros-pkg/jsk_robot/master/jsk_naoqi_robot/pepper.rosinstall
-wstool update -t src
-source /opt/ros/indigo/setup.bash
-rosdep install -y -r --from-paths src --ignore-src
-catkin build
-source devel/setup.bash
-```
-% Make sure that you have already installed the ``Python NAOqi SDK`` in your computer. If not, you can download it from [here](https://community.aldebaran.com/en/resources/software). Be sure to sign in and register a developer program. After downloading the file, unzip and rename it to ``pynaoqi``, then put it under your home folder. And then, please add python path to your ``.bashrc`` like ``export PYTHONPATH=$HOME/pynaoqi/<your naoqi sdk version>:$PYTHONPATH``. 
- 
-You need to set NAO_IP and ROS_IP environment variable to launch `jsk_pepper_startup.launch`
-```
-source ~/catkin_ws/devel/setup.bash
-export NAO_IP="olive.jsk.imi.i.u-tokyo.ac.jp" % OR IP address like "133.11.216.xxx"
-export ROS_IP="133.11.216.yyy" % OR run rossetip command to set ROS_IP
-```
+NAO
+---
+<dl>
+ <dt>jsk_nao_startup</dt> 
+ <dd>contains ROS launch files for NAO</dd>
 
-% Temporary caution
-You have to refer to [this PR](https://github.com/ros-naoqi/pepper_robot/pull/40) in order to execute ```pepper_full.launch```.
+ <dt>naoeus</dt>
+ <dd>package for controlling NAO via roseus</dd>
+</dl>
 
-Install pepper mesh files with manual approval of license
-```
-sudo apt-get install ros-indigo-pepper-meshes
-```
+Pepper
+------
 
-running demo
-------------
-```
-roslaunch jsk_pepper_startup jsk_pepper_startup.launch network_interface:=<YOUR_NETWORK_INTERFACE (ex. eth0)>
-```
-```
-roslaunch nao_apps speech.launch nao_ip:=YOUR_PEPPER_IP
-roslaunch nao_interaction_launchers nao_vision_interface.launch nao_ip:=YOUR_PEPPER_IP
-roslaunch nao_apps behaviors.launch nao_ip:=YOUR_PEPPER_IP
-rosrun jsk_pepper_startup sample.l
-$ (demo1) ;; Pepper may speak twice. (This will be fixed as soon as possible.)
-```
+<dl>
+ <dt>jsk_pepper_startup</dt>
+ <dd>contains ROS launch files for Pepper</dd>
 
-for developers
---------------
-add following source code for debugging.
-```
-cd  catkin_ws/src
-wstool set pepper_robot --git http://github.com/ros-naoqi/pepper_robot
-```
+ <dt>peppereus</dt>
+ <dd>package for controlling Pepper via roseus</dd>
 
-trouble shooting
-----------------
-If you failed in launching jsk_pepper_startup.launch,
-please check below.
-
-1. Please try deleting all the terminals you created before, and even rebooting your PC.
-If another terminal of ```roscore``` has been left and the connected network has changed recently, connecting your PC and pepper may fail.
-
-2. If the log shows below (*), please reboot pepper.
-(*)
-```
-front_cameraCamera Handle is empty - cannot retrieve image
-front_cameraMight be a NAOqi problem. Try to restart the ALVideoDevice.
-```
-
-peppereus
-=========
-
-Here is a list of joints when accessing Pepper.
-ex:
-```
-(send *pepper* :reset-pose)
-=> #f(2.0 -2.0 -5.0 85.0 10.0 -70.0 -20.0 -40.0 85.0 -10.0 70.0 20.0 40.0 0.0 0.0)
-       0    1    2   3    4     5     6     7    8     9    10   11   12   13  14
-```
-```
-0: :knee-p
-1: :hip-r
-2: :hip-p
-3: :larm :shoulder-p
-4: :larm :shoulder-r
-5: :larm :elbow-y
-6: :larm :elbow-p
-7: :larm :wrist-y
-8: :rarm :shoulder-p
-9: :rarm :shoulder-r
-10: :rarm :elbow-y
-11: :rarm :elbow-p
-12: :rarm :wrist-y
-13: :head :neck-y
-14: :head :neck-p
-```
-
-naoeus
-======
-
-how to make nao model on euslisp
---------------------------------
-
-Install nao mesh files from deb with manual approval of license
-```
-sudo apt-get install ros-<ros version>-nao-meshes 
-catkin build
-```
+ <dt>jsk_201504_miraikan</dt>
+ <dd>demo package which Pepper introduces themselves</dd>
+</dl>

--- a/jsk_naoqi_robot/jsk_pepper_startup/README.md
+++ b/jsk_naoqi_robot/jsk_pepper_startup/README.md
@@ -1,0 +1,103 @@
+jsk_pepper_startup
+==================
+
+What's this?
+------------
+contains JSK's launch file for startup Pepper with ROS
+
+Setup environment
+-----------------
+
+% First, you need to install ros. For ros indigo, please refer to install guide like [here](http://wiki.ros.org/indigo/Installation/Ubuntu)
+
+1. Install ``Python NAOqi SDK``
+You can download it from [here](https://community.aldebaran.com/en/resources/software).
+Please unzip the downloaded file.
+Please create ``pynaoqi`` folder in your home directory.
+Then put the file under your ``pynaoqi`` folder.
+
+2. Export environment variables in your ``.bashrc``
+
+```
+export PYTHONPATH=$HOME/pynaoqi/<your Python SDK package name>:$PYTHONPATH
+export NAO_IP="olive.jsk.imi.i.u-tokyo.ac.jp" % OR IP address like "133.11.216.xxx"
+export ROS_IP="133.11.216.yyy" % OR run rossetip command to set ROS_IP
+```
+
+% NAO_IP is IP address of Pepper. Pepper tells you their address when pushing their belly button. 
+
+3. Install ROS packages for Pepper
+
+```
+mkdir -p catkin_ws/src
+cd  catkin_ws
+wstool init src
+wstool merge -t src https://raw.githubusercontent.com/jsk-ros-pkg/jsk_robot/master/jsk_naoqi_robot/pepper.rosinstall
+wstool update -t src
+source /opt/ros/indigo/setup.bash
+rosdep install -y -r --from-paths src --ignore-src
+catkin build
+source devel/setup.bash
+```
+% In addition, please install ```ros-indigo-jsk-tools``` to use ```rossetip``` command.
+Otherwise, please write the line below in your ```.bashrc```.
+
+```
+export ROS_IP="133.11.216.yyy"
+```
+
+4. (optional) For developers
+
+Please add following source code for debugging.
+
+```
+cd  catkin_ws/src
+wstool set pepper_robot --git http://github.com/ros-naoqi/pepper_robot
+```
+
+Running startup program
+-----------------------
+
+```
+rossetip
+roslaunch jsk_pepper_startup jsk_pepper_startup.launch network_interface:=<your network interaface (ex. eth0)>
+```
+
+% Temporarly, you have to refer to [this PR](https://github.com/ros-naoqi/pepper_robot/pull/40) in order to execute ```pepper_full.launch```.
+
+% In order to confirm if ROS-Pepper is booting, please check with rviz.
+
+```
+roscd pepper_bringup/config
+rosrun rviz rviz -d pepper.rviz
+```
+
+Control Pepper via roseus
+-------------------------
+
+Please refer to [README here](https://github.com/jsk-ros-pkg/jsk_robot/tree/master/jsk_naoqi_robot/peppereus).
+
+
+Sample demo
+-----------
+
+```
+roslaunch nao_apps speech.launch nao_ip:=YOUR_PEPPER_IP
+roslaunch nao_interaction_launchers nao_vision_interface.launch nao_ip:=YOUR_PEPPER_IP
+roslaunch nao_apps behaviors.launch nao_ip:=YOUR_PEPPER_IP
+rosrun jsk_pepper_startup sample.l
+$ (demo1) ;; Pepper may speak twice. (This will be fixed as soon as possible.)
+```
+
+If you failed in launching jsk_pepper_startup.launch
+----------------------------------------------------
+
+1. Please try deleting all the terminals you created before, and even rebooting your PC.
+If another terminal of ```roscore``` has been left and the connected network has changed recently, connecting your PC and pepper may fail.
+
+2. If your terminal log looks like below, please reboot pepper.
+
+```
+front_cameraCamera Handle is empty - cannot retrieve image
+front_cameraMight be a NAOqi problem. Try to restart the ALVideoDevice.
+```

--- a/jsk_naoqi_robot/naoeus/README.md
+++ b/jsk_naoqi_robot/naoeus/README.md
@@ -1,0 +1,11 @@
+naoeus
+======
+
+How to make nao model on euslisp
+--------------------------------
+
+Install nao mesh files from deb with manual approval of license
+```
+sudo apt-get install ros-<ros version>-nao-meshes 
+catkin build
+```

--- a/jsk_naoqi_robot/naoqieus/README.md
+++ b/jsk_naoqi_robot/naoqieus/README.md
@@ -1,0 +1,6 @@
+naoqieus
+=========
+
+This is a common package for naoeus and peppereus.
+This is used when controlling NAO and Pepper via roseus. 
+Basic methods for NAO and Pepper are stored. 

--- a/jsk_naoqi_robot/peppereus/README.md
+++ b/jsk_naoqi_robot/peppereus/README.md
@@ -1,0 +1,55 @@
+peppereus
+=========
+
+How to make pepper model on euslisp
+-----------------------------------
+
+Install pepper mesh files with manual approval of license
+```
+sudo apt-get install ros-<ros version>-pepper-meshes
+catkin build
+```
+
+Control Pepper via roseus
+-------------------------
+
+```
+(load "package://peppereus/pepper-interface.l") ;; load modules
+(setq *pepper* (pepper))          ;; creat a robot model
+(setq *ri* (instance pepper-interface :init)) ;; make connection to the real robot
+(objects (list *pepper*))        ;; display the robot model
+```
+or
+
+```
+(load "package://peppereus/pepper-interface.l") ;; load modules
+(pepper-init)
+```
+
+Joints of Pepper
+----------------
+
+Here is a list of joints when accessing Pepper.
+ex:
+```
+(send *pepper* :reset-pose)
+=> #f(2.0 -2.0 -5.0 85.0 10.0 -70.0 -20.0 -40.0 85.0 -10.0 70.0 20.0 40.0 0.0 0.0)
+       0    1    2   3    4     5     6     7    8     9    10   11   12   13  14
+```
+```
+0: :knee-p
+1: :hip-r
+2: :hip-p
+3: :larm :shoulder-p
+4: :larm :shoulder-r
+5: :larm :elbow-y
+6: :larm :elbow-p
+7: :larm :wrist-y
+8: :rarm :shoulder-p
+9: :rarm :shoulder-r
+10: :rarm :elbow-y
+11: :rarm :elbow-p
+12: :rarm :wrist-y
+13: :head :neck-y
+14: :head :neck-p
+```


### PR DESCRIPTION
I split the contents of README under jsk_naoqi_robot because they are hard to read it.
In addition, I added the explanation of package configuration because the relationship of each package seems to be complicated.

What I did is below:
1. split README of jsk_naoqi_robot to
- naoeus
- jsk_pepper_startup
- peppereus

2. added README of naoqieus

3. modified README of jsk_naoqi_robot (wrote package configurration)