### PR TITLE
Action logging with throttling topics

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
@@ -26,7 +26,7 @@
     <arg name="save_joint_states" value="true" />
     <arg name="save_base_trajectory" value="true" />
     <arg name="save_object_detection" value="false" />
-    <arg name="save_action" value="false" />
+    <arg name="save_action" value="true" />
     <arg name="camera_ns" value="head_camera" />
     <arg name="sensor_frame_id" value="head_camera_rgb_optical_frame" />
     <arg name="enable_monitor" value="false" />
@@ -44,13 +44,26 @@
   </rosparam>
 
   <rosparam ns="lifelog/action_logger">
+    max_rate: 2.0
     white_list:
       type:
       - control_msgs/FollowJointTrajectoryActionResult
       - control_msgs/FollowJointTrajectoryActionGoal
       - control_msgs/FollowJointTrajectoryActionFeedback
+      - control_msgs/PointHeadActionResult
+      - control_msgs/PointHeadActionGoal
+      - control_msgs/PointHeadActionFeedback
       - control_msgs/GripperCommandActionResult
       - control_msgs/GripperCommandActionGoal
       - control_msgs/GripperCommandActionFeedback
+      - fetch_auto_dock_msgs/DockActionFeedback
+      - fetch_auto_dock_msgs/DockActionGoal
+      - fetch_auto_dock_msgs/DockActionResult
+      - fetch_auto_dock_msgs/UndockActionFeedback
+      - fetch_auto_dock_msgs/UndockActionGoal
+      - fetch_auto_dock_msgs/UndockActionResult
+      - sound_play/SoundRequestActionFeedback
+      - sound_play/SoundRequestActionGoal
+      - sound_play/SoundRequestActionResult
   </rosparam>
 </launch>

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/db_client.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/db_client.launch
@@ -48,7 +48,6 @@
       - pr2_controllers_msgs/Pr2GripperCommandActionFeedback
       - pr2_controllers_msgs/Pr2GripperCommandActionGoal
       - pr2_controllers_msgs/Pr2GripperCommandActionResult
-      - sound_play/SoundRequestActionFeedback
       - sound_play/SoundRequestActionResult
       - sound_play/SoundRequestActionGoal
   </rosparam>

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/db_client.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/db_client.launch
@@ -15,7 +15,7 @@
     <arg name="save_joint_states" value="true" />
     <arg name="save_base_trajectory" value="true" />
     <arg name="save_object_detection" value="false" />
-    <arg name="save_action" value="false" />
+    <arg name="save_action" value="true" />
     <arg name="enable_monitor" value="false" />
     <arg name="log_rate" value="1.0" />
     <arg name="localhost" value="false" />
@@ -34,23 +34,23 @@
   </rosparam>
 
   <rosparam ns="lifelog/action_logger">
-    black_list:
+    white_list:
       type:
-      - pr2_controllers_msgs/JointTrajectoryActionGoal
-      - pr2_controllers_msgs/JointTrajectoryActionResult
-      - pr2_controllers_msgs/JointTrajectoryActionFeedback
+      - control_msgs/FollowJointTrajectoryActionFeedback
+      - control_msgs/FollowJointTrajectoryActionGoal
+      - control_msgs/FollowJointTrajectoryActionResult
+      - pr2_common_action_msgs/TuckArmsActionFeedback
+      - pr2_common_action_msgs/TuckArmsActionGoal
+      - pr2_common_action_msgs/TuckArmsActionResult
+      - pr2_controllers_msgs/PointHeadActionFeedback
       - pr2_controllers_msgs/PointHeadActionGoal
       - pr2_controllers_msgs/PointHeadActionResult
-      - pr2_controllers_msgs/PointHeadActionFeedback
-      - pr2_controllers_msgs/SingleJointPositionActionGoal
-      - pr2_controllers_msgs/SingleJointPositionActionResult
-      - pr2_controllers_msgs/SingleJointPositionActionFeedback
-      - control_msgs/SingleJointPositionActionGoal
-      - control_msgs/SingleJointPositionActionResult
-      - control_msgs/SingleJointPositionActionFeedback
-      - tf2_msgs/LookupTransformActionGoal
-      - tf2_msgs/LookupTransformActionResult
-      - tf2_msgs/LookupTransformActionFeedback
+      - pr2_controllers_msgs/Pr2GripperCommandActionFeedback
+      - pr2_controllers_msgs/Pr2GripperCommandActionGoal
+      - pr2_controllers_msgs/Pr2GripperCommandActionResult
+      - sound_play/SoundRequestActionFeedback
+      - sound_play/SoundRequestActionResult
+      - sound_play/SoundRequestActionGoal
   </rosparam>
 
   <!-- tweeting robot warning data and etc. -->

--- a/jsk_robot_common/jsk_robot_startup/lifelog/action_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/action_logger.py
@@ -3,13 +3,6 @@
 # Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
 #
 # This script stores actionlib goals, results and feedbacks by MongoDB
-# And store the current robot joints when recieve result.
-#
-# table configuration is bottom of this script
-#
-
-# parameters:
-#    joint_tolerance: store the past joint_states (sec)
 
 import rospy
 from jsk_robot_startup.lifelog import ActionLogger

--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -57,7 +57,9 @@
             respawn="$(arg respawn)">
         <remap from="~input" to="/$(arg camera_ns)/$(arg rgb_ns)/$(arg camera_info_topic)" />
         <remap from="~output" to="rgb/$(arg camera_info_topic)" />
-        <param name="update_rate" value="$(arg log_rate)"/>
+        <rosparam subst_value="true">
+          update_rate: $(arg log_rate)
+        </rosparam>
       </node>
       <node name="throttle_rgb"
             pkg="nodelet" type="nodelet"
@@ -66,7 +68,9 @@
             respawn="$(arg respawn)">
         <remap from="~input" to="/$(arg camera_ns)/$(arg rgb_ns)/$(arg rgb_topic)/compressed"/>
         <remap from="~output" to="rgb/$(arg rgb_topic)/compressed" />
-        <param name="update_rate" value="$(arg log_rate)" />
+        <rosparam subst_value="true">
+          update_rate: $(arg log_rate)
+        </rosparam>
       </node>
 
       <!-- logger -->
@@ -103,7 +107,9 @@
             respawn="$(arg respawn)">
         <remap from="~input" to="/$(arg camera_ns)/$(arg depth_ns)/$(arg camera_info_topic)" />
         <remap from="~output" to="depth/camera_info" />
-        <param name="update_rate" value="$(arg log_rate)"/>
+        <rosparam subst_value="true">
+          update_rate: $(arg log_rate)
+        </rosparam>
       </node>
       <node name="throttle_depth"
             pkg="nodelet" type="nodelet"
@@ -112,7 +118,9 @@
             respawn="$(arg respawn)">
         <remap from="~input" to="/$(arg camera_ns)/$(arg depth_ns)/$(arg depth_topic)/compressedDepth"/>
         <remap from="~output" to="depth/$(arg depth_topic)/compressedDepth" />
-        <param name="update_rate" value="$(arg log_rate)" />
+        <rosparam subst_value="true">
+          update_rate: $(arg log_rate)
+        </rosparam>
       </node>
 
       <!-- logger -->
@@ -147,7 +155,7 @@
           respawn="$(arg respawn)"
           if="$(arg save_tf)">
       <rosparam subst_value="true">
-        log_rate: $(arg log_rate)
+        update_rate: $(arg log_rate)
       </rosparam>
     </node>
 
@@ -204,9 +212,11 @@
           pkg="jsk_robot_startup" type="base_trajectory_logger.py"
           machine="$(arg machine)"
           respawn="$(arg respawn)">
-      <param name="map_frame" value="$(arg map_frame_id)"/>
-      <param name="robot_frame" value="$(arg base_frame_id)"/>
-      <param name="update_cycle" value="$(arg log_rate)" />
+      <rosparam subst_value="true">
+        update_rate: $(arg log_rate)
+        map_frame: $(arg map_frame_id)
+        robot_frame: $(arg base_frame_id)
+      </rosparam>
     </node>
 
     <!-- object detection logger -->
@@ -215,8 +225,10 @@
           pkg="jsk_robot_startup" type="object_detection_logger.py"
           machine="$(arg machine)"
           respawn="$(arg respawn)">
-      <param name="map_frame" value="$(arg map_frame_id)"/>
-      <param name="robot_frame" value="$(arg base_frame_id)"/>
+      <rosparam subst_value="true">
+        map_frame: $(arg map_frame_id)
+        robot_frame: $(arg base_frame_id)
+      </rosparam>
     </node>
 
     <!-- action logger -->

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/action_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/action_logger.py
@@ -3,21 +3,15 @@
 # Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
 #
 # This script stores actionlib goals, results and feedbacks by MongoDB
-# And store the current robot joints when recieve result.
-#
-# table configuration is bottom of this script
 #
 
-# parameters:
-#    joint_tolerance: store the past joint_states (sec)
-
+from collections import defaultdict
 import re
 import rospy
 
 import std_msgs.msg
 import actionlib_msgs.msg
 from actionlib_msgs.msg import GoalID, GoalStatus
-from sensor_msgs.msg import JointState
 
 from logger_base import LoggerBase
 
@@ -31,15 +25,14 @@ class ActionLogger(LoggerBase):
         LoggerBase.__init__(self)
 
         self.queue_size = rospy.get_param("~queue_size", 30)
-        self.action_regex = re.compile(".*Action(Result|Goal|Cancel)$")
-        self.joint_tolerance = 1.0
-        self.joint_states = []
-        self.joint_states_inserted = [] # list of time stamp
-        self.joint_sub = rospy.Subscriber('/joint_states', JointState, self.__joint_states_cb)
+        self.action_regex = re.compile(".*Action(Result|Goal|Feedback)$")
 
-        self.__load_params()
+        self.max_rate = rospy.get_param("~max_rate", 3.0)
+        self.last_inserted_time = defaultdict(rospy.Time)
 
-    def __load_params(self):
+        self.load_params()
+
+    def load_params(self):
         try:
             self.action_name_white_list = rospy.get_param('~white_list')['name']
             rospy.loginfo("whitelist_name: %s", self.action_name_white_list)
@@ -62,77 +55,58 @@ class ActionLogger(LoggerBase):
             self.action_type_black_list = None
 
     # callback functions
-    def __action_goal_cb(self, topic, type_name, msg):
-        self.__insert_action_goal(topic, type_name, msg)
+    def _action_goal_cb(self, topic, type_name, msg):
+        self._insert(topic, type_name, msg, True)
 
-    def __action_result_cb(self, topic, type_name, msg):
-        self.__insert_action_result(topic, type_name, msg)
-        key_func = (lambda js: abs(js.header.stamp-msg.header.stamp))
-        nearest_state = min(self.joint_states, key=key_func)
-        self.__insert_joint_states(nearest_state)
+    def _action_result_cb(self, topic, type_name, msg):
+        self._insert(topic, type_name, msg, True)
 
-    def __action_feedback_cb(self, topic, type_name, msg):
-        self.__insert_action_feedback(topic, type_name, msg)
-
-    def __joint_states_cb(self, msg):
-        self.joint_states = [m for m in self.joint_states if (msg.header.stamp - m.header.stamp).to_sec() < self.joint_tolerance] + [msg]
-        self.joint_states_inserted = [s for s in self.joint_states_inserted if (msg.header.stamp - s).to_sec() < self.joint_tolerance]
+    def _action_feedback_cb(self, topic, type_name, msg):
+        self._insert(topic, type_name, msg, False)
 
     # insert functions
-    def __insert_action_goal(self, topic, type_name, msg):
-        try:
-            res = self.insert(msg)
-            rospy.logdebug("inserted action_goal message: %s (%s) -> %s", topic, type_name, res)
-        except Exception as e:
-            rospy.logerr("failed to insert action goal: %s (%s) -> %s", topic, type_name, e)
+    def _insert(self, topic, type_name, msg, force):
+        key = topic + '-' + type_name
+        stamp = msg.header.stamp
+        last = self.last_inserted_time[key]
+        dt = (stamp - last).to_sec()
 
-    def __insert_action_result(self, topic, type_name, msg):
-        try:
-            res = self.insert(msg)
-            rospy.logdebug("inserted action_result message: %s (%s) -> %s", topic, type_name, res)
-        except Exception as e:
-            rospy.logerr("failed to insert action result: %s (%s) -> %s", topic, type_name, e)
+        if not force and dt < 1.0 / self.max_rate:
+            return True  # drop
 
-    def __insert_action_feedback(self, topic, type_name, msg):
         try:
             res = self.insert(msg)
-            rospy.logdebug("inserted action_feedback message: %s (%s) -> %s", topic, type_name, res)
+            self.last_inserted_time[key] = stamp
+            rospy.logdebug("inserted message: %s (%s) -> %s", topic, type_name, res)
+            return True
         except Exception as e:
-            rospy.logerr("failed to insert action goal: %s (%s) -> %s", topic, type_name, e)
-
-    def __insert_joint_states(self, msg):
-        try:
-            if msg.header.stamp in self.joint_states_inserted:
-                return
-            res = self.insert(msg)
-            rospy.logdebug("inserted joint_states message: %s", res)
-        except Exception as e:
-            rospy.logerr("failed to insert joint states: %s", e)
+            rospy.logerr("failed to insert message: %s (%s) -> %s", topic, type_name, e)
+            return False
 
     # if the message type is goal or result, return the callback
-    def __message_callback_type(self, name, type_name, type_obj):
+    def _get_callback(self, name, type_name, type_obj):
         if not hasattr(type_obj, 'header'):
-            # ignore no header message
+            # ignore message without header
             return None
         if type(type_obj.header) != std_msgs.msg.Header:
-            # ignore non-standard header message
+            # ignore message without non-standard header
             return None
         if hasattr(type_obj, 'goal_id') and hasattr(type_obj, 'goal') and isinstance(type_obj.goal_id, GoalID):
             # action goal
-            return (lambda msg: self.__action_goal_cb(name, type_name, msg))
+            return (lambda msg: self._action_goal_cb(name, type_name, msg))
         elif hasattr(type_obj, 'status') and isinstance(type_obj.status, GoalStatus):
             if hasattr(type_obj, 'result'):
                 # action result
-                return (lambda msg: self.__action_result_cb(name, type_name, msg))
+                return (lambda msg: self._action_result_cb(name, type_name, msg))
             elif hasattr(type_obj, 'feedback'):
                 # action feedback
-                return (lambda msg: self.__action_feedback_cb(name, type_name, msg))
+                return (lambda msg: self._action_feedback_cb(name, type_name, msg))
         return None
 
     # subscriber updater
     def update_subscribers(self):
         # check new publishers
-        topics = [t for t in rospy.client.get_published_topics() if self.action_regex.match(t[1])]
+        topics = [t for t in rospy.get_published_topics() if self.action_regex.match(t[1])]
         if self.action_name_white_list:
             topics = [t for t in topics if t[0] in self.action_name_white_list]
         if self.action_type_white_list:
@@ -169,7 +143,7 @@ class ActionLogger(LoggerBase):
                 continue
 
             try:
-                cb_func = self.__message_callback_type(topic_name, msg_type, type_instance)
+                cb_func = self._get_callback(topic_name, msg_type, type_instance)
                 if cb_func is None:
                     self.useless_types += [py_topic_class]
                     continue

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/action_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/action_logger.py
@@ -26,7 +26,7 @@ class ActionLogger(LoggerBase):
 
         self.queue_size = rospy.get_param("~queue_size", 30)
         self.action_regex = re.compile(".*Action(Result|Goal|Feedback)$")
-
+        self.update_rate = rospy.get_param("~update_rate", 1.0)
         self.max_rate = rospy.get_param("~max_rate", 3.0)
         self.last_inserted_time = defaultdict(rospy.Time)
 
@@ -163,10 +163,11 @@ class ActionLogger(LoggerBase):
             rospy.logdebug("unsubscribe %s" % t)
 
     def run(self):
+        r = rospy.Rate(self.update_rate)
         while not rospy.is_shutdown():
             self.update_subscribers()
             self.spinOnce()
-
+            r.sleep()
 
 if __name__ == "__main__":
     rospy.init_node('action_logger')

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/action_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/action_logger.py
@@ -75,7 +75,7 @@ class ActionLogger(LoggerBase):
             return True  # drop
 
         try:
-            res = self.insert(msg)
+            res = self.insert(msg, meta={'input_topic': topic})
             self.last_inserted_time[key] = stamp
             rospy.logdebug("inserted message: %s (%s) -> %s", topic, type_name, res)
             return True

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/base_trajectory_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/base_trajectory_logger.py
@@ -2,115 +2,128 @@
 # -*- coding: utf-8 -*-
 # Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
 
+import numpy as np
 import rospy
 from transformations import TransformListener
 from geometry_msgs.msg import PoseWithCovarianceStamped
 from logger_base import LoggerBase
 
 
+def diff_pose(p1, p2):
+    pos1 = np.array([p1.position.x, p1.position.y, p1.position.z])
+    pos2 = np.array([p2.position.x, p2.position.y, p2.position.z])
+    rot1 = np.array([p1.orientation.x, p1.orientation.y,
+                     p1.orientation.z, p1.orientation.w])
+    rot2 = np.array([p2.orientation.x, p2.orientation.y,
+                     p2.orientation.z, p2.orientation.w])
+    normp = np.linalg.norm(pos1 - pos2)
+    normr = np.linalg.norm(rot1 - rot2)
+    return normp, normr
+
+
 class BaseTrajectoryLogger(LoggerBase):
     def __init__(self):
         LoggerBase.__init__(self)
-        self.map_frame = rospy.get_param('~map_frame','map')
-        self.robot_frame = rospy.get_param('~robot_frame', 'base_link')
+        self.update_rate = rospy.get_param("~update_rate", 1.0)
+        self.use_amcl = rospy.get_param("~use_amcl", True)
 
-        use_tf2 = rospy.get_param("~use_tf2", True)
-        self.tf_listener = TransformListener(use_tf2=use_tf2)
+        if self.use_amcl:
+            self.map_frame = rospy.get_param("/amcl/global_frame_id")
+            self.robot_frame = rospy.get_param("/amcl/base_frame_id")
+        else:
+            self.map_frame = rospy.get_param('~map_frame','map')
+            self.robot_frame = rospy.get_param('~robot_frame', 'base_link')
+        if self.map_frame.startswith("/"):
+            self.map_frame = self.map_frame[1:]
+        if self.robot_frame.startswith("/"):
+            self.robot_frame = self.robot_frame[1:]
 
-        self.initialpose_pub = rospy.Publisher('/initialpose', PoseWithCovarianceStamped,
-                                               queue_size=1, latch=True)
+        self.tf_listener = TransformListener(
+            use_tf2=rospy.get_param("~use_tf2", True))
+
+        self.initialpose_pub = rospy.Publisher(
+            '/initialpose', PoseWithCovarianceStamped,
+            queue_size=1, latch=True)
+
         rospy.loginfo("map->robot: %s -> %s" % (self.map_frame, self.robot_frame))
 
-        self.current_pose = None
-        self.latest_pose = None
-        self.latest_stamp = rospy.Time(0)
-        self._load_latest_pose()
-        self.pub_latest_pose()
-        self.latest_exception = None
+        self.latest_pose = self.load_latest_pose()
+        # publish initial pose if possible
+        self.publish_initial_pose(self.latest_pose)
 
-    def _insert_pose_to_db(self, map_to_robot):
+        if self.use_amcl:
+            self.sub_amcl = rospy.Subscriber(
+                "/amcl_pose", PoseWithCovarianceStamped,
+                self.amcl_cb, queue_size=1)
+
+    def amcl_cb(self, msg):
+        self.latest_pose = msg
+
+    def get_pose_from_tf(self):
         try:
-            res = self.insert(map_to_robot)
-            rospy.logdebug("inserted %s : %s" % (res, map_to_robot))
+            transform = self.tf_listener.lookup_transform(
+                self.map_frame, self.robot_frame, rospy.Time(0))
+            msg = PoseWithCovarianceStamped(header=transform.header)
+            msg.pose.pose.position.x = transform.transform.translation.x
+            msg.pose.pose.position.y = transform.transform.translation.y
+            msg.pose.pose.position.z = transform.transform.translation.z
+            msg.pose.pose.orientation.x = transform.transform.rotation.x
+            msg.pose.pose.orientation.y = transform.transform.rotation.y
+            msg.pose.pose.orientation.z = transform.transform.rotation.z
+            msg.pose.pose.orientation.w = transform.transform.rotation.w
+            # NOTE: msg.pose.covariance is left blank.
+            return msg
         except Exception as e:
-            rospy.logerr('failed to insert current robot pose to db: %s', e)
+            rospy.logerr("Failed to get current robot pose from tf: %s" % str(e))
+            return None
 
-    def _load_latest_pose(self):
-        updated = None
+    def load_latest_pose(self):
         try:
-            updated = self.msg_store.query('geometry_msgs/TransformStamped',
-                                           single=True,
-                                           sort_query=[("$natural", -1)])
+            msg, meta = self.msg_store.query(
+                PoseWithCovarianceStamped._type,
+                single=True, sort_query=[("$natural", -1)])
+            return msg
         except Exception as e:
             rospy.logerr('failed to load latest pose from db: %s' % e)
-            if 'master has changed' in str(e):
-                self._load_latest_pose()
-            else:
-                return
-        if updated is not None:
-            rospy.loginfo('found latest pose %s' % updated)
-            self.current_pose = updated[0]
-            self.latest_pose = updated[0]
+        return None
 
-    def _need_update_db(self, t):
-        if self.current_pose is None:
-            if self.latest_pose is None:
-                return True
-            else:
-                return False
-        diffthre = 0.1 + 1.0 / (rospy.Time.now() - self.latest_stamp).to_sec()
-        diffpos = sum([(t.transform.translation.x - self.current_pose.transform.translation.x) ** 2,
-                       (t.transform.translation.y - self.current_pose.transform.translation.y) ** 2,
-                       (t.transform.translation.z - self.current_pose.transform.translation.z) ** 2]) ** 0.5
-        diffrot = sum([(t.transform.rotation.x - self.current_pose.transform.rotation.x) ** 2,
-                       (t.transform.rotation.y - self.current_pose.transform.rotation.y) ** 2,
-                       (t.transform.rotation.z - self.current_pose.transform.rotation.z) ** 2,
-                       (t.transform.rotation.w - self.current_pose.transform.rotation.w) ** 2]) ** 0.5
-        rospy.logdebug("diffthre: %f, diffpos: %f, diffrot: %f" % (diffthre, diffpos, diffrot))
-        if diffthre < diffpos or diffthre / 2.0 < diffrot:
-            return True
-        else:
-            return False
+    def publish_initial_pose(self, msg, timeout=10):
+        if not msg: return
 
-    def insert_current_pose(self):
-        try:
-            transform = self.tf_listener.lookup_transform(self.map_frame, self.robot_frame, rospy.Time(0))
-            if self._need_update_db(transform):
-                self._insert_pose_to_db(transform)
-                self.current_pose = transform
-        except Exception as e:
-            if not self.latest_exception or str(e) is self.latest_exception:
-                rospy.logwarn('failed to get current robot pose from tf: %s' % e)
-                self.latest_exception = str(e)
+        r = rospy.Rate(1)
+        while not rospy.is_shutdown():
+            if self.initialpose_pub.get_num_connections() > 0:
+                break
+            rospy.loginfo("waiting /initialpose is subscribed")
+            r.sleep()
 
-    def pub_latest_pose(self):
-        if(self.latest_pose is not None and self.initialpose_pub.get_num_connections() > 0):
-            pub_msg = PoseWithCovarianceStamped()
-            pub_msg.header.stamp = rospy.Time(0)
-            pub_msg.header.frame_id = '/map'
-            pub_msg.pose.covariance = [0.25,  0.0, 0.0, 0.0, 0.0, 0.0,
-                                        0.0, 0.25, 0.0, 0.0, 0.0, 0.0,
-                                        0.0,  0.0, 0.0, 0.0, 0.0, 0.0,
-                                        0.0,  0.0, 0.0, 0.0, 0.0, 0.0,
-                                        0.0,  0.0, 0.0, 0.0, 0.0, 0.0,
-                                        0.0,  0.0, 0.0, 0.0, 0.0, 0.06853891945200942]
-            pub_msg.pose.pose.position.x = self.latest_pose.transform.translation.x
-            pub_msg.pose.pose.position.y = self.latest_pose.transform.translation.y
-            pub_msg.pose.pose.position.z = self.latest_pose.transform.translation.z
-            pub_msg.pose.pose.orientation = self.latest_pose.transform.rotation
-
-            try:
-                self.initialpose_pub.publish(pub_msg)
-                self.latest_pose = None
-                rospy.loginfo('published latest pose %s' % pub_msg)
-            except Exception as e:
-                rospy.logerr('failed to publish initial robot pose: %s' % e)
+        msg.header.stamp = rospy.Time(0)
+        self.initialpose_pub.publish(msg)
 
     def run(self):
+        r = rospy.Rate(self.update_rate)
+        prev_pose = None
         while not rospy.is_shutdown():
-            self.insert_current_pose()
-            self.pub_latest_pose()
+            if not self.use_amcl:
+                self.latest_pose = self.get_pose_from_tf()
+            if self.latest_pose:
+                if prev_pose:
+                    dt = (rospy.Time.now() - self.latest_pose.header.stamp).to_sec()
+                    if dt > 0:
+                        thre = 0.1 + 1.0 / dt
+                        diffp, diffr = diff_pose(
+                            prev_pose.pose.pose, self.latest_pose.pose.pose)
+                        rospy.logdebug(
+                            "diffthre: %f, diffpos: %f, diffrot: %f" % (thre, diffp, diffr))
+                        if thre < diffp or thre / 2.0 < diffr:
+                            self.insert(self.latest_pose)
+                            prev_pose = self.latest_pose
+                else:
+                    self.insert(self.latest_pose)
+                    prev_pose = self.latest_pose
+
             self.spinOnce()
+            r.sleep()
 
 if __name__ == "__main__":
     rospy.init_node('base_trajectory_logger')

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/logger_base.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/logger_base.py
@@ -18,7 +18,6 @@ class LoggerBase(object):
         except KeyError as e:
             rospy.logerr("please specify param \"/robot/name\" (e.g. pr1012, olive)")
             exit(1)
-        self.update_cycle = rospy.get_param("update_cycle", 1)
 
         self.task_id = None
 
@@ -31,6 +30,5 @@ class LoggerBase(object):
         return self.msg_store.insert(msg, meta, wait=wait)
 
     def spinOnce(self):
-        rospy.sleep(self.update_cycle)
         self.task_id = rospy.get_param("/task_id", None)
 

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/object_detection_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/object_detection_logger.py
@@ -17,6 +17,7 @@ from transformations import TransformListener
 class ObjectDetectionLogger(LoggerBase):
     def __init__(self):
         LoggerBase.__init__(self)
+        self.update_rate = rospy.get_param("~update_rate", 1.0)
         self.map_frame = rospy.get_param('~map_frame', 'map')
         self.robot_frame = rospy.get_param('~robot_frame', 'base_footprint')
         rospy.loginfo("map->robot: %s -> %s" % (self.map_frame, self.robot_frame))
@@ -77,9 +78,11 @@ class ObjectDetectionLogger(LoggerBase):
             rospy.logdebug('start subscribe (%s)', sub.name)
 
     def run(self):
+        r = rospy.Rate(self.update_rate)
         while not rospy.is_shutdown():
             self.update_subscribers()
             self.spinOnce()
+            r.sleep()
 
 if __name__ == "__main__":
     rospy.init_node('object_detecton_logger')

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/tf_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/tf_logger.py
@@ -42,7 +42,7 @@ class TFLogger(LoggerBase):
         if not transforms: return
 
         try:
-            self.insert(TFMessage(transforms))
+            self.insert(TFMessage(transforms), meta={'input_topic': '/tf'})
         except Exception as e:
             rospy.logerr(e)
 


### PR DESCRIPTION
This PR includes the features as follows:
- Enabling an option to log action for PR2 / fetch robots
- Add option to throttle action topics
- Use `update_rate` param for adjusting throttling for logging nodes (previously, various names are used in each node)

And this PR also includes some fixes:
- Bugfixes (typo)
- Add option to use `amcl` for logging base trajectory in order to support logging covariances of robots