### PR TITLE
[naoqieus] add 'set/get background movement method'

### DIFF
--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -388,5 +388,23 @@
      (setq res (ros::service-call "/naoqi_driver/get_language" ret))
      (send res :data))
    )
+  (:set-background-movement-enabled
+   (status)
+   (let ((ret (instance std_srvs::SetBoolRequest :init))
+	  res)
+     (ros::wait-for-service "/background_movement/set_enabled")
+     (send ret :data status)
+     (setq res (ros::service-call "/background_movement/set_enabled" ret))
+     (send res :success)
+     ))
+  (:get-background-movement-enabled
+   ()
+   (let ((ret (instance std_srvs::TriggerRequest :init))
+	 res)
+     (ros::wait-for-service "/background_movement/is_enabled")
+     (setq res (ros::service-call "/background_movement/is_enabled" ret))
+     (send res :success)
+     )
+   )
   )
 ;;


### PR DESCRIPTION
[what I did]
added naoqieus method: 
(1) set background movement(*) status (set enabled or disabled)
(2) get background movement status (Is it set or not set?)

(*) slight arm movements while a robot is standing

[related programs]
naoqi api: ALBackgroundMovement
http://doc.aldebaran.com/2-5/naoqi/interaction/autonomousabilities/albackgroundmovement-api.html#albackgroundmovement-api
naoqi_apps program: https://github.com/ros-naoqi/naoqi_bridge/pull/82 (merged)
