### PR TITLE
Change teleop button assignment and enable unsafe teleop

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -2,6 +2,7 @@
   <!-- mainly copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
   <arg name="enable_auto_dock" default="true" />
   <arg name="joy_device" default="/dev/ps3joy"/>
+  <arg name="disable_arm_teleop" default="true"/>
 
   <node name="joy" pkg="joy" type="joy_node">
     <param name="autorepeat_rate" value="1"/>
@@ -10,6 +11,8 @@
 
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop">
     <remap from="teleop/cmd_vel" to="/teleop/cmd_vel/unsafe" />
+    <param name="arm/button_arm_linear" value="17" if="$(arg disable_arm_teleop)"/>
+    <param name="arm/button_arm_angular" value="17" if="$(arg disable_arm_teleop)"/>
     <param name="base/use_mux" value="false" />
   </node>
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -11,6 +11,7 @@
 
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop">
     <remap from="teleop/cmd_vel" to="/teleop/cmd_vel/unsafe" />
+    <!-- set these two motions as non-existent button 17 -->
     <param name="arm/button_arm_linear" value="17" if="$(arg disable_arm_teleop)"/>
     <param name="arm/button_arm_angular" value="17" if="$(arg disable_arm_teleop)"/>
     <param name="base/use_mux" value="false" />

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -12,6 +12,7 @@
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop">
     <remap from="teleop/cmd_vel" to="/teleop/cmd_vel/unsafe" />
     <!-- set these two motions as non-existent button 17 -->
+    <!-- from fetch_teleop version 0.7.11, arm teleop is added and it is necessary to update jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml -->
     <param name="arm/button_arm_linear" value="17" if="$(arg disable_arm_teleop)"/>
     <param name="arm/button_arm_angular" value="17" if="$(arg disable_arm_teleop)"/>
     <param name="base/use_mux" value="false" />

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -12,7 +12,7 @@
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop">
     <remap from="teleop/cmd_vel" to="/teleop/cmd_vel/unsafe" />
     <!-- set these two motions as non-existent button 17 -->
-    <!-- from fetch_teleop version 0.7.11, arm teleop is added and it is necessary to update jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml -->
+    <!-- from fetch_teleop version 0.7.11 (https://github.com/fetchrobotics/fetch_ros/pull/61), arm teleop is added and it is necessary to update jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml -->
     <param name="arm/button_arm_linear" value="17" if="$(arg disable_arm_teleop)"/>
     <param name="arm/button_arm_angular" value="17" if="$(arg disable_arm_teleop)"/>
     <param name="base/use_mux" value="false" />

--- a/jsk_fetch_robot/jsk_fetch_startup/package.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/package.xml
@@ -11,6 +11,8 @@
   <url>http://ros.org/wiki/jsk_fetch_startup</url>
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend version_gte="0.7.11">fetch_teleop</build_depend>
+
   <run_depend>image_proc</run_depend>
   <run_depend>jsk_robot_startup</run_depend>
   <run_depend>jsk_maps</run_depend>


### PR DESCRIPTION
最近のfetchのプログラムアップデートにより、これまでunsafe teleopに割り当てていたボタンが腕の操作に割り当てられてしまっていたので、それを無効にして今までどおりunsafe teleop出来るようにしました。