### PR TITLE
reduce inflation radius parameter for global costmap

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -60,7 +60,7 @@
     </include>
     <rosparam ns="move_base/global_costmap">
 inflater:
-  inflation_radius: 0.80 # 0.7
+  inflation_radius: 0.30 # 0.7
   cost_scaling_factor: 10.0 # 10.0
     </rosparam>
     <rosparam ns="move_base/local_costmap">


### PR DESCRIPTION
fetchをnavigationする際、globalな経路を作れないことが多かったので、inflation radiusを小さくしました。