### PR TITLE
set std=c++11 as default compiler for jsk_robot_startup

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
+++ b/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
@@ -1,6 +1,26 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(jsk_robot_startup)
 
+# for ROS indigo compile without c++11 support
+if(DEFINED ENV{ROS_DISTRO})
+  if(NOT $ENV{ROS_DISTRO} STREQUAL "indigo")
+    add_compile_options(-std=c++11)
+    message(STATUS "Building with C++11 support")
+  else() 
+    message(STATUS "ROS Indigo: building without C++11 support")
+  endif()
+else()
+  message(STATUS "Environmental variable ROS_DISTRO not defined, checking OS version")
+  file(STRINGS /etc/os-release RELEASE_CODENAME
+		REGEX "VERSION_CODENAME=")
+  if(NOT ${RELEASE_CODENAME} MATCHES "trusty") 
+    add_compile_options(-std=c++11)
+    message(STATUS "OS distro is not trusty: building with C++11 support")
+  else()
+    message(STATUS "Ubuntu Trusty: building without C++11 support")
+  endif()
+endif()
+
 find_package(catkin REQUIRED COMPONENTS
   cv_bridge
   dynamic_reconfigure


### PR DESCRIPTION
Build failed.
`jsk_robot_startup/lightweight_logger` requires `c++11` compiler.

```bash
$ catkin bt
==> Expanding alias 'bt' from 'catkin bt' to 'catkin b --this'
==> Expanding alias 'b' from 'catkin b --this' to 'catkin build --this'
-------------------------------------------------------------
Profile:                     default
Extending:          [cached] /opt/ros/kinetic
Workspace:                   /home/shingo/ros/kinetic
-------------------------------------------------------------
Source Space:       [exists] /home/shingo/ros/kinetic/src
Log Space:          [exists] /home/shingo/ros/kinetic/logs
Build Space:        [exists] /home/shingo/ros/kinetic/build
Devel Space:        [exists] /home/shingo/ros/kinetic/devel
Install Space:      [unused] /home/shingo/ros/kinetic/install
DESTDIR:            [unused] None
-------------------------------------------------------------
Devel Space Layout:          linked
Install Space Layout:        None
-------------------------------------------------------------
Additional CMake Args:       None
Additional Make Args:        None
Additional catkin Make Args: None
Internal Make Job Server:    True
Cache Job Environments:      False
-------------------------------------------------------------
Whitelisted Packages:        None
Blacklisted Packages:        None
-------------------------------------------------------------
Workspace configuration appears valid.
-------------------------------------------------------------
[build] Found '93' packages in 0.0 seconds.
[build] Package table is up to date.
Starting  >>> dynamic_tf_publisher
Starting  >>> jsk_recognition_msgs
Finished  <<< dynamic_tf_publisher                [ 0.4 seconds ]
Starting  >>> jsk_topic_tools
Finished  <<< jsk_recognition_msgs                [ 0.7 seconds ]
Finished  <<< jsk_topic_tools                     [ 0.4 seconds ]
Starting  >>> jsk_robot_startup
___________________________________________________________________________________________________________________________________________________________________________________________________________
Warnings   << jsk_robot_startup:check /home/shingo/ros/kinetic/logs/jsk_robot_startup/build.check.002.log
CMake Warning (dev) at CMakeLists.txt:57 (add_dependencies):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  The dependency target "jsk_robot_startup_gencpp" of target
  "joint_states_throttle" does not exist.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at CMakeLists.txt:50 (add_dependencies):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.

  The dependency target "jsk_robot_startup_gencpp" of target
  "jsk_robot_lifelog" does not exist.
This warning is for project developers.  Use -Wno-dev to suppress it.

cd /home/shingo/ros/kinetic/build/jsk_robot_startup; catkin build --get-env jsk_robot_startup | catkin env -si  /usr/bin/make cmake_check_build_system; cd -
...........................................................................................................................................................................................................
___________________________________________________________________________________________________________________________________________________________________________________________________________
Errors     << jsk_robot_startup:make /home/shingo/ros/kinetic/logs/jsk_robot_startup/build.make.003.log
In file included from /usr/include/c++/5/atomic:38:0,
                 from /opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:29,
                 from /opt/ros/kinetic/include/mongo/platform/atomic_word.h:21,
                 from /opt/ros/kinetic/include/mongo/base/status.h:23,
                 from /opt/ros/kinetic/include/mongo/util/assert_util.h:23,
                 from /opt/ros/kinetic/include/mongo/bson/bsontypes.h:20,
                 from /opt/ros/kinetic/include/mongo/bson/bsonelement.h:25,
                 from /opt/ros/kinetic/include/mongo/bson/bsonobj.h:27,
                 from /opt/ros/kinetic/include/mongo/client/bulk_operation_builder.h:20,
                 from /opt/ros/kinetic/include/mongo/client/dbclientinterface.h:29,
                 from /opt/ros/kinetic/include/mongo/client/dbclient_rs.h:23,
                 from /opt/ros/kinetic/include/mongo/client/dbclient.h:59,
                 from /opt/ros/kinetic/include/mongodb_store/message_store.h:17,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h:46,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp:40:
/usr/include/c++/5/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support \
  ^
In file included from /opt/ros/kinetic/include/mongo/base/data_cursor.h:21:0,
                 from /opt/ros/kinetic/include/mongo/bson/bsonelement.h:24,
                 from /opt/ros/kinetic/include/mongo/bson/bsonobj.h:27,
                 from /opt/ros/kinetic/include/mongo/client/bulk_operation_builder.h:20,
                 from /opt/ros/kinetic/include/mongo/client/dbclientinterface.h:29,
                 from /opt/ros/kinetic/include/mongo/client/dbclient_rs.h:23,
                 from /opt/ros/kinetic/include/mongo/client/dbclient.h:59,
                 from /opt/ros/kinetic/include/mongodb_store/message_store.h:17,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h:46,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp:40:
/opt/ros/kinetic/include/mongo/base/data_view.h: In member function ‘const mongo::ConstDataView& mongo::ConstDataView::readNative(T*, size_t) const’:
/opt/ros/kinetic/include/mongo/base/data_view.h:43:23: error: ‘is_trivially_copyable’ is not a member of ‘std’
         static_assert(std::is_trivially_copyable<T>::value,
                       ^
/opt/ros/kinetic/include/mongo/base/data_view.h:43:51: error: expected primary-expression before ‘>’ token
         static_assert(std::is_trivially_copyable<T>::value,
                                                   ^
/opt/ros/kinetic/include/mongo/base/data_view.h:43:52: error: ‘::value’ has not been declared
         static_assert(std::is_trivially_copyable<T>::value,
                                                    ^
/opt/ros/kinetic/include/mongo/base/data_view.h:43:52: note: suggested alternative:
In file included from /usr/include/boost/bind.hpp:22:0,
                 from /opt/ros/kinetic/include/ros/publisher.h:35,
                 from /opt/ros/kinetic/include/ros/node_handle.h:32,
                 from /opt/ros/kinetic/include/ros/ros.h:45,
                 from /opt/ros/kinetic/include/topic_tools/shape_shifter.h:38,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h:44,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp:40:
/usr/include/boost/bind/bind.hpp:112:25: note:   ‘boost::_bi::value’
 template<class T> class value
                         ^
In file included from /opt/ros/kinetic/include/mongo/base/data_cursor.h:21:0,
                 from /opt/ros/kinetic/include/mongo/bson/bsonelement.h:24,
                 from /opt/ros/kinetic/include/mongo/bson/bsonobj.h:27,
                 from /opt/ros/kinetic/include/mongo/client/bulk_operation_builder.h:20,
                 from /opt/ros/kinetic/include/mongo/client/dbclientinterface.h:29,
                 from /opt/ros/kinetic/include/mongo/client/dbclient_rs.h:23,
                 from /opt/ros/kinetic/include/mongo/client/dbclient.h:59,
                 from /opt/ros/kinetic/include/mongodb_store/message_store.h:17,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h:46,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp:40:
/opt/ros/kinetic/include/mongo/base/data_view.h:44:81: error: there are no arguments to ‘static_assert’ that depend on a template parameter, so a declaration of ‘static_assert’ must be available [-fpermissive]
                       "Type for DataView::readNative must be trivially copyable");
                                                                                 ^
/opt/ros/kinetic/include/mongo/base/data_view.h:44:81: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
/opt/ros/kinetic/include/mongo/base/data_view.h: In member function ‘mongo::DataView& mongo::DataView::writeNative(const T&, std::size_t)’:
/opt/ros/kinetic/include/mongo/base/data_view.h:86:23: error: ‘is_trivially_copyable’ is not a member of ‘std’
         static_assert(std::is_trivially_copyable<T>::value,
                       ^
/opt/ros/kinetic/include/mongo/base/data_view.h:86:51: error: expected primary-expression before ‘>’ token
         static_assert(std::is_trivially_copyable<T>::value,
                                                   ^
/opt/ros/kinetic/include/mongo/base/data_view.h:86:52: error: ‘::value’ has not been declared
         static_assert(std::is_trivially_copyable<T>::value,
                                                    ^
/opt/ros/kinetic/include/mongo/base/data_view.h:86:52: note: suggested alternative:
In file included from /usr/include/boost/bind.hpp:22:0,
                 from /opt/ros/kinetic/include/ros/publisher.h:35,
                 from /opt/ros/kinetic/include/ros/node_handle.h:32,
                 from /opt/ros/kinetic/include/ros/ros.h:45,
                 from /opt/ros/kinetic/include/topic_tools/shape_shifter.h:38,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h:44,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp:40:
/usr/include/boost/bind/bind.hpp:112:25: note:   ‘boost::_bi::value’
 template<class T> class value
                         ^
In file included from /opt/ros/kinetic/include/mongo/base/data_cursor.h:21:0,
                 from /opt/ros/kinetic/include/mongo/bson/bsonelement.h:24,
                 from /opt/ros/kinetic/include/mongo/bson/bsonobj.h:27,
                 from /opt/ros/kinetic/include/mongo/client/bulk_operation_builder.h:20,
                 from /opt/ros/kinetic/include/mongo/client/dbclientinterface.h:29,
                 from /opt/ros/kinetic/include/mongo/client/dbclient_rs.h:23,
                 from /opt/ros/kinetic/include/mongo/client/dbclient.h:59,
                 from /opt/ros/kinetic/include/mongodb_store/message_store.h:17,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h:46,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp:40:
/opt/ros/kinetic/include/mongo/base/data_view.h:87:82: error: there are no arguments to ‘static_assert’ that depend on a template parameter, so a declaration of ‘static_assert’ must be available [-fpermissive]
                       "Type for DataView::writeNative must be trivially copyable");
                                                                                  ^
In file included from /opt/ros/kinetic/include/mongo/platform/atomic_word.h:21:0,
                 from /opt/ros/kinetic/include/mongo/base/status.h:23,
                 from /opt/ros/kinetic/include/mongo/util/assert_util.h:23,
                 from /opt/ros/kinetic/include/mongo/bson/bsontypes.h:20,
                 from /opt/ros/kinetic/include/mongo/bson/bsonelement.h:25,
                 from /opt/ros/kinetic/include/mongo/bson/bsonobj.h:27,
                 from /opt/ros/kinetic/include/mongo/client/bulk_operation_builder.h:20,
                 from /opt/ros/kinetic/include/mongo/client/dbclientinterface.h:29,
                 from /opt/ros/kinetic/include/mongo/client/dbclient_rs.h:23,
                 from /opt/ros/kinetic/include/mongo/client/dbclient.h:59,
                 from /opt/ros/kinetic/include/mongodb_store/message_store.h:17,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h:46,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp:40:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h: At global scope:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:167:10: error: ‘atomic’ in namespace ‘std’ does not name a template type
     std::atomic<WordType> _value;
          ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h: In constructor ‘mongo::AtomicWord<_WordType>::AtomicWord(mongo::AtomicWord<_WordType>::WordType)’:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:60:57: error: class ‘mongo::AtomicWord<_WordType>’ does not have any field named ‘_value’
     explicit AtomicWord(WordType value = WordType(0)) : _value(value) {}
                                                         ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h: In member function ‘mongo::AtomicWord<_WordType>::WordType mongo::AtomicWord<_WordType>::load() const’:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:76:16: error: ‘_value’ was not declared in this scope
         return _value.load();
                ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h: In member function ‘mongo::AtomicWord<_WordType>::WordType mongo::AtomicWord<_WordType>::loadRelaxed() const’:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:85:16: error: ‘_value’ was not declared in this scope
         return _value.load(std::memory_order_relaxed);
                ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:85:28: error: ‘memory_order_relaxed’ is not a member of ‘std’
         return _value.load(std::memory_order_relaxed);
                            ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:85:28: note: suggested alternative:
In file included from /usr/include/boost/atomic/fences.hpp:19:0,
                 from /usr/include/boost/atomic/atomic.hpp:20,
                 from /usr/include/boost/atomic.hpp:12,
                 from /usr/include/boost/thread/pthread/once_atomic.hpp:20,
                 from /usr/include/boost/thread/once.hpp:20,
                 from /usr/include/boost/thread.hpp:17,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_common/jsk_topic_tools/include/jsk_topic_tools/stealth_relay.h:44,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h:45,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp:40:
/usr/include/boost/memory_order.hpp:47:5: note:   ‘memory_order_relaxed’
     memory_order_relaxed = 0,
     ^
In file included from /opt/ros/kinetic/include/mongo/platform/atomic_word.h:21:0,
                 from /opt/ros/kinetic/include/mongo/base/status.h:23,
                 from /opt/ros/kinetic/include/mongo/util/assert_util.h:23,
                 from /opt/ros/kinetic/include/mongo/bson/bsontypes.h:20,
                 from /opt/ros/kinetic/include/mongo/bson/bsonelement.h:25,
                 from /opt/ros/kinetic/include/mongo/bson/bsonobj.h:27,
                 from /opt/ros/kinetic/include/mongo/client/bulk_operation_builder.h:20,
                 from /opt/ros/kinetic/include/mongo/client/dbclientinterface.h:29,
                 from /opt/ros/kinetic/include/mongo/client/dbclient_rs.h:23,
                 from /opt/ros/kinetic/include/mongo/client/dbclient.h:59,
                 from /opt/ros/kinetic/include/mongodb_store/message_store.h:17,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h:46,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp:40:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h: In member function ‘void mongo::AtomicWord<_WordType>::store(mongo::AtomicWord<_WordType>::WordType)’:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:94:16: error: ‘_value’ was not declared in this scope
         return _value.store(newValue);
                ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h: In member function ‘mongo::AtomicWord<_WordType>::WordType mongo::AtomicWord<_WordType>::swap(mongo::AtomicWord<_WordType>::WordType)’:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:105:16: error: ‘_value’ was not declared in this scope
         return _value.exchange(newValue);
                ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h: In member function ‘mongo::AtomicWord<_WordType>::WordType mongo::AtomicWord<_WordType>::compareAndSwap(mongo::AtomicWord<_WordType>::WordType, mongo::AtomicWord<_WordType>::WordType)’:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:118:9: error: ‘_value’ was not declared in this scope
         _value.compare_exchange_strong(expected, newValue);
         ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h: In member function ‘mongo::AtomicWord<_WordType>::WordType mongo::AtomicWord<_WordType>::fetchAndAdd(mongo::AtomicWord<_WordType>::WordType)’:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:130:16: error: ‘_value’ was not declared in this scope
         return _value.fetch_add(increment);
                ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h: In member function ‘mongo::AtomicWord<_WordType>::WordType mongo::AtomicWord<_WordType>::fetchAndSubtract(mongo::AtomicWord<_WordType>::WordType)’:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:141:16: error: ‘_value’ was not declared in this scope
         return _value.fetch_sub(decrement);
                ^
In file included from /usr/include/boost/math/policies/policy.hpp:20:0,
                 from /usr/include/boost/math/policies/error_handling.hpp:19,
                 from /usr/include/boost/math/special_functions/round.hpp:14,
                 from /opt/ros/kinetic/include/ros/time.h:58,
                 from /opt/ros/kinetic/include/ros/ros.h:38,
                 from /opt/ros/kinetic/include/topic_tools/shape_shifter.h:38,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h:44,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp:40:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h: At global scope:
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:181:5: error: invalid application of ‘sizeof’ to incomplete type ‘boost::STATIC_ASSERTION_FAILURE<false>’
     BOOST_STATIC_ASSERT(sizeof(NAME) == sizeof(WTYPE)); \
     ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:185:1: note: in expansion of macro ‘_ATOMIC_WORD_DECLARE’
 _ATOMIC_WORD_DECLARE(AtomicUInt32, unsigned)
 ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:181:5: error: template argument 1 is invalid
     BOOST_STATIC_ASSERT(sizeof(NAME) == sizeof(WTYPE)); \
     ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:185:1: note: in expansion of macro ‘_ATOMIC_WORD_DECLARE’
 _ATOMIC_WORD_DECLARE(AtomicUInt32, unsigned)
 ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:181:5: error: invalid application of ‘sizeof’ to incomplete type ‘boost::STATIC_ASSERTION_FAILURE<false>’
     BOOST_STATIC_ASSERT(sizeof(NAME) == sizeof(WTYPE)); \
     ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:186:1: note: in expansion of macro ‘_ATOMIC_WORD_DECLARE’
 _ATOMIC_WORD_DECLARE(AtomicUInt64, unsigned long long)
 ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:181:5: error: template argument 1 is invalid
     BOOST_STATIC_ASSERT(sizeof(NAME) == sizeof(WTYPE)); \
     ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:186:1: note: in expansion of macro ‘_ATOMIC_WORD_DECLARE’
 _ATOMIC_WORD_DECLARE(AtomicUInt64, unsigned long long)
 ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:181:5: error: invalid application of ‘sizeof’ to incomplete type ‘boost::STATIC_ASSERTION_FAILURE<false>’
     BOOST_STATIC_ASSERT(sizeof(NAME) == sizeof(WTYPE)); \
     ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:187:1: note: in expansion of macro ‘_ATOMIC_WORD_DECLARE’
 _ATOMIC_WORD_DECLARE(AtomicInt32, int)
 ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:181:5: error: template argument 1 is invalid
     BOOST_STATIC_ASSERT(sizeof(NAME) == sizeof(WTYPE)); \
     ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:187:1: note: in expansion of macro ‘_ATOMIC_WORD_DECLARE’
 _ATOMIC_WORD_DECLARE(AtomicInt32, int)
 ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:181:5: error: invalid application of ‘sizeof’ to incomplete type ‘boost::STATIC_ASSERTION_FAILURE<false>’
     BOOST_STATIC_ASSERT(sizeof(NAME) == sizeof(WTYPE)); \
     ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:188:1: note: in expansion of macro ‘_ATOMIC_WORD_DECLARE’
 _ATOMIC_WORD_DECLARE(AtomicInt64, long long)
 ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:181:5: error: template argument 1 is invalid
     BOOST_STATIC_ASSERT(sizeof(NAME) == sizeof(WTYPE)); \
     ^
/opt/ros/kinetic/include/mongo/platform/atomic_word_cxx11.h:188:1: note: in expansion of macro ‘_ATOMIC_WORD_DECLARE’
 _ATOMIC_WORD_DECLARE(AtomicInt64, long long)
 ^
In file included from /opt/ros/kinetic/include/mongo/base/data_cursor.h:21:0,
                 from /opt/ros/kinetic/include/mongo/bson/bsonelement.h:24,
                 from /opt/ros/kinetic/include/mongo/bson/bsonobj.h:27,
                 from /opt/ros/kinetic/include/mongo/client/bulk_operation_builder.h:20,
                 from /opt/ros/kinetic/include/mongo/client/dbclientinterface.h:29,
                 from /opt/ros/kinetic/include/mongo/client/dbclient_rs.h:23,
                 from /opt/ros/kinetic/include/mongo/client/dbclient.h:59,
                 from /opt/ros/kinetic/include/mongodb_store/message_store.h:17,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h:46,
                 from /home/shingo/ros/kinetic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp:40:
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘mongo::DataView& mongo::DataView::writeNative(const T&, std::size_t) [with T = int; std::size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_view.h:95:65:   required from ‘mongo::DataView& mongo::DataView::writeLE(const T&, std::size_t) [with T = int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/bson/bsonobjbuilder.h:748:36:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:86:22: error: ‘static_assert’ was not declared in this scope
         static_assert(std::is_trivially_copyable<T>::value,
                      ^
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘const mongo::ConstDataView& mongo::ConstDataView::readNative(T*, size_t) const [with T = signed char; size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_view.h:53:9:   required from ‘T mongo::ConstDataView::readNative(std::size_t) const [with T = signed char; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/base/data_view.h:59:52:   required from ‘T mongo::ConstDataView::readLE(std::size_t) const [with T = signed char; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/bson/bsonelement.h:155:78:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:43:22: error: ‘static_assert’ was not declared in this scope
         static_assert(std::is_trivially_copyable<T>::value,
                      ^
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘const mongo::ConstDataView& mongo::ConstDataView::readNative(T*, size_t) const [with T = long long unsigned int; size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_view.h:53:9:   required from ‘T mongo::ConstDataView::readNative(std::size_t) const [with T = long long unsigned int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/base/data_view.h:59:52:   required from ‘T mongo::ConstDataView::readLE(std::size_t) const [with T = long long unsigned int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/bson/bsonelement.h:240:73:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:43:22: error: ‘static_assert’ was not declared in this scope
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘const mongo::ConstDataView& mongo::ConstDataView::readNative(T*, size_t) const [with T = double; size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_view.h:53:9:   required from ‘T mongo::ConstDataView::readNative(std::size_t) const [with T = double; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/base/data_view.h:59:52:   required from ‘T mongo::ConstDataView::readLE(std::size_t) const [with T = double; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/bson/bsonelement.h:256:54:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:43:22: error: ‘static_assert’ was not declared in this scope
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘const mongo::ConstDataView& mongo::ConstDataView::readNative(T*, size_t) const [with T = int; size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_view.h:53:9:   required from ‘T mongo::ConstDataView::readNative(std::size_t) const [with T = int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/base/data_view.h:59:52:   required from ‘T mongo::ConstDataView::readLE(std::size_t) const [with T = int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/bson/bsonelement.h:261:51:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:43:22: error: ‘static_assert’ was not declared in this scope
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘const mongo::ConstDataView& mongo::ConstDataView::readNative(T*, size_t) const [with T = long long int; size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_view.h:53:9:   required from ‘T mongo::ConstDataView::readNative(std::size_t) const [with T = long long int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/base/data_view.h:59:52:   required from ‘T mongo::ConstDataView::readLE(std::size_t) const [with T = long long int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/bson/bsonelement.h:266:57:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:43:22: error: ‘static_assert’ was not declared in this scope
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘const mongo::ConstDataView& mongo::ConstDataView::readNative(T*, size_t) const [with T = unsigned int; size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_view.h:53:9:   required from ‘T mongo::ConstDataView::readNative(std::size_t) const [with T = unsigned int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/base/data_view.h:59:52:   required from ‘T mongo::ConstDataView::readLE(std::size_t) const [with T = unsigned int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/bson/bsonelement.h:315:56:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:43:22: error: ‘static_assert’ was not declared in this scope
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘mongo::DataView& mongo::DataView::writeNative(const T&, std::size_t) [with T = unsigned int; std::size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_cursor.h:181:9:   required from ‘mongo::DataCursor& mongo::DataCursor::writeNativeAndAdvance(const T&) [with T = unsigned int]’
/opt/ros/kinetic/include/mongo/base/data_cursor.h:188:67:   required from ‘mongo::DataCursor& mongo::DataCursor::writeLEAndAdvance(const T&) [with T = unsigned int]’
/opt/ros/kinetic/include/mongo/bson/bsonobjbuilder.h:489:47:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:86:22: error: ‘static_assert’ was not declared in this scope
         static_assert(std::is_trivially_copyable<T>::value,
                      ^
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘const mongo::ConstDataView& mongo::ConstDataView::readNative(T*, size_t) const [with T = long int; size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_view.h:53:9:   required from ‘T mongo::ConstDataView::readNative(std::size_t) const [with T = long int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/base/data_view.h:59:52:   required from ‘T mongo::ConstDataView::readLE(std::size_t) const [with T = long int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/util/net/message.h:232:72:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:43:22: error: ‘static_assert’ was not declared in this scope
         static_assert(std::is_trivially_copyable<T>::value,
                      ^
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘mongo::DataView& mongo::DataView::writeNative(const T&, std::size_t) [with T = char; std::size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_view.h:95:65:   required from ‘mongo::DataView& mongo::DataView::writeLE(const T&, std::size_t) [with T = char; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/bson/util/builder.h:274:9:   required from ‘void mongo::_BufBuilder<Allocator>::appendNumImpl(T) [with T = char; Allocator = mongo::TrivialAllocator]’
/opt/ros/kinetic/include/mongo/bson/util/builder.h:172:22:   required from ‘void mongo::_BufBuilder<Allocator>::appendNum(char) [with Allocator = mongo::TrivialAllocator]’
/opt/ros/kinetic/include/mongo/bson/bsonobjbuilder.h:135:36:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:86:22: error: ‘static_assert’ was not declared in this scope
         static_assert(std::is_trivially_copyable<T>::value,
                      ^
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘mongo::DataView& mongo::DataView::writeNative(const T&, std::size_t) [with T = long long int; std::size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_view.h:95:65:   required from ‘mongo::DataView& mongo::DataView::writeLE(const T&, std::size_t) [with T = long long int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/bson/util/builder.h:274:9:   required from ‘void mongo::_BufBuilder<Allocator>::appendNumImpl(T) [with T = long long int; Allocator = mongo::TrivialAllocator]’
/opt/ros/kinetic/include/mongo/bson/util/builder.h:201:22:   required from ‘void mongo::_BufBuilder<Allocator>::appendNum(long long int) [with Allocator = mongo::TrivialAllocator]’
/opt/ros/kinetic/include/mongo/bson/bsonobjbuilder.h:244:23:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:86:22: error: ‘static_assert’ was not declared in this scope
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘mongo::DataView& mongo::DataView::writeNative(const T&, std::size_t) [with T = double; std::size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_view.h:95:65:   required from ‘mongo::DataView& mongo::DataView::writeLE(const T&, std::size_t) [with T = double; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/bson/util/builder.h:274:9:   required from ‘void mongo::_BufBuilder<Allocator>::appendNumImpl(T) [with T = double; Allocator = mongo::TrivialAllocator]’
/opt/ros/kinetic/include/mongo/bson/util/builder.h:197:22:   required from ‘void mongo::_BufBuilder<Allocator>::appendNum(double) [with Allocator = mongo::TrivialAllocator]’
/opt/ros/kinetic/include/mongo/bson/bsonobjbuilder.h:305:23:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:86:22: error: ‘static_assert’ was not declared in this scope
/opt/ros/kinetic/include/mongo/base/data_view.h: In instantiation of ‘mongo::DataView& mongo::DataView::writeNative(const T&, std::size_t) [with T = long long unsigned int; std::size_t = long unsigned int]’:
/opt/ros/kinetic/include/mongo/base/data_view.h:95:65:   required from ‘mongo::DataView& mongo::DataView::writeLE(const T&, std::size_t) [with T = long long unsigned int; std::size_t = long unsigned int]’
/opt/ros/kinetic/include/mongo/bson/util/builder.h:274:9:   required from ‘void mongo::_BufBuilder<Allocator>::appendNumImpl(T) [with T = long long unsigned int; Allocator = mongo::TrivialAllocator]’
/opt/ros/kinetic/include/mongo/bson/util/builder.h:204:22:   required from ‘void mongo::_BufBuilder<Allocator>::appendNum(long long unsigned int) [with Allocator = mongo::TrivialAllocator]’
/opt/ros/kinetic/include/mongo/bson/bsonobjbuilder.h:366:64:   required from here
/opt/ros/kinetic/include/mongo/base/data_view.h:86:22: error: ‘static_assert’ was not declared in this scope
make[2]: *** [CMakeFiles/jsk_robot_lifelog.dir/src/lightweight_logger_nodelet.cpp.o] エラー 1
make[1]: *** [CMakeFiles/jsk_robot_lifelog.dir/all] エラー 2
make[1]: *** 未完了のジョブを待っています....
make: *** [all] エラー 2
cd /home/shingo/ros/kinetic/build/jsk_robot_startup; catkin build --get-env jsk_robot_startup | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
...........................................................................................................................................................................................................
Failed     << jsk_robot_startup:make              [ Exited with code 2 ]
Failed    <<< jsk_robot_startup                   [ 7.4 seconds ]
[build] Summary: 3 of 4 packages succeeded.
[build]   Ignored:   89 packages were skipped or are blacklisted.
[build]   Warnings:  1 packages succeeded with warnings.
[build]   Abandoned: None.
[build]   Failed:    1 packages failed.
[build] Runtime: 9.5 seconds total.
```