### PR TITLE
add .rosinstall for fetch on kinetc

### DIFF
--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -2,9 +2,14 @@
    uri: http://github.com/RethinkRobotics/baxter_common.git
    local-name: RethinkRobotics/baxter_common
 - git:
-   uri: https://github.com/fetchrobotics/fetch_ros.git
-   local-name: fetchrobotics/fetch_ros
-- git:
    uri: https://github.com/ros-naoqi/nao_interaction.git
    local-name: ros-naoqi/nao_interaction
-
+# https://github.com/fetchrobotics/fetch_ros.git is not released on kinetic.
+- tar:
+    local-name: fetchrobotics/fetch_ros/fetch_moveit_config
+    uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_moveit_config/0.7.13-0.tar.gz
+    version: fetch_ros-release-release-indigo-fetch_moveit_config-0.7.13-0
+- tar:
+    local-name: fetchrobotics/fetch_ros/fetch_description
+    uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_description/0.7.13-0.tar.gz
+    version: fetch_ros-release-release-indigo-fetch_description-0.7.13-0

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
     - ROSWS=wstool
     - BUILDER=catkin
     - USE_TRAVIS=true
+    - USE_DOCKER=true
     - ROS_PARALLEL_JOBS="-j2"
     - CATKIN_PARALLEL_JOBS="-p2"
     - ROS_PARALLEL_TEST_JOBS="-j1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,4 +47,5 @@ before_script:
   # to install pepper_meshes, nao_meshes, the licenses have to be accepted
   - if [ "$ROS_DISTRO" == "indigo" ]; then export BEFORE_SCRIPT="echo \"ros-indigo-pepper-meshes ros-pepper-meshes/accepted-ros-pepper-meshes boolean true\" | sudo debconf-set-selections; sudo apt-get install -y -qq ros-$ROS_DISTRO-pepper-meshes"; fi
   - if [ "$ROS_DISTRO" == "indigo" ]; then export BEFORE_SCRIPT="echo \"ros-indigo-nao-meshes ros-nao-meshes/accepted-ros-nao-meshes boolean true\" | sudo debconf-set-selections; sudo apt-get install -y -qq ros-$ROS_DISTRO-nao-meshes"; fi
+  - if [ "$ROS_DISTRO" == "kinetic" ]; then export BEFORE_SCRIPT="wstool merge jsk_robot/jsk_fetch_robot/jsk_fetch.rosinstall.kinetic; wstool update"; fi
 script: source .travis/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ notifications:
   slack: jsk-robotics:Av7tc8wj3IWkLYvlTzHE7x2g
 env:
   global:
-    - ROSWS=wstool
-    - BUILDER=catkin
     - USE_TRAVIS=true
     - USE_DOCKER=true
     - ROS_PARALLEL_JOBS="-j2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     - CATKIN_PARALLEL_JOBS="-p2"
     - ROS_PARALLEL_TEST_JOBS="-j1"
     - CATKIN_PARALLEL_TEST_JOBS="-p1"
-    - NOT_TEST_INSTALL=true 
+    - NOT_TEST_INSTALL=true
   matrix:
     - ROS_DISTRO=hydro   USE_DEB=true
     - ROS_DISTRO=hydro   USE_DEB=false EXTRA_DEB="ros-hydro-convex-decomposition ros-hydro-ivcon" BUILD_PKGS="jsk_pr2_calibration jsk_robot_startup pr2_base_trajectory_action jsk_pr2_startup jsk_pr2_desktop"

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -4,7 +4,8 @@
 (require "package://pr2eus/robot-interface.l")
 (require "package://pr2eus_moveit/euslisp/robot-moveit.l")
 
-(ros::load-ros-manifest "fetcheus")
+(ros::load-ros-package "fetcheus")
+(ros::load-ros-package "fetch_driver_msgs")
 
 (defclass fetch-interface
   :super robot-move-base-interface

--- a/jsk_fetch_robot/jsk_fetch.rosinstall
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall
@@ -1,33 +1,15 @@
-- git:
-    local-name: jsk-ros-pkg/jsk_recognition
-    uri: https://github.com/jsk-ros-pkg/jsk_recognition
-    version: 1.2.2
-- git:
-    local-name: jsk-ros-pkg/jsk_pr2eus
-    uri: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
-    version: 0.3.7
+# For proximity sensor on fetch hand.
 - git:
     local-name: FA-I-sensor
     uri: https://github.com/RoboticMaterials/FA-I-sensor.git
+    version: master
+# TODO(furushchev): describe why this is needed.
 - git:
     local-name: ros-drivers/audio_common
     uri: https://github.com/furushchev/audio_common.git
     version: device
-- git:
-    local-name: ros-perception/image_pipeline
-    uri: https://github.com/ros-perception/image_pipeline
-    version: 1.12.20
-- git:
-    local-name: ros/nodelet_core
-    uri: https://github.com/ros/nodelet_core
-    version: 1.9.6
+# TODO(furushchev): describe why this is needed.
 - git:
     local-name: strands-project/mongodb_store
     uri: https://github.com/strands-project/mongodb_store.git
     version: indigo-0.1.30
-# when fetch_moveit_config 0.7.13 is released in apt, lines below can be removed.
-# please check http://packages.fetchrobotics.com/ros/ubuntu/pool/main/r/ros-indigo-fetch-moveit-config/
-- tar:
-    local-name: fetch_ros/fetch_moveit_config
-    uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_moveit_config/0.7.13-0.tar.gz
-    version: fetch_ros-release-release-indigo-fetch_moveit_config-0.7.13-0

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.kinetic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.kinetic
@@ -1,32 +1,14 @@
-- git:
-    local-name: jsk-ros-pkg/jsk_recognition
-    uri: https://github.com/jsk-ros-pkg/jsk_recognition
-    version: 1.2.2
-- git:
-    local-name: jsk-ros-pkg/jsk_pr2eus
-    uri: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
-    version: 0.3.7
+# For proximity sensor on fetch hand.
 - git:
     local-name: FA-I-sensor
     uri: https://github.com/RoboticMaterials/FA-I-sensor.git
+    version: master
+# TODO(furushchev): describe why this is needed.
 - git:
     local-name: ros-drivers/audio_common
     uri: https://github.com/furushchev/audio_common.git
     version: device
-- git:
-    local-name: ros-perception/image_pipeline
-    uri: https://github.com/ros-perception/image_pipeline
-    version: indigo
-- git:
-    local-name: ros/nodelet_core
-    uri: https://github.com/ros/nodelet_core
-    version: 1.9.6
-- git:
-    local-name: strands-project/mongodb_store
-    uri: https://github.com/strands-project/mongodb_store.git
-    version: kinetic-devel
-# when fetch_moveit_config 0.7.13 is released in apt, lines below can be removed.
-# please check http://packages.fetchrobotics.com/ros/ubuntu/pool/main/r/ros-indigo-fetch-moveit-config/
+# https://github.com/fetchrobotics/fetch_ros.git is not released on kinetic.
 - tar:
     local-name: fetch_ros/fetch_moveit_config
     uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_moveit_config/0.7.13-0.tar.gz

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.kinetic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.kinetic
@@ -1,0 +1,37 @@
+- git:
+    local-name: jsk-ros-pkg/jsk_recognition
+    uri: https://github.com/jsk-ros-pkg/jsk_recognition
+    version: 1.2.2
+- git:
+    local-name: jsk-ros-pkg/jsk_pr2eus
+    uri: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
+    version: 0.3.7
+- git:
+    local-name: FA-I-sensor
+    uri: https://github.com/RoboticMaterials/FA-I-sensor.git
+- git:
+    local-name: ros-drivers/audio_common
+    uri: https://github.com/furushchev/audio_common.git
+    version: device
+- git:
+    local-name: ros-perception/image_pipeline
+    uri: https://github.com/ros-perception/image_pipeline
+    version: indigo
+- git:
+    local-name: ros/nodelet_core
+    uri: https://github.com/ros/nodelet_core
+    version: 1.9.6
+- git:
+    local-name: strands-project/mongodb_store
+    uri: https://github.com/strands-project/mongodb_store.git
+    version: kinetic-devel
+# when fetch_moveit_config 0.7.13 is released in apt, lines below can be removed.
+# please check http://packages.fetchrobotics.com/ros/ubuntu/pool/main/r/ros-indigo-fetch-moveit-config/
+- tar:
+    local-name: fetch_ros/fetch_moveit_config
+    uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_moveit_config/0.7.13-0.tar.gz
+    version: fetch_ros-release-release-indigo-fetch_moveit_config-0.7.13-0
+- tar:
+    local-name: fetch_ros/fetch_description
+    uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_description/0.7.13-0.tar.gz
+    version: fetch_ros-release-release-indigo-fetch_description-0.7.13-0

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.kinetic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.kinetic
@@ -8,6 +8,16 @@
     local-name: ros-drivers/audio_common
     uri: https://github.com/furushchev/audio_common.git
     version: device
+# for fetcheus
+- git:
+    local-name: fetchrobotics/fetch_msgs
+    uri: https://github.com/fetchrobotics/fetch_msgs.git
+    version: master
+# for fetcheus
+- git:
+    local-name: fetchrobotics/power_msgs
+    uri: https://github.com/fetchrobotics/power_msgs.git
+    version: master
 # https://github.com/fetchrobotics/fetch_ros.git is not released on kinetic.
 # XXX: below entry must be same as .travis.rosinstall.kinetic.
 - tar:

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.kinetic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.kinetic
@@ -9,11 +9,12 @@
     uri: https://github.com/furushchev/audio_common.git
     version: device
 # https://github.com/fetchrobotics/fetch_ros.git is not released on kinetic.
+# XXX: below entry must be same as .travis.rosinstall.kinetic.
 - tar:
-    local-name: fetch_ros/fetch_moveit_config
+    local-name: fetchrobotics/fetch_ros/fetch_moveit_config
     uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_moveit_config/0.7.13-0.tar.gz
     version: fetch_ros-release-release-indigo-fetch_moveit_config-0.7.13-0
 - tar:
-    local-name: fetch_ros/fetch_description
+    local-name: fetchrobotics/fetch_ros/fetch_description
     uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_description/0.7.13-0.tar.gz
     version: fetch_ros-release-release-indigo-fetch_description-0.7.13-0


### PR DESCRIPTION
merge #913 and #872


- pass catkin build at fetcheus on kinetic
- Consistency in jsk_fetch_robot.rosinstall and .travis.rosinstall
- Cleanup jsk_fetch_robot.rosinstall
- Remove unused env for jsk_travis
- delete white space
- add .rosinstall for fetch on kinetic
- test in docker on travis