### PR TITLE
[jsk_naoqi_robot] add ros::sleep to speaking node

### DIFF
--- a/jsk_naoqi_robot/jsk_nao_startup/launch/jsk_nao_startup.launch
+++ b/jsk_naoqi_robot/jsk_nao_startup/launch/jsk_nao_startup.launch
@@ -60,5 +60,5 @@ enable_turbo_button: 0  # A button
 
   <node name="speaking_program_is_started_or_terminated"
         pkg="roseus" type="roseus"
-        args="$(find jsk_robot_startup)/lifelog/speaking-program-is-started-or-terminated.l &quot;(progn (unix:sleep 2) (good-morning) (do-until-key (ros::spin-once)))&quot;"/>
+        args="$(find jsk_robot_startup)/lifelog/speaking-program-is-started-or-terminated.l &quot;(progn (unix:sleep 2) (good-morning) (ros::spin))&quot;"/>
 </launch>

--- a/jsk_naoqi_robot/jsk_pepper_startup/launch/jsk_pepper_startup.launch
+++ b/jsk_naoqi_robot/jsk_pepper_startup/launch/jsk_pepper_startup.launch
@@ -59,5 +59,5 @@ enable_turbo_button: 0  # A button
 
   <node name="speaking_program_is_started_or_terminated"
         pkg="roseus" type="roseus"
-        args="$(find jsk_robot_startup)/lifelog/speaking-program-is-started-or-terminated.l &quot;(progn (unix:sleep 10) (good-morning) (do-until-key (ros::spin-once)))&quot;"/>
+        args="$(find jsk_robot_startup)/lifelog/speaking-program-is-started-or-terminated.l &quot;(progn (unix:sleep 3) (good-morning) (ros::spin))&quot;"/>
 </launch>


### PR DESCRIPTION
After this change, the CPU temperature of a PC which naoqi-ros is working becomes around 50.
(Before this change, it becomes over 80...)
I executed `roslaunch jsk_nao(pepper)_startup jsk_nao(pepper)_startup.launch`
I used this command to check the temperature: `cat /sys/class/thermal/thermal_zone0/temp`

Note:
After the node is killed, NAO speaks good night, but Pepper doesn't.
I don't know why. I couldn't have solved the issue yet.
