### PR TITLE
[jsk_naoqi_robot] modify dependency of package.xml

### DIFF
--- a/jsk_naoqi_robot/naoeus/package.xml
+++ b/jsk_naoqi_robot/naoeus/package.xml
@@ -11,12 +11,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>nao_apps</build_depend>
   <build_depend>naoqieus</build_depend> <!-- for robot interface -->
   <build_depend>nao_description</build_depend>
   <build_depend>rostest</build_depend>
 
-  <run_depend>nao_apps</run_depend>
+  <run_depend>nao_bringup</run_depend>
   <run_depend>naoqieus</run_depend> <!-- for robot interface -->
   <run_depend>nao_description</run_depend>
 

--- a/jsk_naoqi_robot/peppereus/package.xml
+++ b/jsk_naoqi_robot/peppereus/package.xml
@@ -11,7 +11,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>pepper_bringup</build_depend>
   <build_depend>naoqieus</build_depend> <!-- for robot interface -->
   <build_depend>pepper_description</build_depend>
   <build_depend>rostest</build_depend>


### PR DESCRIPTION
1. why I deleted the dependencies of `nao_apps` from `naoeus package.xml`

I don't think `naoeus` depends on `nao_apps`.
In addtion, `naoeus` depends on `naoqi_bridge`, which causes an error below.
% `naoqi_bridge` is a meta package. I have to learn why this dependency generates an error when compiling. I will send a pull-request to `nao_apps` when I find what is wrong. => updated: I sent a pull-request to https://github.com/ros-naoqi/nao_robot/pull/37
```
Abandoned <<< nao_apps                            [ Depends on unknown jobs: naoqi_bridge ]
Abandoned <<< naoeus                              [ Depends on unknown jobs: naoqi_bridge ]
```
whole log is below:
```
kochigami@kochigami-ThinkPad-T450:~/catkin_ws/src/jsk_robot/jsk_naoqi_robot/naoeus$ catkin bt
==> Expanding alias 'bt' from 'catkin bt' to 'catkin b --this'
==> Expanding alias 'b' from 'catkin b --this' to 'catkin build --this'
--------------------------------------------------------------
Profile:                     default
Extending:          [cached] /opt/ros/indigo
Workspace:                   /home/kochigami/catkin_ws
--------------------------------------------------------------
Source Space:       [exists] /home/kochigami/catkin_ws/src
Log Space:          [exists] /home/kochigami/catkin_ws/logs
Build Space:        [exists] /home/kochigami/catkin_ws/build
Devel Space:        [exists] /home/kochigami/catkin_ws/devel
Install Space:      [unused] /home/kochigami/catkin_ws/install
DESTDIR:            [unused] None
--------------------------------------------------------------
Devel Space Layout:          linked
Install Space Layout:        None
--------------------------------------------------------------
Additional CMake Args:       None
Additional Make Args:        None
Additional catkin Make Args: None
Internal Make Job Server:    True
Cache Job Environments:      False
--------------------------------------------------------------
Whitelisted Packages:        None
Blacklisted Packages:        None
--------------------------------------------------------------
Workspace configuration appears valid.
--------------------------------------------------------------
[build] Found '83' packages in 0.0 seconds.                                    
[build] Package table is up to date.                                           
Abandoned <<< nao_apps                            [ Depends on unknown jobs: naoqi_bridge ]
Abandoned <<< naoeus                              [ Depends on unknown jobs: naoqi_bridge ]
Starting  >>> nao_description                                                  
Starting  >>> nao_interaction_msgs                                             
Starting  >>> naoqi_apps                                                       
Starting  >>> naoqi_bridge_msgs                                                
Finished  <<< nao_description                     [ 0.2 seconds ]              
Finished  <<< naoqi_apps                          [ 0.2 seconds ]              
Starting  >>> naoqi_tools                                                      
Finished  <<< naoqi_tools                         [ 0.3 seconds ]              
Finished  <<< nao_interaction_msgs                [ 1.3 seconds ]              
Finished  <<< naoqi_bridge_msgs                   [ 3.4 seconds ]              
Starting  >>> naoqi_driver                                                     
Starting  >>> naoqi_driver_py                                                  
Starting  >>> naoqi_pose                                                       
Finished  <<< naoqi_driver_py                     [ 0.2 seconds ]              
Starting  >>> naoqi_sensors_py                                                 
Finished  <<< naoqi_pose                          [ 0.2 seconds ]              
Finished  <<< naoqi_sensors_py                    [ 0.3 seconds ]              
Finished  <<< naoqi_driver                        [ 0.6 seconds ]              
Starting  >>> naoqieus                                                         
Finished  <<< naoqieus                            [ 0.2 seconds ]              
[build] Summary: 10 of 12 packages succeeded.                                  
[build]   Ignored:   71 packages were skipped or are blacklisted.              
[build]   Warnings:  None.                                                     
[build]   Abandoned: 2 packages were abandoned.                                
[build]   Failed:    None.                                                     
[build] Runtime: 5.1 seconds total.     
```
2. why I deleted `pepper_bringup` from `build dependency of peppereus`
I don't think `peppereus` depends on `pepper_bringup` when it is built.

3. why I added `nao_bringup` to `run dependency of naoeus`
I just refferred to `peppereus package.xml`, however, at the same time I'm not sure whether this is required.
