### PR TITLE
[jsk_robot_startup/base_trajectory_logger.py] Modified threshold of pos and theta.

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/base_trajectory_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/base_trajectory_logger.py
@@ -126,7 +126,7 @@ class BaseTrajectoryLogger(LoggerBase):
                 self.latest_pose = self.get_pose_from_tf()
             if self.latest_pose:
                 if prev_pose:
-                    dt = (rospy.Time.now() - self.latest_pose.header.stamp).to_sec()
+                    dt = (rospy.Time.now() - prev_pose.header.stamp).to_sec()
                     if dt > 0:
                         thre = 0.1 + 1.0 / dt
                         diffp, diffr = diff_pose(

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/base_trajectory_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/base_trajectory_logger.py
@@ -10,16 +10,23 @@ from geometry_msgs.msg import PoseWithCovarianceStamped
 from logger_base import LoggerBase
 
 
+def quaternion_distance(q1, q2):
+    diff_theta = 2.0 * np.arccos(
+        np.abs(np.dot(q1, q2)))
+    return diff_theta
+
+
 def diff_pose(p1, p2):
     pos1 = np.array([p1.position.x, p1.position.y, p1.position.z])
     pos2 = np.array([p2.position.x, p2.position.y, p2.position.z])
-    rot1 = np.array([p1.orientation.x, p1.orientation.y,
+    q1 = np.array([p1.orientation.x, p1.orientation.y,
                      p1.orientation.z, p1.orientation.w])
-    rot2 = np.array([p2.orientation.x, p2.orientation.y,
+    q2 = np.array([p2.orientation.x, p2.orientation.y,
                      p2.orientation.z, p2.orientation.w])
+    diff_pos = pos1 - pos2
     normp = np.linalg.norm(pos1 - pos2)
-    normr = np.linalg.norm(rot1 - rot2)
-    return normp, normr
+    diff_theta = quaternion_distance(q1, q2)
+    return normp, diff_theta
 
 
 class BaseTrajectoryLogger(LoggerBase):
@@ -28,6 +35,8 @@ class BaseTrajectoryLogger(LoggerBase):
         self.update_rate = rospy.get_param("~update_rate", 1.0)
         self.use_amcl = rospy.get_param("~use_amcl", True)
         self.persistent = rospy.get_param("~persistent", True)
+        self.thre = rospy.get_param('~thre', 5.0)
+        self.rthre = rospy.get_param('~rthre', 1.0)
 
         if self.use_amcl:
             self.map_frame = rospy.get_param("/amcl/global_frame_id")
@@ -120,6 +129,8 @@ class BaseTrajectoryLogger(LoggerBase):
         meta = dict()
         if self.persistent:
             meta.update({"persistent": True})
+        thre = self.thre
+        rthre = self.rthre
         while not rospy.is_shutdown():
             if not self.use_amcl:
                 rospy.logdebug("Getting latest pose from tf")
@@ -128,12 +139,15 @@ class BaseTrajectoryLogger(LoggerBase):
                 if prev_pose:
                     dt = (rospy.Time.now() - prev_pose.header.stamp).to_sec()
                     if dt > 0:
-                        thre = 0.1 + 1.0 / dt
                         diffp, diffr = diff_pose(
                             prev_pose.pose.pose, self.latest_pose.pose.pose)
+                        diffp *= 1000.0
+                        diffr = np.rad2deg(diffr)
                         rospy.logdebug(
-                            "diffthre: %f, diffpos: %f, diffrot: %f" % (thre, diffp, diffr))
-                        if thre < diffp or thre / 2.0 < diffr:
+                            "thre: %.2f[mm], rthre: %.2f[deg], "
+                            "diffpos: %.2f[mm], diffrot: %.2f[deg]"
+                            % (thre, rthre, diffp, diffr))
+                        if thre < diffp or rthre < diffr:
                             self.insert(self.latest_pose, meta=meta)
                             prev_pose = self.latest_pose
                             rospy.loginfo("Inserted latest pose")

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/base_trajectory_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/base_trajectory_logger.py
@@ -35,8 +35,8 @@ class BaseTrajectoryLogger(LoggerBase):
         self.update_rate = rospy.get_param("~update_rate", 1.0)
         self.use_amcl = rospy.get_param("~use_amcl", True)
         self.persistent = rospy.get_param("~persistent", True)
-        self.thre = rospy.get_param('~thre', 5.0)
-        self.rthre = rospy.get_param('~rthre', 1.0)
+        self.thre = rospy.get_param('~thre', 0.005)
+        self.rthre = rospy.get_param('~rthre', np.deg2rad(1.0))
 
         if self.use_amcl:
             self.map_frame = rospy.get_param("/amcl/global_frame_id")
@@ -141,11 +141,9 @@ class BaseTrajectoryLogger(LoggerBase):
                     if dt > 0:
                         diffp, diffr = diff_pose(
                             prev_pose.pose.pose, self.latest_pose.pose.pose)
-                        diffp *= 1000.0
-                        diffr = np.rad2deg(diffr)
                         rospy.logdebug(
-                            "thre: %.2f[mm], rthre: %.2f[deg], "
-                            "diffpos: %.2f[mm], diffrot: %.2f[deg]"
+                            "thre: %.2f[m], rthre: %.2f[rad], "
+                            "diffpos: %.2f[m], diffrot: %.2f[rad]"
                             % (thre, rthre, diffp, diffr))
                         if thre < diffp or rthre < diffr:
                             self.insert(self.latest_pose, meta=meta)


### PR DESCRIPTION
This PR fixed the threshold of base_trajectory update.

Before this PR, calculating threshold become large value,
because ```dt``` is small.

https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/base_trajectory_logger.py#L129
https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/base_trajectory_logger.py#L131

Also, we should use threshold value that easy to understand.
Before this PR, the function ```diff_pose``` returns  the difference postion in mm order and absolute distance of quaternion (this value's unit is not intuitive) .
Therefore, I modified ```diff_pose``` to return angle[rad] of two poses, changed ```diff_pos``` in mm order, changed ```diff_theta``` in deg order, 
 and add param of ```thre``` and ```rthre```.





