### PR TITLE
[fetch] Add grasp functions to fetch-robot class

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch-utils.l
+++ b/jsk_fetch_robot/fetcheus/fetch-utils.l
@@ -14,5 +14,16 @@
    (send-super* :inverse-kinematics target-coords
                 :move-target move-target
                 :link-list link-list
-                args)
-   ))
+                args))
+  (:go-grasp
+    (&key (pos 0)) ;; pos is between 0.0 and 0.1
+      (send self :l_gripper_finger_joint :joint-angle (/ (* pos 1000) 2)) ;; m -> mm
+      (send self :r_gripper_finger_joint :joint-angle (/ (* pos 1000) 2))
+      (return-from :go-grasp t))
+  (:start-grasp
+    ()
+    (send self :go-grasp :pos 0))
+  (:stop-grasp
+    ()
+    (send self :go-grasp :pos 0.1))
+  )


### PR DESCRIPTION
`fetch-robot`のクラスに、グリッパを動かす関数を追加しました。
`fetch-interface`のクラスと同じように引数を与えられるようにしました。

`:start-grasp`
![fetch_start_grasp](https://user-images.githubusercontent.com/19769486/45148069-6391a180-b201-11e8-83cc-cef08135ec63.png)

`:stop-grasp`
![fetch_stop_grasp](https://user-images.githubusercontent.com/19769486/45148083-6db3a000-b201-11e8-97f6-31c17b397eae.png)
