### PR TITLE
[fetch] Add pqp collision detection feature to grasp functions

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch-utils.l
+++ b/jsk_fetch_robot/fetcheus/fetch-utils.l
@@ -24,6 +24,8 @@
    ()
    (+ (/ (send self :l_gripper_finger_joint :joint-angle) 1000.0) ;; mm -> m
       (/ (send self :r_gripper_finger_joint :joint-angle) 1000.0)))
+  ;; this function is mainly copied from https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/master/pr2eus/pr2-utils.l#L280
+  ;; in the future, we should integrate these two codes into upstream code.
   (:start-grasp
    (&optional arg1 arg2)
    (let ((angle 0) target)
@@ -55,6 +57,8 @@
          (send self :grasping-obj target)
          (send (send self :r_gripper_finger_joint) :parent-link :assoc target)
          )))))
+  ;; this function is mainly copied from https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/master/pr2eus/pr2-utils.l#L332
+  ;; in the future, we should integrate these two codes into upstream code.
   (:stop-grasp
    (&optional arg1 arg2)
    (let (angle target finger-joint)

--- a/jsk_fetch_robot/fetcheus/fetch-utils.l
+++ b/jsk_fetch_robot/fetcheus/fetch-utils.l
@@ -20,10 +20,71 @@
       (send self :l_gripper_finger_joint :joint-angle (/ (* pos 1000) 2)) ;; m -> mm
       (send self :r_gripper_finger_joint :joint-angle (/ (* pos 1000) 2))
       (return-from :go-grasp t))
+  (:gripper-angle
+   ()
+   (+ (/ (send self :l_gripper_finger_joint :joint-angle) 1000.0) ;; mm -> m
+      (/ (send self :r_gripper_finger_joint :joint-angle) 1000.0)))
   (:start-grasp
-    ()
-    (send self :go-grasp :pos 0))
+   (&optional arg1 arg2)
+   (let ((angle 0) target)
+     (cond
+      ((or (derivedp arg1 body) (derivedp arg1 cascaded-coords))
+       (setq target arg1)
+       (let ((gripper-angle (send self :gripper-angle)))
+         (while t
+           (send self :go-grasp :pos (- (send self :gripper-angle) 0.001))
+           (when (= (send self :gripper-angle) 0)
+             (send self :go-grasp :pos gripper-angle)
+             (return)
+             )
+           (when  (or (< 0 (pqp-collision-check
+                            (elt (send self :rarm :gripper :links) 0) target)) ;; l_gripper_finger_link
+                      (< 0 (pqp-collision-check
+                            (elt (send self :rarm :gripper :links) 1) target))) ;; r_gripper_finger_link
+             (send self :go-grasp :pos (+ (send self :gripper-angle) 0.001))
+             (ros::ros-info "catched:~A" target)
+             (send self :grasping-obj target)
+             (send (send self :r_gripper_finger_joint) :parent-link :assoc target)
+             (return)
+             ))))
+      (t
+       (when (numberp arg1)
+         (setq angle arg1 target arg2))
+       (send self :go-grasp :pos angle)
+       (when target
+         (send self :grasping-obj target)
+         (send (send self :r_gripper_finger_joint) :parent-link :assoc target)
+         )))))
   (:stop-grasp
-    ()
-    (send self :go-grasp :pos 0.1))
+   (&optional arg1 arg2)
+   (let (angle target finger-joint)
+     (cond
+      ((and (numberp arg1) (derivedp arg2 body))
+       (setq angle arg1 target arg2)
+       (when (eq (send self :grasping-obj) target)
+         (send self :grasping-obj nil)
+         (send (send self :r_gripper_finger_joint) :parent-link :dissoc target))
+       (send self :go-grasp :pos angle))
+      ((numberp arg1)
+       (setq angle arg1)
+       (send self :go-grasp :pos angle))
+      (t
+       (when (derivedp arg1 body) (setq target arg1))
+       (when (null target)
+         (setq target (send self :grasping-obj)))
+       (send self :grasping-obj nil)
+       (send (send self :r_gripper_finger_joint) :parent-link :dissoc target)
+       (send self :go-grasp :pos 0.1)
+         ))))
+  (:grasping-obj
+   (&optional (target t))
+   (cond
+    ((or (derivedp target body) (derivedp target cascaded-coords))
+     (setf (get self 'rarm-grasping-obj) target))
+    (target
+     (get self 'rarm-grasping-obj))
+    ((null target) ;; setq grasping-obj nil
+     (setf (get self 'rarm-grasping-obj) nil))
+    (t
+     )))
   )


### PR DESCRIPTION
I added pqp collision detection to grasp functions of `fetch-robot` class. 
This Pull Request is based on https://github.com/jsk-ros-pkg/jsk_robot/pull/964#issuecomment-419281444.

The pqp collision detection with `fetch` is shown below:
[before grasping]
![fetch-grasp1](https://user-images.githubusercontent.com/19769486/45204103-330d3e80-b2b9-11e8-8ef2-681833fbf7a0.png)

[grasping]
![fetch-grasp2](https://user-images.githubusercontent.com/19769486/45204108-37d1f280-b2b9-11e8-8b6b-5cecd9a9387f.png)

[moving object]
![fetch-grasp3](https://user-images.githubusercontent.com/19769486/45204112-3b657980-b2b9-11e8-8038-7700f16f76ea.png)

test code is as follows:
```lisp
(load "package://fetcheus/fetch-utils.l")

(defun test()
  (let ((cube (make-cube 30 30 30)))
    (fetch)
    (send *fetch* :stop-grasp)
    (send cube :locate (send (send *fetch* :rarm :end-coords) :worldpos))
    (send cube :rotate 1.0 :z)
    (send cube :set-color #f(1 0 0))
    (objects (list *fetch* cube))
    (do-until-key
     (unix:sleep 1))
    (send *fetch* :start-grasp cube)
    (send *irtviewer* :draw-objects :flush t)
    (do-until-key
     (unix:sleep 1))
    (send *fetch* :rarm :move-end-pos #f(400 0 100) :world)
    (send *irtviewer* :draw-objects :flush t)
    ))
```