### PR TITLE
[fetch] Enable to use diagnostic aggregator on fetch

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/fetch_analyzers.yaml
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/fetch_analyzers.yaml
@@ -1,0 +1,134 @@
+pub_rate: 1.0
+base_path: '' # Optional, prepended to all diagnostic output
+analyzers:
+  sound_play:
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: SoundPlay
+    startswith: sound_play
+  breakers:
+    type: diagnostic_aggregator/AnalyzerGroup
+    path: Breakers
+    analyzers:
+      base_breaker:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Base Breaker
+        startswith: base_breaker
+      battery_breaker:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Battery Breaker
+        startswith: battery_breaker
+      computer_breaker:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Computer Breaker
+        startswith: computer_breaker
+      supply_breaker:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Supply Breaker
+        startswith: supply_breaker
+      arm_breaker:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Arm Breaker
+        startswith: arm_breaker
+      gripper_breaker:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Gripper Breaker
+        startswith: gripper_breaker
+  motors:
+    type: diagnostic_aggregator/AnalyzerGroup
+    path: Motor Control Boards
+    analyzers:
+      l_wheel:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Left Wheel
+        startswith: l_wheel
+      r_wheel:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Right Wheel
+        startswith: r_wheel
+      shoulder_pan:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Shoulder Pan Joint
+        startswith: shoulder_pan
+      shoulder_lift:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Shoulder Lift Joint
+        startswith: shoulder_lift
+      upperarm_roll:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Upperarm Roll Joint
+        startswith: upperarm_roll
+      elbow_flex:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Elbow Flex Joint
+        startswith: elbow_flex
+      forearm_roll:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Forearm Roll Joint
+        startswith: forearm_roll
+      wrist_flex:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Wrist Flex Joint
+        startswith: wrist_flex
+      wrist_roll:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Wrist Roll Joint
+        startswith: wrist_roll
+      head_tilt:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Head Tilt Joint
+        startswith: head_tilt
+      head_pan:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Head Pan Joint
+        startswith: head_pan
+      torso_lift:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Torso Lift Joint
+        startswith: torso_lift
+      gripper:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Gripper Joint
+        startswith: gripper_board
+  sensors:
+    type: diagnostic_aggregator/AnalyzerGroup
+    path: Sensors
+    analyzers:
+      base_breaker:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Sick TIM551 Laser
+        startswith: sick_tim
+      camera:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Head Camera
+        timeout: 5.0
+        startswith: 'throttle_nodelet_manager'
+        num_items: 2
+      imu:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: IMU
+        timeout: 5.0
+        contains: ['IMU']
+      #head_camera:
+      #  type: diagnostic_aggregator/GenericAnalyzer
+      #  path:
+      #  startswith:
+  peripherals:
+    type: diagnostic_aggregator/AnalyzerGroup
+    path: Peripherals
+    analyzers:
+      joy:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: PS3 Controller
+        find_and_remove_prefix: "joy:"
+  system:
+    type: diagnostic_aggregator/AnalyzerGroup
+    path: System
+    analyzers:
+      mainboard:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Mainboard
+        startswith: Mainboard
+      charger:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Charger
+        startswith: Charger

--- a/jsk_fetch_robot/jsk_fetch_startup/config/fetch_analyzers.yaml
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/fetch_analyzers.yaml
@@ -132,3 +132,15 @@ analyzers:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Charger
         startswith: Charger
+  cpu:
+    type: diagnostic_aggregator/AnalyzerGroup
+    path: CPU
+    analyzers:
+      mainboard:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Temperature
+        startswith: 'my_machine CPU Temperature'
+      charger:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: CPU Usage
+        startswith: 'my_machine CPU Usage'

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -36,6 +36,9 @@
     <rosparam command="load" file="$(find jsk_fetch_startup)/config/fetch_analyzers.yaml" />
   </node>
 
+  <!-- publish CPU status to diagnostics -->
+  <include file="$(find pr2_computer_monitor)/demo/cpu_monitor.launch"/>
+
   <!-- app manager -->
   <include file="$(find jsk_robot_startup)/lifelog/app_manager.launch">
     <arg name="applist" value="$(find jsk_fetch_startup)/apps"/>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -30,6 +30,12 @@
     <arg name="map_frame" value="$(arg map_frame)" />
   </include>
 
+  <!-- diagnostic aggregator -->
+  <node pkg="diagnostic_aggregator" type="aggregator_node"
+        name="diag_agg" args="CPP" output="screen" >
+    <rosparam command="load" file="$(find jsk_fetch_startup)/config/fetch_analyzers.yaml" />
+  </node>
+
   <!-- app manager -->
   <include file="$(find jsk_robot_startup)/lifelog/app_manager.launch">
     <arg name="applist" value="$(find jsk_fetch_startup)/apps"/>

--- a/jsk_fetch_robot/jsk_fetch_startup/package.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/package.xml
@@ -36,6 +36,9 @@
   <run_depend>topic_tools</run_depend>
   <run_depend>fetch_teleop</run_depend>
 
+  <!-- for diagnostic aggregator -->
+  <run_depend>diagnostic_aggregator</run_depend>
+
   <test_depend>rostest</test_depend>
 
   <export>


### PR DESCRIPTION
This Pull Request enables to publish `/diagnostic_agg` topic by default on `fetch` robot.
(This is based on https://github.com/fetchrobotics/fetch_robots/blob/indigo-devel/fetch_bringup/config/analyzers.yaml)

You can view this information by typing the command below:
```
rosrun rqt_robot_monitor rqt_robot_monitor
```

![diagnostic_agg](https://user-images.githubusercontent.com/19769486/47426019-ff359c00-d7c6-11e8-90cd-4cc2a6ef2d92.png)
