### PR TITLE
[fetch] Change threshold of CPU usage warning

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -37,7 +37,14 @@
   </node>
 
   <!-- publish CPU status to diagnostics -->
-  <include file="$(find pr2_computer_monitor)/demo/cpu_monitor.launch"/>
+  <node name="cpu_monitor" pkg="pr2_computer_monitor" type="cpu_monitor.py"
+        args="--diag-hostname=my_machine" >
+    <param name="check_ipmi_tool" value="false" type="bool" />
+    <param name="enforce_clock_speed" value="false" type="bool" />
+    <param name="num_cores" value="-1" type="int" />
+    <param name="load1_threshold" value="7.0"/>
+    <param name="load5_threshold" value="5.0"/>
+  </node>
 
   <!-- app manager -->
   <include file="$(find jsk_robot_startup)/lifelog/app_manager.launch">


### PR DESCRIPTION
In pr2_computer_monitor, default value of `load1/5_threshold` is very low, so fetch often says 'CPU usage is too high'. (very noisy)
I reduced the threshold in this Pull Request, and now fetch do not speak too much.
I will keep my eyes on it for a while.