### PR TITLE
[fetch] Restart sixad by upstart, when PS controller fails to connect to fetch

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/restart-sixad.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/restart-sixad.conf
@@ -1,0 +1,6 @@
+description "restart sixad when bluetooth connection is failed."
+author "Naoya Yamaguchi <yamaguchi@jsk.imi.i.u-tokyo.ac.jp>"
+start on runlevel [2345]
+stop on runlevel [!2345]
+respawn
+exec sudo /home/fetch/restart-sixad.py

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/restart-sixad.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/restart-sixad.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import linecache
+import os
+from subprocess import call
+import syslog
+import time
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+log_file = '/var/log/syslog'
+BASEDIR = os.path.abspath(os.path.dirname(log_file))
+
+
+class ChangeHandler(FileSystemEventHandler):
+    def on_modified(self, event):
+        num_lines = sum(1 for line in open(log_file))  # how many lines in the log file
+        for i in range(5):  # check latest 5 lines
+            target_line = linecache.getline(log_file, num_lines - i)
+            if ('bluetoothd' in target_line) and ("Can't find device agent" in target_line):
+                syslog.syslog(syslog.LOG_INFO, 'restart sixad service')
+                call(['service', 'sixad', 'restart'])  # restart sixad
+        linecache.clearcache()
+
+
+if __name__ in '__main__':
+    while 1:
+        event_handler = ChangeHandler()
+        observer = Observer()
+        observer.schedule(event_handler, BASEDIR, recursive=True)
+        observer.start()
+        try:
+            while True:
+                time.sleep(3)
+        except KeyboardInterrupt:
+            observer.stop()
+        observer.join()


### PR DESCRIPTION
Problem
======
Sometimes, PS controller fails to connect to fetch in spite of pushing deadman button (the center button on PS controller).

What I did
========
In this Pull Request, I add a script and a upstart config file for `restart-sixad` service.
With this service, bluetooth connection between the PS controller and `fetch` automatically recovers when the bluetooth pairing fails.

Execution log
============

First, stop `restart-sixad` service which I added in this Pull Request.
```
$ sudo service restart-sixad stop
restart-sixad stop/waiting
```
Then I pushed PS button, but bluetooth connection between controller and fetch is failed.
```
$ sudo tail -f /var/log/syslog
Nov  1 14:50:49 fetch15 bluetoothd[1627]: Refusing input device connect: No such file or directory (2)
Nov  1 14:50:49 fetch15 bluetoothd[1627]: Can't find device agent
Nov  1 14:50:49 fetch15 bluetoothd[1627]: input: authorization for D8:FC:93:0F:16:57 failed: Operation not permitted (-1)
Nov  1 14:50:54 fetch15 bluetoothd[1627]: Refusing input device connect: No such file or directory (2)
Nov  1 14:50:54 fetch15 bluetoothd[1627]: Can't find device agent
Nov  1 14:50:54 fetch15 bluetoothd[1627]: input: authorization for D8:FC:93:0F:16:57 failed: Operation not permitted (-1)
```
Next, I started `restart-sixad` service which I added in this Pull Request.
```
$ sudo service restart-sixad start
restart-sixad start/running, process 14379
```
Finally, bluetooth connection succeeded and PS controller vibrated.
```
Nov  1 14:50:59 fetch15 bluetoothd[1627]: Refusing input device connect: No such file or directory (2)
Nov  1 14:50:59 fetch15 bluetoothd[1627]: Can't find device agent
Nov  1 14:50:59 fetch15 bluetoothd[1627]: input: authorization for D8:FC:93:0F:16:57 failed: Operation not permitted (-1)
Nov  1 14:51:02 fetch15 restart-sixad.py: restart sixad service
Nov  1 14:51:02 fetch15 sixad-bin[1614]: Done
Nov  1 14:51:02 fetch15 kernel: [  195.496614] init: sixad main process (994) killed by TERM signal
Nov  1 14:51:02 fetch15 restart-sixad.py: restart sixad service
Nov  1 14:51:02 fetch15 kernel: [  195.518991] init: sixad main process (14454) killed by TERM signal
Nov  1 14:51:04 fetch15 kernel: [  197.572380] init: bluetooth main process (1627) killed by KILL signal
Nov  1 14:51:04 fetch15 kernel: [  197.572388] init: bluetooth main process ended, respawning
Nov  1 14:51:04 fetch15 bluez: Stopping uarts
Nov  1 14:51:04 fetch15 sixad-bin[14548]: started
Nov  1 14:51:04 fetch15 sixad-bin[14548]: sixad started, press the PS button now
Nov  1 14:51:04 fetch15 bluez: Stopping rfcomm
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Bluetooth daemon 4.101
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Starting SDP server
Nov  1 14:51:04 fetch15 bluetoothd[14553]: DIS cannot start: GATT is disabled
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Failed to init deviceinfo plugin
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Failed to init proximity plugin
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Failed to init time plugin
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Failed to init alert plugin
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Failed to init thermometer plugin
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Failed to init gatt_example plugin
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Bluetooth Management interface initialized
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Adapter /org/bluez/14553/hci0 has been enabled
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Unknown command complete for opcode 19
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Endpoint registered: sender=:1.83 path=/MediaEndpoint/HFPAG
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Endpoint registered: sender=:1.83 path=/MediaEndpoint/HFPHS
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Endpoint registered: sender=:1.83 path=/MediaEndpoint/A2DPSource
Nov  1 14:51:04 fetch15 bluetoothd[14553]: Endpoint registered: sender=:1.83 path=/MediaEndpoint/A2DPSink
Nov  1 14:51:06 fetch15 sixad-sixaxis[14601]: started
Nov  1 14:51:06 fetch15 kernel: [  199.405754] input: PLAYSTATION(R)3 Controller (FC:62:B9:0C:88:D0) as /devices/virtual/input/input9
Nov  1 14:51:06 fetch15 sixad-sixaxis[14601]: Connected 'PLAYSTATION(R)3 Controller (FC:62:B9:0C:88:D0)' [Battery 05]
```
