### PR TITLE
[fetch] Enable to speak both japanese and english during navigation

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -14,7 +14,11 @@
 
   <!-- add jsk startups -->
   <node pkg="jsk_fetch_startup" name="warning" type="warning.py" respawn="true" />
-  <node pkg="jsk_fetch_startup" name="nav_speak" type="nav_speak.py" respawn="true" />
+  <node pkg="jsk_fetch_startup" name="nav_speak" type="nav_speak.py" respawn="true" >
+    <rosparam>
+      lang: japanese
+    </rosparam>
+  </node>
   <node if="$(arg boot_sound)" pkg="jsk_fetch_startup" name="boot_sound" type="boot_sound.py" />
 
   <!-- japanese speech node -->

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/nav_speak.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/nav_speak.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import rospy
 import time
 
 from sound_play.libsoundplay import SoundClient
+from sound_play.msg import SoundRequestActionGoal
 from move_base_msgs.msg import MoveBaseActionGoal, MoveBaseActionResult
 from actionlib_msgs.msg import GoalStatus
 
@@ -25,6 +27,10 @@ class NavSpeak:
         self.move_base_goal_sub = rospy.Subscriber("/move_base/goal", MoveBaseActionGoal, self.move_base_goal_callback, queue_size = 1)
         self.move_base_result_sub = rospy.Subscriber("/move_base/result", MoveBaseActionResult, self.move_base_result_callback, queue_size = 1)
         self.sound = SoundClient()
+        self.lang = "japanese"  # speak japanese by default
+        if rospy.has_param("/nav_speak/lang"):
+            self.lang = rospy.get_param("/nav_speak/lang")
+        self.pub = rospy.Publisher('/robotsound_jp/goal', SoundRequestActionGoal, queue_size=1)
 
     def move_base_goal_callback(self, msg):
         self.sound.play(2)
@@ -32,16 +38,41 @@ class NavSpeak:
     def move_base_result_callback(self, msg):
         text = "{}: {}".format(goal_status(msg.status.status), msg.status.text)
         rospy.loginfo(text)
+        if self.lang == "japanese":  # speak japanese
+            sound_goal = SoundRequestActionGoal()
+            sound_goal.goal_id.stamp = rospy.Time.now()
+            sound_goal.goal.sound_request.sound = -3
+            sound_goal.goal.sound_request.command = 1
+            sound_goal.goal.sound_request.volume = 1.0
+            sound_goal.goal.sound_request.arg2 = "jp"
         if msg.status.status == GoalStatus.SUCCEEDED:
             self.sound.play(1)
+            time.sleep(1)
+            if self.lang == "japanese":
+                sound_goal.goal.sound_request.arg = "到着しました"
+                self.pub.publish(sound_goal)
+            else:
+                self.sound.say(text)
         elif msg.status.status == GoalStatus.PREEMPTED:
             self.sound.play(2)
+            time.sleep(1)
+            if self.lang == "japanese":
+                sound_goal.goal.sound_request.arg = "別のゴールがセットされました"
+                self.pub.publish(sound_goal)
+            else:
+                self.sound.say(text)
         elif msg.status.status == GoalStatus.ABORTED:
             self.sound.play(3)
+            time.sleep(1)
+            if self.lang == "japanese":
+                sound_goal.goal.sound_request.arg = "中断しました"
+                self.pub.publish(sound_goal)
+            else:
+                self.sound.say(text)
         else:
             self.sound.play(4)
-        time.sleep(1)
-        self.sound.say(text)
+            time.sleep(1)
+            self.sound.say(text)
 
 if __name__ == "__main__":
     global sound


### PR DESCRIPTION
In this Pull Request, I enable `fetch` to speak both `Japanese` and `English` during navigation.

The spoken language is `Japanese` by default, but it can be specified by `/nav_speak/lang` parameter.
