### PR TITLE
[jsk_fetch_startup] Add settings for twitter

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -46,6 +46,9 @@
     <param name="load5_threshold" value="5.0"/>
   </node>
 
+  <!-- twitter -->
+  <include file="$(find jsk_fetch_startup)/launch/fetch_tweet.launch" />
+
   <!-- app manager -->
   <include file="$(find jsk_robot_startup)/lifelog/app_manager.launch">
     <arg name="applist" value="$(find jsk_fetch_startup)/apps"/>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_tweet.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_tweet.launch
@@ -1,0 +1,14 @@
+<launch>
+
+  <include file="$(find jsk_fetch_startup)/jsk_fetch.machine" />
+
+  <include file="$(find jsk_robot_startup)/lifelog/tweet.launch">
+    <arg name="robot_name" value="fetch15"/>
+
+    <arg name="machine" value="localhost"/>
+    <arg name="output" value="screen"/>
+
+    <arg name="account_info" value="/var/lib/robot/twitter_account_fetch15jsk.yaml" />
+  </include>
+
+</launch>


### PR DESCRIPTION
With this patch, fetch can tweet by publishing std_msgs/String to  ```/tweet```.
Fetch15's account is here.
https://twitter.com/fetch15jsk
