### PR TITLE
Use 'git' instead of 'tar' in jsk_fetch.rosinstall.kinetic

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.kinetic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.kinetic
@@ -20,11 +20,7 @@
     version: indigo-devel
 # https://github.com/fetchrobotics/fetch_ros.git is not released on kinetic.
 # XXX: below entry must be same as .travis.rosinstall.kinetic.
-- tar:
-    local-name: fetchrobotics/fetch_ros/fetch_moveit_config
-    uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_moveit_config/0.7.13-0.tar.gz
-    version: fetch_ros-release-release-indigo-fetch_moveit_config-0.7.13-0
-- tar:
-    local-name: fetchrobotics/fetch_ros/fetch_description
-    uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_description/0.7.13-0.tar.gz
-    version: fetch_ros-release-release-indigo-fetch_description-0.7.13-0
+- git:
+    local-name: fetchrobotics/fetch_ros
+    uri: https://github.com/fetchrobotics/fetch_ros.git
+    version: 0.7.14


### PR DESCRIPTION
Before, `tar file` is installed by `wstool`, but `tar file` is inconvenient because it is not `git repository`.
After this pull request, `git repository` will be installed by `wstool`.

Also, from version `0.7.14`, my commit (https://github.com/fetchrobotics/fetch_ros/commit/c0bc8bc62a24c60fd44351cd2a251e9b4836aa4e) is merged and fetch's amcl will be improved.