### PR TITLE
[fetch] Make .rosinstall for both robot PC and user PC

### DIFF
--- a/jsk_fetch_robot/README.md
+++ b/jsk_fetch_robot/README.md
@@ -43,9 +43,9 @@ mkdir -p catkin_ws/src
 cd  catkin_ws
 wstool init src
 if [ $ROS_DISTRO = "indigo" ]; then
-  wstool merge -t src https://raw.githubusercontent.com/jsk-ros-pkg/jsk_robot/master/jsk_fetch_robot/jsk_fetch.rosinstall
+  wstool merge -t src https://raw.githubusercontent.com/jsk-ros-pkg/jsk_robot/master/jsk_fetch_robot/jsk_fetch_user.rosinstall.indigo
 elif [ $ROS_DISTRO = "kinetic" ]; then
-  wstool merge -t src https://raw.githubusercontent.com/jsk-ros-pkg/jsk_robot/master/jsk_fetch_robot/jsk_fetch.rosinstall.kinetic
+  wstool merge -t src https://raw.githubusercontent.com/jsk-ros-pkg/jsk_robot/master/jsk_fetch_robot/jsk_fetch_user.rosinstall.kinetic
 fi
 wstool update -t src
 source /opt/ros/$ROS_DISTRO/setup.bash

--- a/jsk_fetch_robot/jsk_fetch.rosinstall
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall
@@ -1,3 +1,5 @@
+# This file is for work space in fetch PC.
+
 # For proximity sensor on fetch hand.
 - git:
     local-name: FA-I-sensor
@@ -13,3 +15,11 @@
     local-name: strands-project/mongodb_store
     uri: https://github.com/strands-project/mongodb_store.git
     version: indigo-0.1.30
+- git:
+    local-name: ros-perception/image_pipeline
+    uri: https://github.com/ros-perception/image_pipeline.git
+    version: 1.12.20
+- git:
+    local-name: ros/nodelet_core
+    uri: https://github.com/ros/nodelet_core.git
+    version: 1.9.6

--- a/jsk_fetch_robot/jsk_fetch_user.rosinstall.indigo
+++ b/jsk_fetch_robot/jsk_fetch_user.rosinstall.indigo
@@ -1,0 +1,12 @@
+# This file is for work space in indigo user PC.
+
+# For proximity sensor on fetch hand.
+- git:
+    local-name: FA-I-sensor
+    uri: https://github.com/RoboticMaterials/FA-I-sensor.git
+    version: master
+# TODO(furushchev): describe why this is needed.
+- git:
+    local-name: ros-drivers/audio_common
+    uri: https://github.com/furushchev/audio_common.git
+    version: device

--- a/jsk_fetch_robot/jsk_fetch_user.rosinstall.kinetic
+++ b/jsk_fetch_robot/jsk_fetch_user.rosinstall.kinetic
@@ -1,3 +1,5 @@
+# This file is for work space in kinetic user PC.
+
 # For proximity sensor on fetch hand.
 - git:
     local-name: FA-I-sensor
@@ -20,11 +22,7 @@
     version: indigo-devel
 # https://github.com/fetchrobotics/fetch_ros.git is not released on kinetic.
 # XXX: below entry must be same as .travis.rosinstall.kinetic.
-- tar:
-    local-name: fetchrobotics/fetch_ros/fetch_moveit_config
-    uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_moveit_config/0.7.13-0.tar.gz
-    version: fetch_ros-release-release-indigo-fetch_moveit_config-0.7.13-0
-- tar:
-    local-name: fetchrobotics/fetch_ros/fetch_description
-    uri: https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/indigo/fetch_description/0.7.13-0.tar.gz
-    version: fetch_ros-release-release-indigo-fetch_description-0.7.13-0
+- git:
+    local-name: fetchrobotics/fetch_ros
+    uri: https://github.com/fetchrobotics/fetch_ros.git
+    version: 0.7.14


### PR DESCRIPTION
 - In this Pull Request, I made `.rosinstall`  for both robot PC and user PC.
The former is `jsk_fetch.rosinstall` and the latter is `jsk_fetch_user.rosinstall.indigo`  and `jsk_fetch_user.rosintall.kinetic`.

 - Before this pull request, tar file of `fetch_ros` is installed to `kinetic` user PC by `wstool`, but tar file is inconvenient because it is not git repository.
After this pull request, git repository of `fetch_ros` will be installed to `kinetic` user PC by `wstool`.

 - In `jsk_fetch_user.rosinstall.kinetic`, `fetch_ros` version is `0.7.14` because my commit (fetchrobotics/fetch_ros@c0bc8bc) is merged and fetch's amcl will be improved.