### PR TITLE
[jsk_aero_robot] Fix README

### DIFF
--- a/jsk_aero_robot/aeroeus/README.md
+++ b/jsk_aero_robot/aeroeus/README.md
@@ -36,7 +36,7 @@ To initialize eus interface,
 Then, you can control AERO from euslisp, like
 
 ```
-(send *aero* :reset-manip-pose)
+(send *aero* :reset-pose)
 (send *ri* :angle-vector (send *aero* :angle-vector) 5000)
 ```
 


### PR DESCRIPTION
Because Aero doesn't have `reset-manip-pose`, fix `README.md`