### PR TITLE
jsk_robot_startup: deferred initialize mongodb interface on nodelet

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
+++ b/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
@@ -61,7 +61,10 @@ endmacro()
 
 add_lifelog_nodelet(src/lightweight_logger_nodelet.cpp "jsk_robot_lifelog/LightweightLogger" "lightweight_logger")
 
-add_library(jsk_robot_lifelog SHARED ${${PROJECT_NAME}_LIFELOG_NODELET_SRCS})
+add_library(jsk_robot_lifelog SHARED
+  ${${PROJECT_NAME}_LIFELOG_NODELET_SRCS}
+  src/message_store_singleton.cpp)
+
 target_link_libraries(jsk_robot_lifelog
   ${Boost_LIBRARIES}
   ${OpenCV_LIBRARIES}

--- a/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h
+++ b/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h
@@ -41,10 +41,14 @@
 #ifndef LIGHTWEIGHT_LOGGER_H__
 #define LIGHTWEIGHT_LOGGER_H__
 
+#include <diagnostic_updater/diagnostic_updater.h>
+#include <diagnostic_updater/publisher.h>
 #include <topic_tools/shape_shifter.h>
+#include <jsk_topic_tools/diagnostic_utils.h>
 #include <jsk_topic_tools/stealth_relay.h>
-#include <mongodb_store/message_store.h>
-
+#include <jsk_topic_tools/timered_diagnostic_updater.h>
+#include <jsk_topic_tools/vital_checker.h>
+#include <jsk_robot_startup/message_store_singleton.h>
 
 namespace jsk_robot_startup
 {
@@ -54,12 +58,23 @@ namespace jsk_robot_startup
     {
     protected:
       virtual void onInit();
+      virtual ~LightweightLogger();
+      virtual void loadThread();
       virtual void inputCallback(const ros::MessageEvent<topic_tools::ShapeShifter>& event);
+      virtual void updateDiagnostic(diagnostic_updater::DiagnosticStatusWrapper &stat);
 
-      boost::shared_ptr<mongodb_store::MessageStoreProxy> msg_store_;
+      mongodb_store::MessageStoreProxy* msg_store_;
+      boost::thread deferred_load_thread_;
       bool wait_for_insert_;
       bool initialized_;
       std::string input_topic_name_;
+      std::string db_name_, col_name_;
+
+      // diagnostics
+      ros::Time init_time_;
+      uint64_t inserted_count_, insert_error_count_, prev_insert_error_count_;
+      jsk_topic_tools::VitalChecker::Ptr vital_checker_;
+      jsk_topic_tools::TimeredDiagnosticUpdater::Ptr diagnostic_updater_;
     };
   }
 }

--- a/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/message_store_singleton.h
+++ b/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/message_store_singleton.h
@@ -1,0 +1,73 @@
+// -*- mode: C++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * message_store_singleton.h
+ * Author:  <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+
+#ifndef MESSAGE_STORE_SINGLETON_H__
+#define MESSAGE_STORE_SINGLETON_H__
+
+#include <boost/thread.hpp>
+#include <mongodb_store/message_store.h>
+
+
+namespace jsk_robot_startup
+{
+namespace lifelog
+{
+class MessageStoreSingleton
+{
+ public:
+  typedef std::map<std::string, mongodb_store::MessageStoreProxy*> M_Proxy;
+  static mongodb_store::MessageStoreProxy* getInstance(
+      const std::string& collection="message_store",
+      const std::string& database="message_store",
+      const std::string& prefix="/message_store");
+  static void destroy();
+ protected:
+  static ros::NodeHandle nh_;
+  static M_Proxy instances_;
+  static boost::mutex mutex_;
+ private:
+  // prohibit constructor
+  MessageStoreSingleton(MessageStoreSingleton const&) {};
+  MessageStoreSingleton& operator=(MessageStoreSingleton const&) {};
+};
+} // lifelog
+} // jsk_robot_startup
+
+#endif // MESSAGE_STORE_SINGLETON_H__

--- a/jsk_robot_common/jsk_robot_startup/src/message_store_singleton.cpp
+++ b/jsk_robot_common/jsk_robot_startup/src/message_store_singleton.cpp
@@ -1,0 +1,69 @@
+// -*- mode: C++ -*-
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2017, JSK Lab
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/o2r other materials provided
+ *     with the distribution.
+ *   * Neither the name of the JSK Lab nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+/*
+ * message_store_singleton.cpp
+ * Author:  <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+ */
+
+#include <jsk_robot_startup/message_store_singleton.h>
+
+namespace jsk_robot_startup
+{
+namespace lifelog
+{
+  mongodb_store::MessageStoreProxy* MessageStoreSingleton::getInstance(
+      const std::string& collection,
+      const std::string& database,
+      const std::string& prefix) {
+    boost::mutex::scoped_lock lock(mutex_);
+    std::string key = prefix + database + "/" + collection;
+    if (instances_.count(key) == 0) {
+      instances_[key] = new mongodb_store::MessageStoreProxy(nh_, collection, database, prefix);
+    }
+    return instances_[key];
+  }
+
+  void MessageStoreSingleton::destroy() {
+    for (M_Proxy::iterator it = instances_.begin(); it != instances_.end(); ++it)
+    {
+      if (it->second) delete it->second;
+    }
+  }
+
+MessageStoreSingleton::M_Proxy MessageStoreSingleton::instances_;
+boost::mutex MessageStoreSingleton::mutex_;
+ros::NodeHandle MessageStoreSingleton::nh_;
+} // lifelog
+} // jsk_robot_startup


### PR DESCRIPTION
- Reuse mongodb interface object for nodelets with the same manager
- Add diagnostic for logger
- Deferred initialization of logger on nodelet for non-blocking loading