### PR TITLE
[jsk_naoqi_robot] fix wrong file path and typo at #1015

### DIFF
--- a/jsk_naoqi_robot/README.md
+++ b/jsk_naoqi_robot/README.md
@@ -141,7 +141,7 @@ NAO & Pepper
 
 To connect NAO and Pepper to wifi, please refer to [here](doc/connect_to_wifi.md).
 
-To control multiple robots in one PC, please refer to [here](control_multiple_robots_in_one_pc.md).  
+To control multiple robots in one PC, please refer to [here](doc/control_multiple_robots_in_one_pc.md).
 
 To control NAO and Pepper via gazebo simulator and roseus, please refer to [here](doc/simulator.md).
 

--- a/jsk_naoqi_robot/doc/control_multiple_robots_in_one_pc.md
+++ b/jsk_naoqi_robot/doc/control_multiple_robots_in_one_pc.md
@@ -1,5 +1,9 @@
 # Control multiple robots in one PC
 
+## When is this feature useful?
+
+When creating one *ri* instance in one file, and communicate with each other using topics. Currently, we can't create multiple *ri* instances in one file. 
+
 ## Requirements
 
 Please use following packages from source:

--- a/jsk_naoqi_robot/doc/control_multiple_robots_in_one_pc.md
+++ b/jsk_naoqi_robot/doc/control_multiple_robots_in_one_pc.md
@@ -4,7 +4,7 @@
 
 Please use following packages from source:
 - jsk_pepper_startup (master branch)
-- naoqi_driver (kochigami-develop branch)[https://github.com/kochigami/naoqi_driver/tree/kochigami-develop]
+- naoqi_driver [(kochigami-develop branch)](https://github.com/kochigami/naoqi_driver/tree/kochigami-develop)
 
 [Especially, related change is stored in this branch](https://github.com/kochigami/naoqi_driver/tree/add-group-name-to-subscribe-topic-name)  
 
@@ -104,9 +104,9 @@ For example, `/joint_states`, `/tf`, `/tf_static`, `/dummy_state`, `/robot_inter
 Robot1: Pepper, Robot2: NAO  
 Confirmed with Ubuntu 16.04, ROS kinetic, NAO 2.4.3, Pepper 2.5.5.5
 
-- Put `boot_config.json` with new name under `naoqi_driver/share` as much as the number of robots you want to control. Change `group_name` of `subscribers` group. See examples of [json file1](jsk_pepper_startup/sample/control_multiple_robots/boot_config1.json) and [json file2](jsk_pepper_startup/sample/control_multiple_robots/boot_config2.json).
+- Put `boot_config.json` with new name under `naoqi_driver/share` as much as the number of robots you want to control. Change `group_name` of `subscribers` group. See examples of [json file1](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_naoqi_robot/sample/control_multiple_robots/boot_config1.json) and [json file2](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_naoqi_robot/sample/control_multiple_robots/boot_config2.json).
 
-- Set value of `boot_config_file_name` and `nao_ip` (ex. NAO_IP -> NAO_IP1) like [launch file1](jsk_pepper_startup/sample/control_multiple_robots/sample1.launch) and [launch file2](jsk_pepper_startup/sample/control_multiple_robots/sample2.launch). 
+- Set value of `boot_config_file_name` and `nao_ip` (ex. NAO_IP -> NAO_IP1) like [launch file1](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_naoqi_robot/sample/control_multiple_robots/sample1.launch) and [launch file2](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_naoqi_robot/sample/control_multiple_robots/sample2.launch). 
 
 ```
 roslaunch sample1.launch network_interface:=<network>

--- a/jsk_naoqi_robot/sample/control_multiple_robots/sample2.l
+++ b/jsk_naoqi_robot/sample/control_multiple_robots/sample2.l
@@ -1,6 +1,6 @@
 #!/usr/bin/env roseus
 (ros::roseus "sample2")
-(require :pepper-interface "package://peppereus/pepper-interface.l")
-(pepper-init nil "robot2")
+(require :nao-interface "package://naoeus/nao-interface.l")
+(nao-init nil "robot2")
 (unix:sleep 10)
 (send *ri* :speak "Hello Pepper!")


### PR DESCRIPTION
- fixed wrong path files (README, sample code)
- fixed sample code (`sample2.l` should load `nao-interface.l`, not `pepper-interface.l`)
- add explanation about when this feature is useful (`control_multiple_robots_in_one_pc.md`)