### PR TITLE
[jsk_nao_startup] add joy-client.l to jsk_nao_startup.launch

### DIFF
--- a/jsk_naoqi_robot/jsk_nao_startup/launch/jsk_nao_startup.launch
+++ b/jsk_naoqi_robot/jsk_nao_startup/launch/jsk_nao_startup.launch
@@ -57,6 +57,9 @@ enable_turbo_button: 0  # A button
       <param name="filename_format" value="/tmp/nao_camera.png" />
     </node>
   </group>
+  <include file="$(find naoqi_dashboard)/launch/naoqi_dashboard.launch"/>
+
+  <node pkg="jsk_nao_startup" name="joy_client" type="joy-client.l" if="$(arg launch_joy)" />
 
   <node name="speaking_program_is_started_or_terminated"
         pkg="roseus" type="roseus"

--- a/jsk_naoqi_robot/jsk_nao_startup/nodes/joy-client.l
+++ b/jsk_naoqi_robot/jsk_nao_startup/nodes/joy-client.l
@@ -1,0 +1,88 @@
+#!/usr/bin/env roseus
+
+
+(ros::roseus "joy_client")
+(ros::load-ros-package "naoeus")
+
+
+(if (not (find-package "NAOQI_BRIDGE_MSGS"))
+    (make-package "NAOQI_BRIDGE_MSGS" :nicknames "NAOQI_MSGS"))
+
+(ros::advertise "/speech" std_msgs::String 1)
+(defun speak-jp (str &rest args)
+  (let ((msg (instance std_msgs::String :init)))
+    (send msg :data (apply #'format nil str args))
+    (ros::ros-info "speech ~A" (send msg :data))
+    (ros::publish "/speech" msg))
+  )
+
+(ros::advertise "/nao_tweet" std_msgs::String 1)
+(defun tweet (str &rest args)
+  (ros::publish "/nao_tweet" (instance std_msgs::String :init :data (apply #'format nil str args))))
+
+
+(ros::advertise "/nao_robot/pose/joint_angles" naoqi_bridge_msgs::JointAnglesWithSpeed 1)
+
+(setq *power-button-time* (ros::time-now))
+(setq *power-button-mode* "/nao_robot/pose/wakeup")
+(setq *power-button-state* 0)
+(ros::subscribe "/joy" sensor_msgs::Joy
+		#'(lambda (msg)
+		    (let* ((buttons (send msg :buttons))
+			   (axes (send msg :axes))
+			   (power-button-state (elt buttons 8))
+			   (rb-button-state (elt buttons 5))
+			   (b-button-state (elt buttons 1))
+			   (x-button-state (elt buttons 2))
+			   (y-button-state (elt buttons 3)))
+		      (print (list buttons power-button-state (ros::time- (ros::time-now) *power-button-time*)))
+		      (cond ((and (= *power-button-state* 1)
+				  (=  power-button-state  0)
+				  (> (send (ros::time- (ros::time-now) *power-button-time*) :to-sec) 2))
+			     (if (string= *power-button-mode* "/nao_robot/pose/wakeup")
+				 (progn
+				   (speak-jp "もう朝かな")
+				   (call-empty-service *power-button-mode*)
+				   (tweet "おはよう")
+				   (setq *power-button-mode* "/nao_robot/pose/rest"))
+			       (progn
+				 (speak-jp "もうそろそろ寝ます")
+				 (call-empty-service *power-button-mode*)
+				 (tweet "おやすみ")
+				 (setq *power-button-mode* "/nao_robot/pose/wakeup")))
+			     (unix:sleep 5)
+			     );; when
+			    ((= rb-button-state 1)
+			     (let ((up-down (elt axes 4))
+				   (left-right (elt axes 3))
+				   (ja_msg (instance naoqi_bridge_msgs::JointAnglesWithSpeed :init)))
+			       (send ja_msg :header :stamp (ros::time-now))
+			       (send ja_msg :header :seq 1)
+			       (send ja_msg :speed 0.1)
+			       (send ja_msg :relative 1)
+			       (send ja_msg :joint_names (list "HeadYaw" "HeadPitch"))
+			       (send ja_msg :joint_angles (scale 0.1 (float-vector left-right up-down)))
+			       (ros::publish "/nao_robot/pose/joint_angles" ja_msg)
+			       ))
+			    ((= b-button-state 1)
+			     (speak-jp "disabled")
+			     (call-empty-service "/nao_robot/pose/life/disable")
+			     (unix:sleep 1)
+			     (call-empty-service "/nao_robot/pose/wakeup"))
+			    ((= x-button-state 1)
+			     (speak-jp "interactive")
+			     (call-empty-service "/nao_robot/pose/life/enable"))
+			    (t
+			     ))
+		      (setq *power-button-time* (ros::time-now))
+		      (setq *power-button-state* power-button-state)
+		      )));;
+
+
+(ros::ros-info "start joy-client.l")
+(unix:sleep 1) ;; need to wait 1 sec to speek
+(speak-jp "joy client")
+(tweet "おはよう")
+(ros::spin)
+
+

--- a/jsk_naoqi_robot/jsk_nao_startup/nodes/joy-client.l
+++ b/jsk_naoqi_robot/jsk_nao_startup/nodes/joy-client.l
@@ -4,9 +4,7 @@
 (ros::roseus "joy_client")
 (ros::load-ros-package "naoeus")
 
-
-(if (not (find-package "NAOQI_BRIDGE_MSGS"))
-    (make-package "NAOQI_BRIDGE_MSGS" :nicknames "NAOQI_MSGS"))
+(ros::load-ros-package "naoqi_bridge_msgs")
 
 (ros::advertise "/speech" std_msgs::String 1)
 (defun speak-jp (str &rest args)
@@ -22,8 +20,6 @@
 
 
 (ros::advertise "/nao_robot/pose/joint_angles" naoqi_bridge_msgs::JointAnglesWithSpeed 1)
-
-(setq *power-button-time* (ros::time-now))
 (setq *power-button-mode* "/nao_robot/pose/wakeup")
 (setq *power-button-state* 0)
 (ros::subscribe "/joy" sensor_msgs::Joy
@@ -33,12 +29,10 @@
 			   (power-button-state (elt buttons 8))
 			   (rb-button-state (elt buttons 5))
 			   (b-button-state (elt buttons 1))
-			   (x-button-state (elt buttons 2))
-			   (y-button-state (elt buttons 3)))
-		      (print (list buttons power-button-state (ros::time- (ros::time-now) *power-button-time*)))
+			   (x-button-state (elt buttons 2)))
+		      (print (list buttons power-button-state))
 		      (cond ((and (= *power-button-state* 1)
-				  (=  power-button-state  0)
-				  (> (send (ros::time- (ros::time-now) *power-button-time*) :to-sec) 2))
+				  (=  power-button-state  0))
 			     (if (string= *power-button-mode* "/nao_robot/pose/wakeup")
 				 (progn
 				   (speak-jp "もう朝かな")
@@ -74,7 +68,6 @@
 			     (call-empty-service "/nao_robot/pose/life/enable"))
 			    (t
 			     ))
-		      (setq *power-button-time* (ros::time-now))
 		      (setq *power-button-state* power-button-state)
 		      )));;
 

--- a/jsk_naoqi_robot/jsk_nao_startup/nodes/joy-client.l
+++ b/jsk_naoqi_robot/jsk_nao_startup/nodes/joy-client.l
@@ -4,6 +4,12 @@
 (ros::roseus "joy_client")
 (ros::load-ros-package "naoeus")
 
+;; This tries to treat naoqi_msgs as naoqi_bridge_msgs,
+;; but it doesn't work as intended.
+;; We leave this as it is because it doesn't cause any error now.
+;; Please see https://github.com/jsk-ros-pkg/jsk_robot/issues/1046
+(if (not (find-package "NAOQI_BRIDGE_MSGS"))
+    (make-package "NAOQI_BRIDGE_MSGS" :nicknames "NAOQI_MSGS"))
 (ros::load-ros-package "naoqi_bridge_msgs")
 
 (ros::advertise "/speech" std_msgs::String 1)

--- a/jsk_naoqi_robot/jsk_pepper_startup/nodes/joy-client.l
+++ b/jsk_naoqi_robot/jsk_pepper_startup/nodes/joy-client.l
@@ -4,9 +4,7 @@
 (ros::roseus "joy_client")
 (ros::load-ros-package "peppereus")
 
-
-(if (not (find-package "NAOQI_BRIDGE_MSGS"))
-    (make-package "NAOQI_BRIDGE_MSGS" :nicknames "NAOQI_MSGS"))
+(ros::load-ros-package "naoqi_bridge_msgs")
 
 (ros::advertise "/speech" std_msgs::String 1)
 (defun speak-jp (str &rest args)
@@ -22,8 +20,6 @@
 
 
 (ros::advertise "/pepper_robot/pose/joint_angles" naoqi_bridge_msgs::JointAnglesWithSpeed 1)
-
-(setq *power-button-time* (ros::time-now))
 (setq *power-button-mode* "/pepper_robot/pose/wakeup")
 (setq *power-button-state* 0)
 (ros::subscribe "/joy" sensor_msgs::Joy
@@ -33,12 +29,10 @@
 			   (power-button-state (elt buttons 8))
 			   (rb-button-state (elt buttons 5))
 			   (b-button-state (elt buttons 1))
-			   (x-button-state (elt buttons 2))
-			   (y-button-state (elt buttons 3)))
-		      (print (list buttons power-button-state (ros::time- (ros::time-now) *power-button-time*)))
+			   (x-button-state (elt buttons 2)))
+		      (print (list buttons power-button-state))
 		      (cond ((and (= *power-button-state* 1)
-				  (=  power-button-state  0)
-				  (> (send (ros::time- (ros::time-now) *power-button-time*) :to-sec) 2))
+				  (=  power-button-state  0))
 			     (if (string= *power-button-mode* "/pepper_robot/pose/wakeup")
 				 (progn
 				   (speak-jp "もう朝かな")
@@ -74,7 +68,6 @@
 			     (call-empty-service "/pepper_robot/pose/life/enable"))
 			    (t
 			     ))
-		      (setq *power-button-time* (ros::time-now))
 		      (setq *power-button-state* power-button-state)
 		      )));;
 

--- a/jsk_naoqi_robot/jsk_pepper_startup/nodes/joy-client.l
+++ b/jsk_naoqi_robot/jsk_pepper_startup/nodes/joy-client.l
@@ -2,7 +2,7 @@
 
 
 (ros::roseus "joy_client")
-(ros::load-ros-manifest "peppereus")
+(ros::load-ros-package "peppereus")
 
 
 (if (not (find-package "NAOQI_BRIDGE_MSGS"))

--- a/jsk_naoqi_robot/jsk_pepper_startup/nodes/joy-client.l
+++ b/jsk_naoqi_robot/jsk_pepper_startup/nodes/joy-client.l
@@ -4,6 +4,12 @@
 (ros::roseus "joy_client")
 (ros::load-ros-package "peppereus")
 
+;; This tries to treat naoqi_msgs as naoqi_bridge_msgs,
+;; but it doesn't work as intended.
+;; We leave this as it is because it doesn't cause any error now.
+;; Please see https://github.com/jsk-ros-pkg/jsk_robot/issues/1046
+(if (not (find-package "NAOQI_BRIDGE_MSGS"))
+    (make-package "NAOQI_BRIDGE_MSGS" :nicknames "NAOQI_MSGS"))
 (ros::load-ros-package "naoqi_bridge_msgs")
 
 (ros::advertise "/speech" std_msgs::String 1)


### PR DESCRIPTION
I want to include same nodes for nao and pepper, so I added `joy-client.l` to `jsk_nao_startup.launch`.

TODO
- [x] try this with real robot (nao and pepper): (memo) I don't know why two variables `*power-button-state*` and `power-button-state` are required. Let's check it!
- [x] consider #1046 
~- [ ] create button map of a controller, add it to README~ => #1031 