### PR TITLE
[jsk_robot_startup] Add option to check isAlive for lightweight_logger

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -32,6 +32,7 @@
   <!-- logging -->
   <include file="$(find jsk_fetch_startup)/launch/fetch_lifelog.xml">
     <arg name="map_frame" value="$(arg map_frame)" />
+    <arg name="vital_check" value="false" />
   </include>
 
   <!-- diagnostic aggregator -->

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
@@ -1,6 +1,7 @@
 <launch>
   <arg name="use_system_mongod" default="true" />
   <arg name="map_frame" default="map" />
+  <arg name="vital_check" default="false" />
 
   <include file="$(find jsk_fetch_startup)/jsk_fetch.machine" />
 
@@ -33,6 +34,7 @@
     <arg name="launch_manager" value="true" />
     <arg name="map_frame_id" value="$(arg map_frame)" />
     <arg name="base_frame_id" value="base_link" />
+    <arg name="vital_check" value="$(arg vital_check)" />
   </include>
 
   <rosparam ns="lifelog/joint_states_throttle">

--- a/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h
+++ b/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h
@@ -66,6 +66,7 @@ namespace jsk_robot_startup
       mongodb_store::MessageStoreProxy* msg_store_;
       boost::thread deferred_load_thread_;
       bool wait_for_insert_;
+      bool vital_check_;
       bool initialized_;
       std::string input_topic_name_;
       std::string db_name_, col_name_;

--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -10,6 +10,7 @@
   <arg name="save_object_detection" default="false" />
   <arg name="save_action" default="false" />
   <arg name="save_app" default="true" />
+  <arg name="vital_check" default="true" />
 
   <!-- namespace -->
   <arg name="camera_ns" default="kinect_head" />
@@ -200,6 +201,7 @@
         <rosparam subst_value="true">
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg joint_states_topic)
+          vital_check: $(arg vital_check)
         </rosparam>
       </node>
     </group>

--- a/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp
+++ b/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp
@@ -58,6 +58,8 @@ namespace jsk_robot_startup
 
       pnh_->param("wait_for_insert", wait_for_insert_, false);
 
+      pnh_->param("vital_check", vital_check_, true);
+
       input_topic_name_ = pnh_->resolveName("input", true);
 
       diagnostic_updater_.reset(
@@ -138,7 +140,7 @@ namespace jsk_robot_startup
       } else if (!initialized_) {
         stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR,
                      getName() + " is taking too long to be initialized");
-      } else if (!vital_checker_->isAlive()) {
+      } else if (vital_check_ && !vital_checker_->isAlive()) {
         jsk_topic_tools::addDiagnosticErrorSummary(getName(), vital_checker_, stat);
       } else if (insert_error_count_ != prev_insert_error_count_) {
         stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR,


### PR DESCRIPTION
In this Pull Request, I added an option to ignore `vital_checker_->isAlive`.

Current problem is below:

`joint_states_logger` output error when `joint_states_throttle/output` is not subscribed for long time.
https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch#L195-L204

However, `joint_states_throttle/output` is published only when robots move.

Therefore, robots using `joint_states_logger` (fetch or PR2) output error whenever they are not moving.

I think this PR solve this problem.
