### PR TITLE
[Fetch] Remove /tuck_arm which is already launched in fetch_bringup/launch/include/teleop.launch.xml

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -25,8 +25,6 @@
 
   <node name="controller_reset" pkg="fetch_bringup" type="controller_reset.py" />
 
-  <node name="tuck_arm" pkg="fetch_teleop" type="tuck_arm.py" args="--joystick" respawn="true" />
-
   <!-- safe teleop -->
   <node name="unsafe_vel_mux" pkg="topic_tools" type="mux" respawn="true"
 	args="/teleop/cmd_vel /teleop/cmd_vel/safe /teleop/cmd_vel/unsafe">


### PR DESCRIPTION
Now in Fetch, `/tuck_arm` is launched in both
- fetch_teleop.xml in `jsk_fetch_startup` (https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml#L28 )

and

- teleop.launch.xml in `fetch_bringup` (https://github.com/fetchrobotics/fetch_robots/blob/indigo-devel/fetch_bringup/launch/include/teleop.launch.xml#L18 )

In this PR, we remove `/tuck_arm` in `jsk_fetch_startup`.