### PR TITLE
[Fetch] Load all nodelet in one manager in order to avoid nodelet crushing

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -59,7 +59,9 @@
   </include>
 
   <!-- downsample / throttle sensor data -->
-  <include file="$(find jsk_fetch_startup)/launch/fetch_sensors.xml" />
+  <include file="$(find jsk_fetch_startup)/launch/fetch_sensors.xml" >
+    <arg name="launch_manager" value="false"/>
+  </include>
 
   <!-- include fetch moveit -->
   <include file="$(find fetch_moveit_config)/launch/move_group.launch"


### PR DESCRIPTION
In this PR, I load all vision `nodelet` into single `nodelet manager` to prevent nodelet crushing.

Before, `/head_camera/depth_registered/points` is published and subscribed in different nodelet manager.
This sometimes causes nodelet crushing.