### PR TITLE
[Fetch] Fix diagnostics analyzer config for fetch's head camera

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/fetch_analyzers.yaml
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/fetch_analyzers.yaml
@@ -101,7 +101,7 @@ analyzers:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Head Camera
         timeout: 5.0
-        startswith: 'throttle_nodelet_manager'
+        startswith: 'head_camera'
         num_items: 2
       imu:
         type: diagnostic_aggregator/GenericAnalyzer


### PR DESCRIPTION
In this PR, I change the config file of `diagnostic analyzer`.

I need this change because analyzers' name of vision nodelet has changed in https://github.com/jsk-ros-pkg/jsk_robot/pull/1053 .