### PR TITLE
[Fetch] Manage workspace in Fetch's PC by .rosinstall

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall
@@ -17,11 +17,11 @@
     uri: https://github.com/strands-project/mongodb_store.git
     version: 0.4.4
 # to install jsk_robot_startup/lifelog/common_logger.launch
-# remove after 708yamaguchi/jsk_robot (fetch-ws branch) is merged and released
+# remove after current master is released
 - git:
     local-name: jsk-ros-pkg/jsk_robot
-    uri: https://github.com/708yamaguchi/jsk_robot.git
-    version: fetch-ws
+    uri: https://github.com/jsk-ros-pkg/jsk_robot.git
+    version: master
 # to pass build of jsk_robot
 # remove after 2.2.10 is released
 - git:

--- a/jsk_fetch_robot/jsk_fetch.rosinstall
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall
@@ -1,28 +1,64 @@
 # This file is for work space in fetch PC.
 
-# For proximity sensor on fetch hand.
+# To install app_manager.launch
+# remove after 1.1.0 (https://github.com/PR2/app_manager/commit/7fa0929b6608246073a0fb89eed013edd6b934ca) is released
 - git:
-    local-name: FA-I-sensor
-    uri: https://github.com/RoboticMaterials/FA-I-sensor.git
-    version: master
-# TODO(furushchev): describe why this is needed.
+    local-name: PR2/app_manager
+    uri: https://github.com/PR2/app_manager.git
+    version: 1.1.0
+# For fetch to use twitter
 - git:
-    local-name: ros-drivers/audio_common
-    uri: https://github.com/furushchev/audio_common.git
-    version: device
-# TODO(furushchev): describe why this is needed.
+    local-name: furushchev/image_pipeline
+    uri: https://github.com/furushchev/image_pipeline.git
+    version: develop
+# To send lifelog data to musca
 - git:
     local-name: strands-project/mongodb_store
     uri: https://github.com/strands-project/mongodb_store.git
-    version: indigo-0.1.30
+    version: 0.4.4
+# to install jsk_robot_startup/lifelog/common_logger.launch
+# remove after 708yamaguchi/jsk_robot (fetch-ws branch) is merged and released
 - git:
-    local-name: ros-perception/image_pipeline
-    uri: https://github.com/ros-perception/image_pipeline.git
-    version: 1.12.20
+    local-name: jsk-ros-pkg/jsk_robot
+    uri: https://github.com/708yamaguchi/jsk_robot.git
+    version: fetch-ws
+# to pass build of jsk_robot
+# remove after 2.2.10 is released
+- git:
+    local-name: jsk-ros-pkg/jsk_common
+    uri: https://github.com/jsk-ros-pkg/jsk_common.git
+    version: 2.2.10
+# to avoid volume 0 problem
+# remove after 0.3.14 (https://github.com/jsk-ros-pkg/jsk_pr2eus/commit/41183fe3401d742bbec0edd13b67cb909a6968bd) is released
+- git:
+    local-name: jsk-ros-pkg/jsk_pr2eus
+    uri: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
+    version: 0.3.14
+# to use fetch's dock position for several demos
+# remove after https://github.com/jsk-ros-pkg/jsk_demos/commit/810acc7cc24a4792d455a7e9e8c8c50e5e07e21b (0.0.5) is released
+# Now, we set CATKIN_IGNORE to all packages except jsk_maps because we need only jsk_maps in fetch PC
+- git:
+    local-name: jsk-ros-pkg/jsk_demos
+    uri: https://github.com/jsk-ros-pkg/jsk_demos.git
+    version: 810acc7
+# jsk_topic_tools requires nodelet gte 1.9.11
+# remove after 1.9.11 is released by apt
 - git:
     local-name: ros/nodelet_core
     uri: https://github.com/ros/nodelet_core.git
-    version: 1.9.6
+    version: 1.9.11
+# 0.3.x is needed to set volume in pr2eus/speak.l
+# remove after 0.3.x is released by apt
+- git:
+    local-name: ros-drivers/audio_common
+    uri: https://github.com/ros-drivers/audio_common.git
+    version: 0.3.3
+# to install nodelet_plugins.xml
+# remove after 1.3.10 is released by apt
+- git:
+    local-name: ros-perception/slam_gmapping
+    uri: https://github.com/ros-perception/slam_gmapping.git
+    version: 1.3.10
 # indigo is already EOL and 2.1.13 is never released.
 # set the same version as https://github.com/jsk-ros-pkg/jsk_robot/blob/master/.travis.rosinstall.indigo#L7-L11
 - git:


### PR DESCRIPTION
In this Pull Request, I add `jsk_fetch.rosinstall` which can reproduce the workspace in fetch' PC.

This `jsk_fetch.rosinstall` is based on https://github.com/jsk-ros-pkg/jsk_robot/pull/1017, https://github.com/jsk-ros-pkg/jsk_robot/pull/1048, https://github.com/jsk-ros-pkg/jsk_robot/pull/1050. https://github.com/jsk-ros-pkg/jsk_robot/pull/1051, https://github.com/jsk-ros-pkg/jsk_robot/pull/1052, https://github.com/jsk-ros-pkg/jsk_robot/pull/1053, https://github.com/jsk-ros-pkg/jsk_robot/pull/1054, so please merge after these PR are merged.

Currently, workspace in fetch's PC is managed by this `jsk_fetch.rosinstall`

I will keep this setup for several weeks with @sktometometo.
If some problems occur, then I will re-make PR.

