### PR TITLE
[baxtereus] Check if simulation mode in test-baxter-moveit-init

### DIFF
--- a/jsk_baxter_robot/baxtereus/test/baxter-moveit.test
+++ b/jsk_baxter_robot/baxtereus/test/baxter-moveit.test
@@ -17,5 +17,5 @@
 
   <!-- start test -->
   <test test-name="baxter_moveit_test" pkg="baxtereus" type="test-baxter-moveit.l"
-	retry="3" time-limit="300"/>
+	retry="1" time-limit="300"/>
 </launch>

--- a/jsk_baxter_robot/baxtereus/test/test-baxter-moveit.l
+++ b/jsk_baxter_robot/baxtereus/test/test-baxter-moveit.l
@@ -37,7 +37,8 @@
     (ros::ros-info "moveit ready")
 
     (setq *ri* (instance baxter-interface :init))
-    (setq *baxter* (instance baxter-robot :init))))
+    (setq *baxter* (instance baxter-robot :init))
+    (assert (not (send *ri* :simulation-modep)) "baxter-interface is in simulation mode")))
 
 (deftest test-baxter-moveit-angle-vector()
   (let (av)


### PR DESCRIPTION
I don't think `baxter-moveit.test` works correctly.
In my local environment and travis, the following errors come up:
```
MoveItSimpleControllerManager: Action client not connected: /robot/limb/right/follow_joint_trajectory
MoveItSimpleControllerManager: Action client not connected: /robot/limb/left/follow_joint_trajectory
```
I think missing `follow_joint_trajectory` server makes `baxter-interface` simulation mode.

In this test, I added checking if `baxter-interface` is in simulation mode.