### PR TITLE
[jsk_robot_startup] Add option to use vital_check to all LightweightLogger in common_logger.launch

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -10,7 +10,6 @@
   <arg name="save_object_detection" default="false" />
   <arg name="save_action" default="false" />
   <arg name="save_app" default="true" />
-  <arg name="vital_check" default="true" />
 
   <!-- namespace -->
   <arg name="camera_ns" default="kinect_head" />
@@ -44,6 +43,7 @@
   <arg name="enable_monitor" default="false" />
   <arg name="log_rate" default="1.0" />
   <arg name="respawn" default="false" />
+  <arg name="vital_check" default="true" />
   <arg name="vital_rate" default="0.1" />
 
   <!-- nodelet manager -->
@@ -132,6 +132,7 @@
         <rosparam subst_value="true">
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg camera_ns)/$(arg rgb_ns)/$(arg rgb_topic)
+          vital_check: $(arg vital_check)
         </rosparam>
       </node>
       <node name="rgb_camera_info_logger"
@@ -143,6 +144,7 @@
         <rosparam subst_value="true">
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg camera_ns)/$(arg rgb_ns)/$(arg rgb_topic)
+          vital_check: $(arg vital_check)
         </rosparam>
       </node>
     </group>
@@ -156,6 +158,7 @@
         <rosparam subst_value="true">
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg camera_ns)/$(arg depth_ns)/$(arg depth_topic)
+          vital_check: $(arg vital_check)
         </rosparam>
       </node>
       <node name="depth_camera_info_logger"
@@ -167,6 +170,7 @@
         <rosparam subst_value="true">
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg camera_ns)/$(arg depth_ns)/$(arg depth_topic)
+          vital_check: $(arg vital_check)
         </rosparam>
       </node>
     </group>


### PR DESCRIPTION
Related to https://github.com/jsk-ros-pkg/jsk_robot/pull/1048.

Fetch still outputs error of `LightweightLogger`, because we set `vital_check` false only for `/joint_states` in https://github.com/jsk-ros-pkg/jsk_robot/pull/1048.
(e.g. Fetch sometime says that rgb image does not come for 1.00 sec)

In this PR, I enable to set `vital_check` for all `LightweightLogger`.