### PR TITLE
[fetch] Enable arm teleop and set buttons similar to PR2

### DIFF
--- a/jsk_fetch_robot/README.md
+++ b/jsk_fetch_robot/README.md
@@ -13,13 +13,13 @@
 |2     |Control forward/backward driving|
 |3     |Close gripper                   |
 |4     |Disable motor position holding  |
-|5     |Not used                        |
+|5     |Move arm linear                 |
 |6     |Arm tuck                        |
-|7     |Not used                        |
-|8     |Head control deadman            |
+|7     |Move arm angular                |
+|8     |Not used                        |
 |9     |Unsafe teleop                   |
 |10    |Primary deadman                 |
-|11    |Not used                        |
+|11    |Head control deadman            |
 |12    |Torso up                        |
 |13    |Dock                            |
 |14    |Torso down                      |

--- a/jsk_fetch_robot/README.md
+++ b/jsk_fetch_robot/README.md
@@ -12,10 +12,10 @@
 |1     |Control robot turning           |
 |2     |Control forward/backward driving|
 |3     |Close gripper                   |
-|4     |Disable motor position holding  |
-|5     |Move arm linear                 |
-|6     |Arm tuck                        |
-|7     |Move arm angular                |
+|4     |Move arm linear                 |
+|5     |Arm tuck                        |
+|6     |Move arm angular                |
+|7     |Disable motor position holding  |
 |8     |Not used                        |
 |9     |Unsafe teleop                   |
 |10    |Primary deadman                 |

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -3,11 +3,15 @@
   <arg name="enable_auto_dock" default="true" />
   <arg name="joy_device" default="/dev/ps3joy"/>
 
+  <!-- copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
   <node name="joy" pkg="joy" type="joy_node" respawn="true">
     <param name="autorepeat_rate" value="1"/>
     <param name="dev" value="$(arg joy_device)"/>
   </node>
 
+  <!-- copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
+  <!-- copied to support unsafe teleop. -->
+  <!-- copied for button mapping is changed to standardize with PR2 joy. -->
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop" respawn="true">
     <remap from="teleop/cmd_vel" to="/teleop/cmd_vel/unsafe" />
     <param name="arm/button_arm_linear" value="4"/>
@@ -16,15 +20,20 @@
     <param name="base/use_mux" value="false" />
   </node>
 
+  <!-- copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
   <node name="cmd_vel_mux" pkg="topic_tools" type="mux" respawn="true" output="screen"
 	args="base_controller/command /cmd_vel /teleop/cmd_vel">
     <remap from="mux" to="cmd_vel_mux" />
   </node>
 
+  <!-- copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
+  <!-- copied for button mapping is changed to standardize with PR2 joy. -->
   <node name="controller_reset" pkg="fetch_bringup" type="controller_reset.py">
     <param name="reset_button" value="7" />
   </node>
 
+  <!-- copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
+  <!-- copied for button mapping is changed to standardize with PR2 joy. -->
   <node name="tuck_arm" pkg="fetch_teleop" type="tuck_arm.py" args="--joystick" respawn="true" >
     <param name="tuck_button" value="5"/>
   </node>
@@ -37,6 +46,7 @@
 
   <!-- m.button[10]: L1 -->
   <!-- m.button[9] : R2 -->
+  <!-- safe teleop with L1 -->
   <node name="cmd_vel_mux_selector" pkg="jsk_robot_startup" type="mux_selector.py"
 	respawn="true"
 	args="/joy 'm.buttons[10]==1' /teleop/cmd_vel /cmd_vel 'True' /cmd_vel">
@@ -44,6 +54,7 @@
     <param name="default_select" value="/cmd_vel" />
   </node>
 
+  <!-- unsafe teleop with L1 and R2 -->
   <node name="unsafe_vel_mux_selector" pkg="jsk_robot_startup" type="mux_selector.py"
 	respawn="true"
 	args="/joy 'm.buttons[10]==1 and m.buttons[9]==1' /teleop/cmd_vel/unsafe /joy 'm.buttons[10]==1 and m.buttons[9]==0' /teleop/cmd_vel/safe">

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -2,12 +2,28 @@
   <!-- mainly copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
   <arg name="enable_auto_dock" default="true" />
   <arg name="joy_device" default="/dev/ps3joy"/>
+  <arg name="launch_fetch_bringup_teleop" default="false" />
 
-  <!-- need to launch joy_node because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch, see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
   <node name="joy" pkg="joy" type="joy_node" respawn="true">
     <param name="autorepeat_rate" value="1"/>
     <param name="dev" value="$(arg joy_device)"/>
   </node>
+
+  <group unless="$(arg launch_fetch_bringup_teleop)" >
+    <!-- need to launch joy_node because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch,
+         see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
+    <node name="joy" pkg="joy" type="joy_node" respawn="true">
+      <param name="autorepeat_rate" value="1"/>
+      <param name="dev" value="$(arg joy_device)"/>
+    </node>
+
+    <!-- need to launch cmd_vel_mux because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch,
+         see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
+    <node name="cmd_vel_mux" pkg="topic_tools" type="mux" respawn="true" output="screen"
+          args="base_controller/command /cmd_vel /teleop/cmd_vel">
+      <remap from="mux" to="cmd_vel_mux" />
+    </node>
+  </group>
 
   <!-- need to launch joystick_teleop because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch, see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
   <!-- copied to support unsafe teleop. -->
@@ -21,13 +37,6 @@
     <param name="base/use_mux" value="false" />
   </node>
 
-  <!-- need to launch cmd_vel_mux because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch, see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
-  <node name="cmd_vel_mux" pkg="topic_tools" type="mux" respawn="true" output="screen"
-	args="base_controller/command /cmd_vel /teleop/cmd_vel">
-    <remap from="mux" to="cmd_vel_mux" />
-  </node>
-
-  <!-- need to launch controller_reset because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch, see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
   <!-- copied for button mapping is changed to standardize with PR2 joy. -->
   <node name="controller_reset" pkg="fetch_bringup" type="controller_reset.py">
     <param name="reset_button" value="7" />

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -25,10 +25,12 @@
     </node>
   </group>
 
-  <!-- need to launch joystick_teleop because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch, see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
-  <!-- copied to support unsafe teleop. -->
-  <!-- joystick_teleop need to publish /teleop/cmd_vel/unsafe , see https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_fetch_robot/jsk_fetch_startup/README.md -->
-  <!-- copied for button mapping is changed to standardize with PR2 joy. -->
+  <!-- copied for button mapping is changed to standardize with PR2 joy.
+       need to launch joystick_teleop because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch,
+       see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
+  <!-- copied to support unsafe teleop.
+       joystick_teleop need to publish /teleop/cmd_vel/unsafe ,
+       see https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_fetch_robot/jsk_fetch_startup/README.md -->
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop" respawn="true">
     <remap from="teleop/cmd_vel" to="/teleop/cmd_vel/unsafe" />
     <param name="arm/button_arm_linear" value="4"/>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -10,18 +10,24 @@
 
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop" respawn="true">
     <remap from="teleop/cmd_vel" to="/teleop/cmd_vel/unsafe" />
-    <param name="arm/button_arm_linear" value="5"/>
-    <param name="arm/button_arm_angular" value="7"/>
+    <param name="arm/button_arm_linear" value="4"/>
+    <param name="arm/button_arm_angular" value="6"/>
     <param name="head/button_deadman" value="11"/>
     <param name="base/use_mux" value="false" />
   </node>
 
-  <node name="cmd_vel_mux" pkg="topic_tools" type="mux" respawn="true"
+  <node name="cmd_vel_mux" pkg="topic_tools" type="mux" respawn="true" output="screen"
 	args="base_controller/command /cmd_vel /teleop/cmd_vel">
     <remap from="mux" to="cmd_vel_mux" />
   </node>
 
-  <node name="controller_reset" pkg="fetch_bringup" type="controller_reset.py" />
+  <node name="controller_reset" pkg="fetch_bringup" type="controller_reset.py">
+    <param name="reset_button" value="7" />
+  </node>
+
+  <node name="tuck_arm" pkg="fetch_teleop" type="tuck_arm.py" args="--joystick" respawn="true" >
+    <param name="tuck_button" value="5"/>
+  </node>
 
   <!-- safe teleop -->
   <node name="unsafe_vel_mux" pkg="topic_tools" type="mux" respawn="true"

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -2,7 +2,6 @@
   <!-- mainly copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
   <arg name="enable_auto_dock" default="true" />
   <arg name="joy_device" default="/dev/ps3joy"/>
-  <arg name="disable_arm_teleop" default="true"/>
 
   <node name="joy" pkg="joy" type="joy_node" respawn="true">
     <param name="autorepeat_rate" value="1"/>
@@ -11,10 +10,9 @@
 
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop" respawn="true">
     <remap from="teleop/cmd_vel" to="/teleop/cmd_vel/unsafe" />
-    <!-- set these two motions as non-existent button 17 -->
-    <!-- from fetch_teleop version 0.7.11 (https://github.com/fetchrobotics/fetch_ros/pull/61), arm teleop is added and it is necessary to update jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml -->
-    <param name="arm/button_arm_linear" value="17" if="$(arg disable_arm_teleop)"/>
-    <param name="arm/button_arm_angular" value="17" if="$(arg disable_arm_teleop)"/>
+    <param name="arm/button_arm_linear" value="5"/>
+    <param name="arm/button_arm_angular" value="7"/>
+    <param name="head/button_deadman" value="11"/>
     <param name="base/use_mux" value="false" />
   </node>
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -3,14 +3,15 @@
   <arg name="enable_auto_dock" default="true" />
   <arg name="joy_device" default="/dev/ps3joy"/>
 
-  <!-- copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
+  <!-- need to launch joy_node because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch, see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
   <node name="joy" pkg="joy" type="joy_node" respawn="true">
     <param name="autorepeat_rate" value="1"/>
     <param name="dev" value="$(arg joy_device)"/>
   </node>
 
-  <!-- copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
+  <!-- need to launch joystick_teleop because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch, see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
   <!-- copied to support unsafe teleop. -->
+  <!-- joystick_teleop need to publish /teleop/cmd_vel/unsafe , see https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_fetch_robot/jsk_fetch_startup/README.md -->
   <!-- copied for button mapping is changed to standardize with PR2 joy. -->
   <node name="teleop" pkg="fetch_teleop" type="joystick_teleop" respawn="true">
     <remap from="teleop/cmd_vel" to="/teleop/cmd_vel/unsafe" />
@@ -20,19 +21,19 @@
     <param name="base/use_mux" value="false" />
   </node>
 
-  <!-- copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
+  <!-- need to launch cmd_vel_mux because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch, see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
   <node name="cmd_vel_mux" pkg="topic_tools" type="mux" respawn="true" output="screen"
 	args="base_controller/command /cmd_vel /teleop/cmd_vel">
     <remap from="mux" to="cmd_vel_mux" />
   </node>
 
-  <!-- copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
+  <!-- need to launch controller_reset because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch, see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
   <!-- copied for button mapping is changed to standardize with PR2 joy. -->
   <node name="controller_reset" pkg="fetch_bringup" type="controller_reset.py">
     <param name="reset_button" value="7" />
   </node>
 
-  <!-- copied from $(find fetch_bringup)/launch/include/teleop.launch.xml -->
+  <!-- need to launch tuck_arm because of launch_teleop:=false is set at /etc/ros/indigo/robot.launch, see https://github.com/fetchrobotics/fetch_robots/pull/40 -->
   <!-- copied for button mapping is changed to standardize with PR2 joy. -->
   <node name="tuck_arm" pkg="fetch_teleop" type="tuck_arm.py" args="--joystick" respawn="true" >
     <param name="tuck_button" value="5"/>


### PR DESCRIPTION
Before, we disable fetch's arm teleop, but this causes error (sometimes fetch move base and sometimes move arm).
To prevent this error, we assign arm teleop buttons to unused buttons.

Also, I change button assignment for head control similar to PR2.