### PR TITLE
update jsk_travis to 0.5.0

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,1 +1,5 @@
 # see .travis.rosinstall.ROS_DISTRO
+- git:
+    local-name: PR2/app_manager
+    uri: https://github.com/PR2/app_manager.git
+    version: kinetic-devel

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
   allow_failures:
     - env: ROS_DISTRO=hydro   USE_DEB=true
     - env: ROS_DISTRO=hydro   USE_DEB=false EXTRA_DEB="ros-hydro-convex-decomposition ros-hydro-ivcon" BUILD_PKGS="jsk_pr2_calibration jsk_robot_startup pr2_base_trajectory_action jsk_pr2_startup jsk_pr2_desktop"
+    - env: ROS_DISTRO=indigo  USE_DEB=true
     - env: ROS_DISTRO=indigo  USE_DEB=false EXTRA_DEB="ros-indigo-convex-decomposition ros-indigo-ivcon"
     - env: ROS_DISTRO=kinetic USE_DEB=true
     - env: ROS_DISTRO=melodic USE_DEB=true


### PR DESCRIPTION
- update jsk_travis submodule to 0.5.0
- add `app_manager` in `.travis.rosinstall`
  - waiting for upstream `app_manager` #1083 
- allow failure on `indigo USE_DEB:=true`