### PR TITLE
Make rviz node to anonymous

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/rviz.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/rviz.launch
@@ -1,4 +1,4 @@
 <launch>
-  <node pkg="rviz" type="rviz" name="jsk_startup_rviz"
+  <node pkg="rviz" type="rviz" name="$(anon jsk_startup_rviz)"
         args="-d $(find jsk_fetch_startup)/config/jsk_startup.rviz" />
 </launch>

--- a/jsk_pr2_robot/jsk_pr2_startup/rviz.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/rviz.launch
@@ -1,4 +1,4 @@
 <launch>
-  <node pkg="rviz" type="rviz" name="jsk_startup_rviz"
+  <node pkg="rviz" type="rviz" name="$(anon jsk_startup_rviz)"
         args="-d $(find jsk_pr2_startup)/config/jsk_startup.rviz" />
 </launch>


### PR DESCRIPTION
In current, Fetch and PR2's ```rviz.launch``` node is not anonymous.
If mutliuser launch this launch file to view robot state, only one node can be launched.
So I modified launch file to launch anonymous node.