### PR TITLE
[pr2] Add mannequin_mode setup

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/pr2_bringup.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2_bringup.launch
@@ -5,7 +5,8 @@
   <arg name="launch_wifi_ddwrt" default="false" />
   <arg name="launch_network_detector" default="false" />
   <arg name="launch_app_manager" default="true" />
-  <arg name="launch_mannequin_mode" default="true" />
+  <arg name="setup_mannequin_mode" default="true"
+       doc="prepares mannequin_mode to be callable by EusLisp interface"/>
 
   <param name="/use_sim_time" value="false"/>
   <include file="$(find pr2_machine)/pr2.machine" />
@@ -213,7 +214,7 @@
   </include>
 
   <!-- mannequin mode -->
-  <group if="$(arg launch_mannequin_mode)">
+  <group if="$(arg setup_mannequin_mode)">
     <include file="$(find pr2_mannequin_mode)/launch/trajectory_lock.launch"/>
     <rosparam command="load" file="$(find pr2_mannequin_mode)/config/pr2_arm_controllers_loose.yaml" />
     <rosparam command="load" file="$(find pr2_mannequin_mode)/config/head_position_controller_loose.yaml" />

--- a/jsk_pr2_robot/jsk_pr2_startup/pr2_bringup.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2_bringup.launch
@@ -5,6 +5,7 @@
   <arg name="launch_wifi_ddwrt" default="false" />
   <arg name="launch_network_detector" default="false" />
   <arg name="launch_app_manager" default="true" />
+  <arg name="launch_mannequin_mode" default="true" />
 
   <param name="/use_sim_time" value="false"/>
   <include file="$(find pr2_machine)/pr2.machine" />
@@ -210,4 +211,15 @@
     <arg name="applist" value="$(find jsk_pr2_startup)/apps"/>
     <arg name="respawn" value="false"/>
   </include>
+
+  <!-- mannequin mode -->
+  <group if="$(arg launch_mannequin_mode)">
+    <include file="$(find pr2_mannequin_mode)/launch/trajectory_lock.launch"/>
+    <rosparam command="load" file="$(find pr2_mannequin_mode)/config/pr2_arm_controllers_loose.yaml" />
+    <rosparam command="load" file="$(find pr2_mannequin_mode)/config/head_position_controller_loose.yaml" />
+    <node pkg="pr2_controller_manager" type="pr2_controller_manager"
+          name="load_mannequin_controllers"
+          args="load head_traj_controller_loose l_arm_controller_loose r_arm_controller_loose"/>
+  </group>
+
 </launch>


### PR DESCRIPTION
The PR2 robot interface have a `:start-mannequin-mode` and `:stop-mannequin-mode`, which are not functional now because they imply a series of preconditions. This PR takes care of such preconditions by default on pr2_bringup.launch and make such methods functional again.

Shouldn't have any consequences when  the mannequin mode is off.

@knorth55 