### PR TITLE
[Fetch] do not speak warning diagnostics to avoid noisy fetch

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -14,9 +14,7 @@
   <include file="$(find jsk_fetch_startup)/jsk_fetch.machine" />
 
   <!-- add jsk startups -->
-  <node pkg="jsk_fetch_startup" name="warning" type="warning.py" respawn="true" >
-    <param name="speak_warn" value="false"/>
-  </node>
+  <node pkg="jsk_fetch_startup" name="warning" type="warning.py" respawn="true" />
 
   <node pkg="jsk_fetch_startup" name="battery_warning" type="battery_warning.py"
         respawn="true" output="screen">

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/warning.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/warning.py
@@ -45,6 +45,14 @@ class DiagnosticsSpeakThread(threading.Thread):
     def run(self):
         global sound
         for status in  self.error_status:
+            # ignore error status if the error already occured in the latest 10 minites
+            if error_status_in_10_min.has_key(status.message):
+                if rospy.Time.now().secs - error_status_in_10_min[status.message] < 600:
+                    continue
+                else:
+                    error_status_in_10_min[status.message] = rospy.Time.now().secs
+            else:
+                error_status_in_10_min[status.message] = rospy.Time.now().secs
             # we can ignore "Joystick not open."
             if status.message == "Joystick not open." :
                 continue
@@ -151,6 +159,9 @@ class Warning:
 
 if __name__ == "__main__":
     global sound
+    # store error status and time of the error in the latest 10 minites
+    global error_status_in_10_min
+    error_status_in_10_min = {}
     rospy.init_node("cable_warning")
     sound = SoundClient()
     w = Warning()


### PR DESCRIPTION
In this Pull Request, I set `~speak_warn` param as `False` by default, so that our fetch do not speak too much.

There are many `ROS_WARN` in fetch PC and fetch sometimes speak noisy (e.g. when I use rosserial).
This causes fetch user to kill `sound_play`. 

(fetchのwarningがうるさくて僕がしばしばrosnode killしてしまい、他のfetchユーザに迷惑がかかってしまうので、warningは喋らせないようにしました。)

Cc @knorth55 