### PR TITLE
[aero] rivise aero_sensors

### DIFF
--- a/jsk_aero_robot/jsk_aero_startup/launch/aero.launch
+++ b/jsk_aero_robot/jsk_aero_startup/launch/aero.launch
@@ -1,24 +1,26 @@
 <launch>
   <arg name="use_base" default="true"/>
-  <arg name="use_ps4eye" default="true"/>
-  <arg name="use_kinect" default="true"/>
   <arg name="use_lifelog" default="true"/>
+  <arg name="use_sensors" default="true"/>
 
-  <arg name="ROBOT" default="$(optenv ROBOT aero)"/>
+  <arg name="machine" default="$(optenv AERO aeroc)"/>
+  <machine name="$(arg machine)" address="$(arg machine)"/>
 
-  <include file="$(find jsk_aero_startup)/$(arg ROBOT).machine"/>
+  <!-- Bringup Minimal Aero -->
+  <include file="$(find jsk_aero_startup)/launch/aero_bringup.launch"/>
 
+  <!-- Bringup Aero Base -->
   <include file="$(find jsk_aero_startup)/launch/aero_base.xml"
            if="$(arg use_base)"/>
 
-  <include file="$(find jsk_aero_startup)/launch/aero_sensors.xml">
-    <arg name="use_ps4eye" value="$(arg use_ps4eye)"/>
-    <arg name="use_kinect" value="$(arg use_kinect)"/>
+  <!-- Bringup Camera Nodes -->
+  <include file="$(find jsk_aero_startup)/launch/aero_sensors.xml"
+           if="$(arg use_sensors)">
+    <arg name="machine" value="$(arg machine)"/>
   </include>
 
+  <!-- Bringup Lifelog Nodes -->
   <include file="$(find jsk_aero_startup)/launch/aero_lifelog.xml"
            if="$(arg use_lifelog)" />
-
-  <node name="tf2_buffer_server" pkg="tf2_ros" type="buffer_server"/>
 
 </launch>

--- a/jsk_aero_robot/jsk_aero_startup/launch/aero_sensors.sh
+++ b/jsk_aero_robot/jsk_aero_startup/launch/aero_sensors.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+ARGS=""
+for OPT in "$@"; do
+  case "$OPT" in
+    __*)  # remove ROS arguments
+      shift
+      ;;
+    *)
+      ARGS="$ARGS $1"
+      shift
+      ;;
+  esac
+done
+
+roslaunch jsk_aero_startup sensor_bringup.xml $ARGS --screen 1>&2

--- a/jsk_aero_robot/jsk_aero_startup/launch/aero_sensors.xml
+++ b/jsk_aero_robot/jsk_aero_startup/launch/aero_sensors.xml
@@ -1,20 +1,13 @@
 <launch>
-  <arg name="use_kinect" default="true"/>
-  <arg name="use_ps4eye" default="true"/>
+  <arg name="use_xtion" default="true"/>
+  <arg name="use_zed" default="false"/>
+  <arg name="use_torso_sensor" default="false"/>
+  <arg name="machine" default="aeroc"/>
 
-  <group if="$(arg use_ps4eye)">
-    <include file="$(find jsk_aero_startup)/launch/ps4eye_local.launch">
-      <arg name="machine" value="aero_c"/>
-    </include>
-
-    <include file="$(find jsk_aero_startup)/launch/ps4eye_remote.launch"/>
-  </group>
-
-  <group if="$(arg use_kinect)">
-    <include file="$(find linux_kinect)/launch/kinect_rgbd_interaction.launch">
-      <arg name="log" value="true"/>
-      <arg name="frame" value="dynamic_kinect_frame"/>
-      <arg name="localradius_r" value="4.0"/>
-    </include>
-  </group>
+  <node name="spawn_aero_sensors"
+        pkg="jsk_aero_startup" type="aero_sensors.sh"
+        args="use_xtion:=$(arg use_xtion)
+              use_zed:=$(arg use_zed)
+              use_torso_sensor:=$(arg use_torso_sensor)"
+        machine="$(arg machine)" output="screen"/>
 </launch>

--- a/jsk_aero_robot/jsk_aero_startup/launch/sensor_bringup.xml
+++ b/jsk_aero_robot/jsk_aero_startup/launch/sensor_bringup.xml
@@ -1,0 +1,10 @@
+<launch>
+  <arg name="use_xtion" default="true"/>
+  <arg name="use_zed" default="false"/>
+  <arg name="use_torso_sensor" default="false"/>
+  <arg name="machine" default="aeroc"/>
+
+  <include file="$(find jsk_aero_startup)/launch/xtion_bringup.launch"
+           if="$(arg use_xtion)"
+           machine="$(arg machine)"/>
+</launch>

--- a/jsk_aero_robot/jsk_aero_startup/launch/xtion_bringup.launch
+++ b/jsk_aero_robot/jsk_aero_startup/launch/xtion_bringup.launch
@@ -1,0 +1,30 @@
+<launch>
+
+  <arg name="rgb_camera_info_url"   default="" />
+  <arg name="depth_camera_info_url" default="" />
+  <arg name="publish_tf" default="true" />
+  <arg name="camera" default="openni_camera" />
+
+  <!-- set lowest png compression level -->
+  <param name="$(arg camera)/depth/image_raw/compressed/format" value="png" />
+  <param name="$(arg camera)/depth/image_raw/compressed/png_level" value="1" />
+  <param name="$(arg camera)/depth/image_raw/compressedDepth/png_level" value="1" />
+  <param name="$(arg camera)/depth_registered/image_raw/compressed/format" value="png" />
+  <param name="$(arg camera)/depth_registered/image_raw/compressed/png_level" value="1" />
+  <param name="$(arg camera)/depth_registered/image_raw/compressedDepth/png_level" value="1" />
+
+  <include file="$(find openni2_launch)/launch/openni2.launch">
+    <arg name="camera" value="$(arg camera)"/>
+    <arg name="depth_registration" value="true" />
+    <arg name="publish_tf" value="$(arg publish_tf)" />
+  </include>
+
+  <arg name="base_frame" default="/head_link" />
+  <arg name="camera_frame" default="/$(arg camera)_link" />
+
+  <node name="xtion_link_publisher"
+        pkg="tf" type="static_transform_publisher"
+        args="0.083 0.05 0.1
+              0.011 0.062 0.014 0.998
+              $(arg base_frame) $(arg camera_frame) 1000" />
+</launch>


### PR DESCRIPTION
The jsk_aero has changed a lot compared to the previous version of aero_sensors

Before
- ps4eye on head
- kinect on torso

Now 
- xtion on head
- realsense on the wrist (optional)

I added machine tags because sometimes, we need to launch the camera node on another PC.
