### PR TITLE
[aero][wip] add jsk_aero_teleop

### DIFF
--- a/jsk_aero_robot/jsk_aero_startup/euslisp/aero-teleop.l
+++ b/jsk_aero_robot/jsk_aero_startup/euslisp/aero-teleop.l
@@ -1,0 +1,212 @@
+#!/usr/bin/env roseus
+;; (ros::load-ros-manifest "roseus")
+(ros::load-ros-manifest "sensor_msgs")
+
+(defvar *max-pos* 3.0)
+(defvar *max-rot* 0.015)
+(defvar *send-time* 1000)
+(defvar *head-controller-gain* 0.30)
+(defvar *ik-type* :arm-ik)
+(defvar *debug* t)
+
+(defun teleop-cb (msg &key (ik-type *ik-type*))
+  ;; mode callback
+  (let* ((axes (send msg :axes))
+	 (Lstick (coerce (subseq axes 0 2) float-vector))
+	 (Rstick (float-vector (elt axes 2) (elt axes 5)))
+	 (buttons (send msg :buttons))
+
+	 (select (elt buttons 8))
+	 (start (elt buttons 9))
+	 (L2 (elt buttons 6))
+	 (R2 (elt buttons 7))
+	 (R1 (elt buttons 5))
+	 (L1 (elt buttons 4))
+	 (right/left       (elt Rstick 0))
+	 (up/down          (elt Rstick 1))
+	 (forward/backward (elt Lstick 1))
+
+	 (circle   (elt buttons 2)) ;; roll+
+	 (square   (elt buttons 0)) ;; roll-
+	 (triangle (elt buttons 3)) ;; pitch-
+	 (cross    (elt buttons 1)) ;; pitch+
+	 (right    (- (elt axes 9))) ;; yaw+
+	 (left     (elt axes 9)) ;; yaw-
+
+	 (roll  (* *max-rot* (- circle square)))
+	 (pitch (* *max-rot* (- cross triangle)))
+	 (yaw   (* *max-rot* (- right left)))
+
+	 (up       (elt axes 10)) ;; grasp
+	 (down     (- (elt axes 10))) ;; release
+	 (switch   (elt buttons 10)) ;; lstick button
+	 arm pos
+	 target-coords)
+
+    (when (= switch 1)
+      (send *robot* :angle-vector (send *ri* :state :potentio-vector)))
+
+    (when (= start 1)
+      (setq *reset* t)
+      (return-from teleop-cb nil))
+
+    (when (or (= R2 1)
+	      (= L2 1)
+	      (= R1 1))
+      (cond
+       ;; ((= R1 1)
+       ;;  (let* ((neck-p (send *robot* :neck_p_joint :joint-angle))
+       ;;         (neck-y (send *robot* :neck_y_joint :joint-angle)))
+       ;;    (send *robot* :neck_p_joint :joint-angle
+       ;;  	(min 54 (max -14 (- neck-p (* *head-controller-gain* up/down)))))
+       ;;    (send *robot* :neck_y_joint :joint-angle
+       ;;  	(min 118 (max -118 (+ neck-y (* *head-controller-gain* right/left)))))
+       ;;    ))
+       (t
+	(when (= select 1)
+	  (cond
+	   ((= R2 1)
+	    (setq *look-right-hand* t))
+	   ((= L2 1)
+	    (setq *look-left-hand* t)))
+	  (return-from teleop-cb nil)
+	  )
+
+	(setq pos (scale *max-pos* (float-vector forward/backward
+						 right/left
+						 up/down)))
+	(cond
+	 ((= R2 1)
+	  (setq arm :rarm)
+	  (cond ((= up 1) (setq *r-grasp* t))
+		((= down 1) (setq *r-grasp* nil))))
+	 ((= L2 1)
+	  (setq arm :larm)
+	  (cond ((= up 1) (setq *l-grasp* t))
+		((= down 1) (setq *l-grasp* nil))))
+	 ((= R1 1)
+          (return-from teleop-cb nil)))
+
+	;; (send *robot* arm :move-end-pos pos :world)
+	;; (send *robot* arm :move-end-rot rot axis :world)
+	(setq target-coords
+	      (send
+	       (send
+		(send
+		 (send
+		  (send *robot* arm :end-coords :copy-worldcoords)
+		  :translate pos :world)
+		 :rotate roll :x :world)
+		:rotate pitch :y :world)
+	       :rotate yaw :z :world))
+
+        (if (= L1 1)
+            (send *robot* :inverse-kinematics
+                  (if (eq arm :rarm)
+                      (list
+                       target-coords
+                       (send (send *robot* :larm :end-coords) :copy-worldcoords))
+                    (list
+                     (send (send *robot* :rarm :end-coords) :copy-worldcoords)
+                     target-coords))
+                  :ik-group :both-arm-whole-body
+                  :revert-if-fail nil
+                  :stop 100
+                  :debug-view nil)
+          (send *robot* :inverse-kinematics target-coords
+                :ik-group (if (eq arm :rarm) :rarm-whole-body :larm-whole-body)
+                :revert-if-fail t
+                :stop 100
+                :debug-view nil)
+          )
+        (send *robot* :look-at-hand arm)
+        )
+       ))
+
+    (send *ri* :angle-vector (send *robot* :angle-vector) *send-time*
+          :default-controller (ros::time 0))
+    (if *debug* (send *irtviewer* :draw-objects))
+    ))
+
+(defun grasp-loop ()
+  (when (or (and (not *prev-r-grasp*) *r-grasp*)
+	    (and *prev-r-grasp* (not *r-grasp*))) ;; when state changed
+    (if *r-grasp*
+	(send *ri* :start-grasp :rarm)
+      (progn
+	(send *ri* :stop-grasp :rarm)
+	(send *ri* :angle-vector (send *robot* :angle-vector) 2000
+              :default-controller (ros::time 0))
+	(send *ri* :wait-interpolation)
+	)))
+  (when (or (and (not *prev-l-grasp*) *l-grasp*)
+	    (and *prev-l-grasp* (not *l-grasp*))) ;; when state changed
+    (if *l-grasp*
+	(send *ri* :start-grasp :larm)
+      (progn
+	(send *ri* :stop-grasp :larm)
+	;; (send *robot* :stop-grasp :larm)
+	(send *ri* :angle-vector (send *robot* :angle-vector) 2000
+              :default-controller (ros::time 0))
+	(send *ri* :wait-interpolation)
+	)))
+  (setq *prev-r-grasp* *r-grasp*
+	*prev-l-grasp* *l-grasp*)
+  t)
+
+(defun reset-loop (&key (reset-type :reset-pose))
+  (when *reset*
+    (send *ri* :angle-vector (send *robot* reset-type) 5000
+          :default-controller (ros::time 0))
+    (send *ri* :wait-interpolation))
+  (setq *reset* nil)
+  t)
+
+(defun look-at-loop ()
+  (when (or *look-right-hand*
+	    *look-left-hand*)
+    (let* ((arm (cond (*look-right-hand* :rarm)
+		      (*look-left-hand*  :larm))))
+      (send *robot* :head :look-at (send *robot* arm :end-coords :worldpos))
+      (send *ri* :angle-vector (send *robot* :angle-vector) 2000
+            :default-controller (ros::time 0))
+      (send *ri* :wait-interpolation))
+
+    (setq *look-right-hand* nil
+	  *look-left-hand*  nil)
+    )
+  )
+
+(defun test-teleop ()
+  (format t "~A~%" "start aero-teleop-ik")
+  (send *robot* :angle-vector (send *ri* :state :potentio-vector))
+  (send *ri* :angle-vector (send *robot* :angle-vector) 5000
+        :default-controller (ros::time 0))
+  (send *ri* :wait-interpolation)
+  (setq *prev-r-grasp* nil
+	*prev-l-grasp* nil
+	*r-grasp*      nil
+	*l-grasp*      nil
+	*look-right-hand* nil
+	*look-left-hand*  nil
+	*reset* nil)
+  (do-until-key
+   (ros::spin-once)   
+   (grasp-loop)
+   (reset-loop)
+   (look-at-loop)
+   (ros::sleep))
+  )
+
+(defun aero-teleop-setup ()
+  (load "package://aeroeus/aero-interface.l")
+  (aero-init)
+  (setq *robot* *aero*)
+  ;; (objects (list *robot*))
+  (ros::rate 0.3)
+  (ros::subscribe "/joy" sensor_msgs::Joy #'teleop-cb)
+  )
+
+;; (ros::roseus "aero_teleop_ik")
+(aero-teleop-setup)
+(test-teleop)

--- a/jsk_aero_robot/jsk_aero_startup/launch/aero.launch
+++ b/jsk_aero_robot/jsk_aero_startup/launch/aero.launch
@@ -1,24 +1,38 @@
 <launch>
+  <arg name="use_teleop" default="true"/>
+  <arg name="use_ik_teleop" default="true"/>
+  <arg name="use_lifelog" default="true"/>
   <arg name="use_base" default="true"/>
   <arg name="use_ps4eye" default="true"/>
   <arg name="use_kinect" default="true"/>
-  <arg name="use_lifelog" default="true"/>
 
-  <arg name="ROBOT" default="$(optenv ROBOT aero)"/>
 
-  <include file="$(find jsk_aero_startup)/$(arg ROBOT).machine"/>
+  <arg name="machine" default="$(optenv AERO aeroc)"/>
+  <machine name="$(arg machine)" address="$(arg machine)"/>
 
+  <!-- Bringup Minimal Aero -->
+  <include file="$(find jsk_aero_startup)/launch/aero_bringup.launch"/>
+
+  <!-- Aero Teleop -->
+  <group if="$(arg use_teleop)">
+    <include file="$(find jsk_aero_startup)/launch/aero_teleop_with_ik.launch"
+             if="$(arg use_ik_teleop)"/>
+    <include file="$(find aero_teleop)/launch/aero_teleop.launch"
+             unless="$(arg use_ik_teleop)"/>
+  </group>
+
+  <!-- Bringup Aero Base -->
   <include file="$(find jsk_aero_startup)/launch/aero_base.xml"
            if="$(arg use_base)"/>
 
+  <!-- Bringup Perception Sensors -->
   <include file="$(find jsk_aero_startup)/launch/aero_sensors.xml">
     <arg name="use_ps4eye" value="$(arg use_ps4eye)"/>
     <arg name="use_kinect" value="$(arg use_kinect)"/>
   </include>
 
+  <!-- Bringup Lifelog Nodes -->
   <include file="$(find jsk_aero_startup)/launch/aero_lifelog.xml"
            if="$(arg use_lifelog)" />
-
-  <node name="tf2_buffer_server" pkg="tf2_ros" type="buffer_server"/>
 
 </launch>

--- a/jsk_aero_robot/jsk_aero_startup/launch/aero_teleop_with_ik.launch
+++ b/jsk_aero_robot/jsk_aero_startup/launch/aero_teleop_with_ik.launch
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="joy_config" default="ps4" />
+  <arg name="joy_dev" default="/dev/input/js0" />
+  <arg name="config_filepath" default="$(find aero_teleop)/config/$(arg joy_config).config.yaml" />
+
+  <node name="joy_node"
+        pkg="joy" type="joy_node" >
+    <param name="dev" value="$(arg joy_dev)" />
+    <param name="deadzone" value="0.3" />
+    <param name="autorepeat_rate" value="20" />
+  </node>
+
+  <node name="joy_msg_switcher"
+        pkg="jsk_aero_startup" type="joy_msg_switcher.py"
+        output="log">
+    <remap from="~angle_mode" to="/joy_msg_switcher/angle_pub" />
+    <remap from="~ik_mode" to="/joy_msg_switcher/ik_pub" />
+  </node>
+
+  <node name="aero_teleop_ik"
+        pkg="jsk_aero_startup"  type="aero-teleop.l"
+        output="log">
+    <remap from="/joy" to="/joy_msg_switcher/ik_pub" />
+  </node>
+
+  <node name="teleop_joy"
+        pkg="aero_teleop"  type="xbox_one_teleop_node"
+        output="log">
+    <rosparam command="load" file="$(arg config_filepath)" />
+    <remap from="/cmd_vel" to="/teleop/cmd_vel" />
+    <remap from="/joy" to="/joy_msg_switcher/angle_pub" />
+  </node>
+
+</launch>

--- a/jsk_aero_robot/jsk_aero_startup/scripts/joy_msg_switcher.py
+++ b/jsk_aero_robot/jsk_aero_startup/scripts/joy_msg_switcher.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+import rospy
+from sensor_msgs.msg import Joy
+
+class JoyMsgSwitcher():
+    def __init__(self):
+        self.counter = 1
+        self.pre = 0
+        self.angle_pub = rospy.Publisher('~angle_mode', Joy, queue_size=1)
+        self.ik_pub = rospy.Publisher('~ik_mode', Joy, queue_size=1)
+        rospy.Subscriber('joy', Joy, self.callback)
+
+    def callback(self, msg):
+        joy_msg = msg
+        l3_button = msg.buttons[10]
+
+        if l3_button - self.pre == 1:
+            self.counter += 1
+
+        if self.counter % 2 == 0:
+            self.ik_pub.publish(joy_msg)
+        else:
+            self.angle_pub.publish(joy_msg)
+
+        self.pre = l3_button
+
+if __name__=='__main__':
+    rospy.init_node('joy_msg_switcher')
+    joy_msg_swither = JoyMsgSwitcher()
+    rospy.spin()


### PR DESCRIPTION
I added aero_teleop.
That enables us to switch default teleop (aero-ros-pkg) and original ik teleop.

I can apply this program https://github.com/jsk-ros-pkg/jsk_robot/pull/1097 to aero_ik_teleop because both are almost same.
I will change `aero-teleop.l` to `jsk_robot_common/jsk_robot_utils/euslisp/aero-teleop-joy.l ` after https://github.com/jsk-ros-pkg/jsk_robot/pull/1097 merge.