### PR TITLE
fix fetch robot localization and navigation

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -185,4 +185,10 @@
     <remap from="~input" to="/imu" />
     <remap from="~output" to="/imu_corrected" />
   </node>
+
+  <!-- /odom has no covariance value. -->
+  <node name="odom_corrector" pkg="jsk_fetch_startup" type="odom_corrector.py">
+    <remap from="~input" to="/odom" />
+    <remap from="~output" to="/odom_corrected" />
+  </node>
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -140,6 +140,7 @@
 
     <!-- robot localization ukf -->
     <node pkg="robot_localization" type="ukf_localization_node" name="ukf_se" clear_params="true">
+      <remap from="odometry/filtered" to="/odom_combined" />
       <rosparam>
         frequency: 50
         sensor_timeout: 1.0

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -200,7 +200,13 @@
     <rosparam ns="move_base">
       base_local_planner: base_local_planner/TrajectoryPlannerROS
       TrajectoryPlannerROS:
+        min_in_place_vel_theta: 0.8
         escape_vel: -0.1 # -0.1
+        meter_scoring: true
+        pdist_scale: 5.0
+        gdist_scale: 3.2
+        occdist_scale: 0.1
+        dwa: true
       recovery_behavior_enabled: true
       recovery_behaviors:
         - name: "conservative_reset"

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -216,6 +216,8 @@
         - limited_distance: 0.3
         - limited_rot_speed: 0.45
         - limited_trans_speed: 0.25
+      TrajectoryPlannerROS:
+        dwa: true
     </rosparam>
   </group>
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -173,10 +173,10 @@
     <rosparam ns="amcl">
       update_min_a: 0.01 <!-- update filter every 0.01[m] translation -->
       update_min_d: 0.01 <!-- update filter every 0.01[rad] rotation -->
-      odom_alpha1: 0.05  # rotation noise per rotation
-      odom_alpha2: 0.05  # rotation noise per translation
-      odom_alpha3: 0.05  # translation noise per translation
-      odom_alpha4: 0.05  # translation noise per rotation
+      odom_alpha1: 0.2  # rotation noise per rotation
+      odom_alpha2: 0.2  # rotation noise per translation
+      odom_alpha3: 0.2  # translation noise per translation
+      odom_alpha4: 0.2  # translation noise per rotation
     </rosparam>
 
     <rosparam ns="move_base">

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -159,11 +159,11 @@
         odom0_nodelay: true
         odom0_differential: true
         imu0: /imu_corrected
-        imu0_config: [true, true, false,
-                      false, false,  true,
-                      true, true, false,
-                      false, false,  true,
-                      false, false, false]
+        imu0_config: [false, false, false,
+                      false, false, false,
+                      false, false, false,
+                      false, false, true,
+                      true, true, false]
         imu0_nodelay: true
         imu0_differential: true
       </rosparam>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -173,6 +173,10 @@
     <rosparam ns="amcl">
       update_min_a: 0.01 <!-- update filter every 0.01[m] translation -->
       update_min_d: 0.01 <!-- update filter every 0.01[rad] rotation -->
+      odom_alpha1: 0.5  # rotation noise per rotation
+      odom_alpha2: 0.5  # rotation noise per translation
+      odom_alpha3: 0.5  # translation noise per translation
+      odom_alpha4: 0.5  # translation noise per rotation
     </rosparam>
 
     <rosparam ns="move_base/global_costmap">

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -137,9 +137,41 @@
       <arg name="map_keepout_file" value="$(arg keepout_map_file)" />
       <arg name="use_keepout" value="true" />
     </include>
+
+    <!-- robot localization ukf -->
+    <node pkg="robot_localization" type="ukf_localization_node" name="ukf_se" clear_params="true">
+      <rosparam>
+        frequency: 50
+        sensor_timeout: 1.0
+        two_d_mode: true
+        publish_tf: true
+        publish_acceleration: false
+        map_frame: map
+        odom_frame: odom_combined
+        base_link_frame: base_link
+        odom0: /odom_corrected
+        odom0_config: [true, true, false,
+                       false, false, true,
+                       true, true, false,
+                       false, false, true,
+                       false, false, false]
+        odom0_nodelay: true
+        odom0_differential: true
+        imu0: /imu_corrected
+        imu0_config: [true, true, false,
+                      false, false,  true,
+                      true, true, false,
+                      false, false,  true,
+                      false, false, false]
+        imu0_nodelay: true
+        imu0_differential: true
+      </rosparam>
+    </node>
+
     <rosparam ns="amcl">
       update_min_a: 0.01 <!-- update filter every 0.01[m] translation -->
       update_min_d: 0.01 <!-- update filter every 0.01[rad] rotation -->
+      odom_frame_id: odom_combined
     </rosparam>
 
     <rosparam ns="move_base/global_costmap">
@@ -148,6 +180,7 @@
         cost_scaling_factor: 10.0 # 10.0
     </rosparam>
     <rosparam ns="move_base/local_costmap">
+      global_frame: odom_combined
       inflater:
         inflation_radius: 0.30 # 0.7
         cost_scaling_factor: 100.0 # 25.0 default 10, increasing factor decrease the cost value

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -143,33 +143,39 @@
     </rosparam>
 
     <rosparam ns="move_base/global_costmap">
-inflater:
-  inflation_radius: 0.30 # 0.7
-  cost_scaling_factor: 10.0 # 10.0
+      inflater:
+        inflation_radius: 0.30 # 0.7
+        cost_scaling_factor: 10.0 # 10.0
     </rosparam>
     <rosparam ns="move_base/local_costmap">
-inflater:
-  inflation_radius: 0.30 # 0.7
-  cost_scaling_factor: 100.0 # 25.0 default 10, increasing factor decrease the cost value
-update_frequency: 10.0 # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
+      inflater:
+        inflation_radius: 0.30 # 0.7
+        cost_scaling_factor: 100.0 # 25.0 default 10, increasing factor decrease the cost value
+      update_frequency: 10.0 # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
     </rosparam>
     <rosparam ns="move_base">
-base_local_planner: base_local_planner/TrajectoryPlannerROS
-TrajectoryPlannerROS:
-  escape_vel: -0.1 # -0.1
-recovery_behavior_enabled: true
-recovery_behaviors:
-  - name: "conservative_reset"
-    type: "clear_costmap_recovery/ClearCostmapRecovery"
-  - name: "rotate_recovery"
-    type: "rotate_recovery/RotateRecovery"
-    frequency: 20.0
-    sim_granularity: 0.017
-  - name: "aggressive_reset"
-    type: "clear_costmap_recovery/ClearCostmapRecovery"
-conservative_reset: {reset_distance: 1.0} # 3.0
-aggressive_reset: {reset_distance: 0.2} # 0.5
-move_slow_and_clear: {clearing_distance: 0.5, limited_distance: 0.3, limited_rot_speed: 0.45, limited_trans_speed: 0.25}
+      base_local_planner: base_local_planner/TrajectoryPlannerROS
+      TrajectoryPlannerROS:
+        escape_vel: -0.1 # -0.1
+      recovery_behavior_enabled: true
+      recovery_behaviors:
+        - name: "conservative_reset"
+          type: "clear_costmap_recovery/ClearCostmapRecovery"
+        - name: "rotate_recovery"
+          type: "rotate_recovery/RotateRecovery"
+          frequency: 20.0
+          sim_granularity: 0.017
+        - name: "aggressive_reset"
+          type: "clear_costmap_recovery/ClearCostmapRecovery"
+      conservative_reset:
+        - reset_distance: 1.0 # 3.0
+      aggressive_reset:
+        - reset_distance: 0.2 # 0.5
+      move_slow_and_clear:
+        - clearing_distance: 0.5
+        - limited_distance: 0.3
+        - limited_rot_speed: 0.45
+        - limited_trans_speed: 0.25
     </rosparam>
   </group>
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -181,8 +181,9 @@
 
     <rosparam ns="move_base/global_costmap">
       inflater:
-        inflation_radius: 0.30 # 0.7
-        cost_scaling_factor: 10.0 # 10.0
+        inflation_radius: 3.0 # 0.7
+        cost_scaling_factor: 3.0 # 10.0
+      footprint_padding: 0.05
     </rosparam>
     <rosparam ns="move_base/local_costmap">
       inflater:
@@ -190,6 +191,7 @@
         cost_scaling_factor: 3.0 # 25.0 default 10, increasing factor decrease the cost value
       # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
       update_frequency: 10.0
+      footprint_padding: 0.05
     </rosparam>
     <rosparam ns="move_base">
       base_local_planner: base_local_planner/TrajectoryPlannerROS

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -182,9 +182,10 @@
     <rosparam ns="move_base/local_costmap">
       global_frame: odom_combined
       inflater:
-        inflation_radius: 0.30 # 0.7
-        cost_scaling_factor: 100.0 # 25.0 default 10, increasing factor decrease the cost value
-      update_frequency: 10.0 # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
+        inflation_radius: 3.0 # 0.7
+        cost_scaling_factor: 3.0 # 25.0 default 10, increasing factor decrease the cost value
+      # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
+      update_frequency: 10.0
     </rosparam>
     <rosparam ns="move_base">
       base_local_planner: base_local_planner/TrajectoryPlannerROS

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -147,7 +147,7 @@
         publish_tf: true
         publish_acceleration: false
         map_frame: map
-        odom_frame: odom_combined
+        odom_frame: odom
         base_link_frame: base_link
         odom0: /odom_corrected
         odom0_config: [true, true, false,
@@ -171,7 +171,6 @@
     <rosparam ns="amcl">
       update_min_a: 0.01 <!-- update filter every 0.01[m] translation -->
       update_min_d: 0.01 <!-- update filter every 0.01[rad] rotation -->
-      odom_frame_id: odom_combined
     </rosparam>
 
     <rosparam ns="move_base/global_costmap">
@@ -180,7 +179,6 @@
         cost_scaling_factor: 10.0 # 10.0
     </rosparam>
     <rosparam ns="move_base/local_costmap">
-      global_frame: odom_combined
       inflater:
         inflation_radius: 3.0 # 0.7
         cost_scaling_factor: 3.0 # 25.0 default 10, increasing factor decrease the cost value

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -172,4 +172,11 @@ aggressive_reset: {reset_distance: 0.2} # 0.5
 move_slow_and_clear: {clearing_distance: 0.5, limited_distance: 0.3, limited_rot_speed: 0.45, limited_trans_speed: 0.25}
     </rosparam>
   </group>
+
+  <!-- /imu has no frame_id information and there is no bug fix release in indigo. -->
+  <!-- see https://github.com/fetchrobotics/fetch_ros/issues/70 -->
+  <node name="imu_corrector" pkg="jsk_fetch_startup" type="imu_corrector.py">
+    <remap from="~input" to="/imu" />
+    <remap from="~output" to="/imu_corrected" />
+  </node>
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -166,6 +166,7 @@
                       true, true, false]
         imu0_nodelay: true
         imu0_differential: true
+        imu0_remove_gravitational_acceleration: true
       </rosparam>
     </node>
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -212,16 +212,14 @@
         - name: "aggressive_reset"
           type: "clear_costmap_recovery/ClearCostmapRecovery"
       conservative_reset:
-        - reset_distance: 1.0 # 3.0
+        reset_distance: 1.0 # 3.0
       aggressive_reset:
-        - reset_distance: 0.2 # 0.5
+        reset_distance: 0.2 # 0.5
       move_slow_and_clear:
-        - clearing_distance: 0.5
-        - limited_distance: 0.3
-        - limited_rot_speed: 0.45
-        - limited_trans_speed: 0.25
-      TrajectoryPlannerROS:
-        dwa: true
+        clearing_distance: 0.5
+        limited_distance: 0.3
+        limited_rot_speed: 0.45
+        limited_trans_speed: 0.25
     </rosparam>
   </group>
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -179,6 +179,10 @@
       odom_alpha4: 0.05  # translation noise per rotation
     </rosparam>
 
+    <rosparam ns="move_base">
+      controller_frequency: 10.0
+    </rosparam>
+
     <rosparam ns="move_base/global_costmap">
       inflater:
         inflation_radius: 1.0 # 0.7

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -183,12 +183,16 @@
       inflater:
         inflation_radius: 3.0 # 0.7
         cost_scaling_factor: 3.0 # 10.0
+      obstacles:
+        min_obstacle_height: 0.05
       footprint_padding: 0.05
     </rosparam>
     <rosparam ns="move_base/local_costmap">
       inflater:
         inflation_radius: 3.0 # 0.7
         cost_scaling_factor: 3.0 # 25.0 default 10, increasing factor decrease the cost value
+      obstacles:
+        min_obstacle_height: 0.05
       # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
       update_frequency: 10.0
       footprint_padding: 0.05

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -206,6 +206,7 @@
       TrajectoryPlannerROS:
         min_in_place_vel_theta: 0.8
         escape_vel: -0.1 # -0.1
+        vx_samples: 10
         meter_scoring: true
         pdist_scale: 5.0
         gdist_scale: 3.2

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -181,7 +181,7 @@
 
     <rosparam ns="move_base/global_costmap">
       inflater:
-        inflation_radius: 3.0 # 0.7
+        inflation_radius: 1.0 # 0.7
         cost_scaling_factor: 3.0 # 10.0
       obstacles:
         min_obstacle_height: 0.05
@@ -189,7 +189,7 @@
     </rosparam>
     <rosparam ns="move_base/local_costmap">
       inflater:
-        inflation_radius: 3.0 # 0.7
+        inflation_radius: 1.0 # 0.7
         cost_scaling_factor: 3.0 # 25.0 default 10, increasing factor decrease the cost value
       obstacles:
         min_obstacle_height: 0.05

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -173,10 +173,10 @@
     <rosparam ns="amcl">
       update_min_a: 0.01 <!-- update filter every 0.01[m] translation -->
       update_min_d: 0.01 <!-- update filter every 0.01[rad] rotation -->
-      odom_alpha1: 0.5  # rotation noise per rotation
-      odom_alpha2: 0.5  # rotation noise per translation
-      odom_alpha3: 0.5  # translation noise per translation
-      odom_alpha4: 0.5  # translation noise per rotation
+      odom_alpha1: 0.05  # rotation noise per rotation
+      odom_alpha2: 0.05  # rotation noise per translation
+      odom_alpha3: 0.05  # translation noise per translation
+      odom_alpha4: 0.05  # translation noise per rotation
     </rosparam>
 
     <rosparam ns="move_base/global_costmap">

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -185,16 +185,16 @@
 
     <rosparam ns="move_base/global_costmap">
       inflater:
-        inflation_radius: 1.0 # 0.7
-        cost_scaling_factor: 3.0 # 10.0
+        inflation_radius: 0.7 # 0.7
+        cost_scaling_factor: 5.0 # 10.0
       obstacles:
         min_obstacle_height: 0.05
       footprint_padding: 0.05
     </rosparam>
     <rosparam ns="move_base/local_costmap">
       inflater:
-        inflation_radius: 1.0 # 0.7
-        cost_scaling_factor: 3.0 # 25.0 default 10, increasing factor decrease the cost value
+        inflation_radius: 0.7 # 0.7
+        cost_scaling_factor: 5.0 # 25.0 default 10, increasing factor decrease the cost value
       obstacles:
         min_obstacle_height: 0.05
       # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
@@ -204,7 +204,7 @@
     <rosparam ns="move_base">
       base_local_planner: base_local_planner/TrajectoryPlannerROS
       TrajectoryPlannerROS:
-        min_in_place_vel_theta: 0.8
+        min_in_place_vel_theta: 1.0
         escape_vel: -0.1 # -0.1
         vx_samples: 10
         meter_scoring: true

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -81,6 +81,8 @@
     inflater:
       inflation_radius: 3.0 # 0.7
       cost_scaling_factor: 3.0 # 25.0 default 10, increasing factor decrease the cost value
+    obstacles:
+      min_obstacle_height: 0.05
     # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
     update_frequency: 10.0
     footprint_padding: 0.05

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -78,7 +78,6 @@
     <rosparam file="$(find fetch_navigation)/config/fetch/costmap_local.yaml" command="load" ns="local_costmap" />
     <rosparam>
       local_costmap:
-        global_frame: odom_combined
         # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
         update_frequency: 10.0
     </rosparam>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -79,7 +79,7 @@
   </node>
   <rosparam ns="safe_teleop_base/local_costmap">
     inflater:
-      inflation_radius: 3.0 # 0.7
+      inflation_radius: 1.0 # 0.7
       cost_scaling_factor: 3.0 # 25.0 default 10, increasing factor decrease the cost value
     obstacles:
       min_obstacle_height: 0.05

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -76,12 +76,15 @@
     <rosparam file="$(find fetch_navigation)/config/fetch/costmap_common.yaml" command="load" ns="local_costmap" />
     <rosparam file="$(find fetch_navigation)/config/costmap_local.yaml" command="load" ns="local_costmap" />
     <rosparam file="$(find fetch_navigation)/config/fetch/costmap_local.yaml" command="load" ns="local_costmap" />
-    <rosparam>
-      local_costmap:
-        # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
-        update_frequency: 10.0
-    </rosparam>
   </node>
+  <rosparam ns="safe_teleop_base/local_costmap">
+    inflater:
+      inflation_radius: 3.0 # 0.7
+      cost_scaling_factor: 3.0 # 25.0 default 10, increasing factor decrease the cost value
+    # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
+    update_frequency: 10.0
+    footprint_padding: 0.05
+  </rosparam>
 
   <node name="safe_tilt_head" pkg="jsk_fetch_startup" type="safe_tilt_head.py" />
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml
@@ -76,6 +76,12 @@
     <rosparam file="$(find fetch_navigation)/config/fetch/costmap_common.yaml" command="load" ns="local_costmap" />
     <rosparam file="$(find fetch_navigation)/config/costmap_local.yaml" command="load" ns="local_costmap" />
     <rosparam file="$(find fetch_navigation)/config/fetch/costmap_local.yaml" command="load" ns="local_costmap" />
+    <rosparam>
+      local_costmap:
+        global_frame: odom_combined
+        # default 5 (http://wiki.ros.org/navigation/Tutorials/Navigation%20Tuning%20Guide)
+        update_frequency: 10.0
+    </rosparam>
   </node>
 
   <node name="safe_tilt_head" pkg="jsk_fetch_startup" type="safe_tilt_head.py" />

--- a/jsk_fetch_robot/jsk_fetch_startup/package.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/package.xml
@@ -28,6 +28,7 @@
   <run_depend>amcl</run_depend>
   <run_depend>map_server</run_depend>
   <run_depend>move_base</run_depend>
+  <run_depend>robot_localization</run_depend>
 
   <!-- for fetch teleop -->
   <run_depend>app_manager</run_depend>

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/correct_position.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/correct_position.py
@@ -22,17 +22,20 @@ class CorrectPosition(ConnectionBasedTransport):
                 self.dock_pose = spot.pose
 
         self.is_docking = False
+        self.timer = rospy.Timer(rospy.Duration(1.0), self._cb_correct_position)
 
     def subscribe(self):
-        self.sub_dock = rospy.Subscriber('/battery_state',
-                                         BatteryState,
-                                         self._cb_correct_position)
+        self.sub_dock = rospy.Subscriber(
+            '/battery_state', BatteryState, self._cb)
 
     def unsubscribe(self):
         self.sub_dock.unregister()
 
-    def _cb_correct_position(self, msg):
-        if msg.is_charging and (not self.is_docking):
+    def _cb(self, msg):
+        self.is_docking = msg.is_charging
+
+    def _cb_correct_position(self, event):
+        if self.is_docking:
             self.pos = PoseWithCovarianceStamped()
             self.pos.header.stamp = rospy.Time.now()
             self.pos.header.frame_id = 'map'
@@ -44,7 +47,6 @@ class CorrectPosition(ConnectionBasedTransport):
                                         0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
                                         0.0, 0.0, 0.0, 0.0, 0.0, 1e-3]
             self.pub.publish(self.pos)
-        self.is_docking = msg.is_charging
 
 
 if __name__ == '__main__':

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/correct_position.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/correct_position.py
@@ -37,7 +37,12 @@ class CorrectPosition(ConnectionBasedTransport):
             self.pos.header.stamp = rospy.Time.now()
             self.pos.header.frame_id = 'map'
             self.pos.pose.pose = self.dock_pose
-            self.pos.pose.covariance = [0.25, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.25, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.06853891945200942]
+            self.pos.pose.covariance = [1e-3, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                        0.0, 1e-3, 0.0, 0.0, 0.0, 0.0,
+                                        0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                        0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                        0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                                        0.0, 0.0, 0.0, 0.0, 0.0, 1e-3]
             self.pub.publish(self.pos)
         self.is_docking = msg.is_charging
 

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/imu_corrector.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/imu_corrector.py
@@ -15,6 +15,9 @@ class ImuCorrector(object):
 
     def _cb(self, msg):
         msg.header.frame_id = 'base_link'
+        msg.angular_velocity_covariance = [0, 0, 0,
+                                           0, 0, 0,
+                                           0, 0, 0.000004]
         self.pub.publish(msg)
 
 

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/imu_corrector.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/imu_corrector.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import rospy
+
+from sensor_msgs.msg import Imu
+
+
+class ImuCorrector(object):
+    def __init__(self):
+        super(ImuCorrector, self).__init__()
+        self.sub = rospy.Subscriber(
+            '~input', Imu, self._cb, queue_size=1)
+        self.pub = rospy.Publisher(
+            '~output', Imu, queue_size=1)
+
+    def _cb(self, msg):
+        msg.header.frame_id = 'base_link'
+        self.pub.publish(msg)
+
+
+if __name__ == '__main__':
+    rospy.init_node('imu_corrector')
+    app = ImuCorrector()
+    rospy.spin()

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/imu_corrector.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/imu_corrector.py
@@ -17,7 +17,7 @@ class ImuCorrector(object):
         msg.header.frame_id = 'base_link'
         msg.angular_velocity_covariance = [0, 0, 0,
                                            0, 0, 0,
-                                           0, 0, 0.000004]
+                                           0, 0, 4e-6]
         self.pub.publish(msg)
 
 

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/odom_corrector.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/odom_corrector.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+import rospy
+
+from nav_msgs.msg import Odometry
+
+
+class OdomCorrector(object):
+    def __init__(self):
+        super(OdomCorrector, self).__init__()
+        self.sub = rospy.Subscriber(
+            '~input', Odometry, self._cb, queue_size=1)
+        self.pub = rospy.Publisher(
+            '~output', Odometry, queue_size=1)
+        self.covariance = [1e-3, 0, 0, 0, 0, 0,
+                           0, 1e-3, 0, 0, 0, 0,
+                           0, 0, 1e-6, 0, 0, 0,
+                           0, 0, 0, 1e-6, 0, 0,
+                           0, 0, 0, 0, 1e-6, 0,
+                           0, 0, 0, 0, 0, 1e-3]
+
+    def _cb(self, msg):
+        msg.pose.covariance = self.covariance
+        self.pub.publish(msg)
+
+
+if __name__ == '__main__':
+    rospy.init_node('odom_corrector')
+    app = OdomCorrector()
+    rospy.spin()

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/odom_corrector.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/odom_corrector.py
@@ -20,7 +20,7 @@ class OdomCorrector(object):
                            0, 0, 0, 0, 0, 1e-3]
 
     def _cb(self, msg):
-        msg.pose.covariance = self.covariance
+        msg.twist.covariance = self.covariance
         self.pub.publish(msg)
 
 

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/odom_corrector.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/odom_corrector.py
@@ -14,12 +14,13 @@ class OdomCorrector(object):
             '~output', Odometry, queue_size=1)
         self.covariance = [1e-3, 0, 0, 0, 0, 0,
                            0, 1e-3, 0, 0, 0, 0,
-                           0, 0, 1e-6, 0, 0, 0,
-                           0, 0, 0, 1e-6, 0, 0,
-                           0, 0, 0, 0, 1e-6, 0,
+                           0, 0, 0, 0, 0, 0,
+                           0, 0, 0, 0, 0, 0,
+                           0, 0, 0, 0, 0, 0,
                            0, 0, 0, 0, 0, 1e-3]
 
     def _cb(self, msg):
+        msg.pose.covariance = self.covariance
         msg.twist.covariance = self.covariance
         self.pub.publish(msg)
 


### PR DESCRIPTION
I add nodes which publish correct odom `/odom_corrected` and imu `/imu_corrected`.
Then I use these two corrected topics for `robot_localization` `ukf` for localization.
I wonder this change suppress odometry error.

- add odom_corrector.py
  - `/odom` does not have `frame_id`: https://github.com/fetchrobotics/fetch_ros/issues/70
  - `/odom` has zero covariance and overwrited in graft: https://github.com/fetchrobotics/fetch_robots/blob/indigo-devel/fetch_bringup/config/graft.yaml
- add imu_corrector.py
   - `/imu` has zero covariance and overwrited in graft: https://github.com/fetchrobotics/fetch_robots/blob/indigo-devel/fetch_bringup/config/graft.yaml
- use robot_localization instead of graft
  - `graft` is no more maintenanced: https://github.com/ros-perception/graft/issues/29#issuecomment-461223365 https://github.com/fetchrobotics/fetch_robots/pull/56
- refactor fetch_bringup.launch navigation parameters
- update `correct_position.py`
- update costmap parameters
- update move_base local planner parameters

now testing on fetch15.

cc. @708yamaguchi @sktometometo 

related:

 
