### PR TITLE
add fetch_ros to jsk_fetch_user.rosinstall.indigo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_user.rosinstall.indigo
+++ b/jsk_fetch_robot/jsk_fetch_user.rosinstall.indigo
@@ -16,3 +16,10 @@
     local-name: jsk-ros-pkg/jsk_3rdparty
     uri: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
     version: 2.1.13
+# indigo is already EOL and fetch_ros is never released.
+# We cannot use version 0.8.x (for melodic) because some packages of fetch_ros cannot be built in indigo PC. This is because indigo PC uses OpenCV 2.4.8 while fetch_ros of 0.8.x requires OpenCV 3.2.
+# See https://github.com/jsk-ros-pkg/jsk_robot/pull/1148
+- git:
+    local-name: fetchrobotics/fetch_ros
+    uri: https://github.com/fetchrobotics/fetch_ros.git
+    version: 4680118106ba8ffa99a803122bf1a9e383edf3df


### PR DESCRIPTION
Now, `fetch_ros` is not released in Indigo, so we need to install it manually.
I add `fetch_ros` to `jsk_fetch_user.rosinstall.indigo`.
(`jsk_fetch_user.rosinstall.indigo` is needed to build `jsk_fetch_startup` and `fetcheus` in fetch user's PC.)

Related to https://github.com/jsk-ros-pkg/jsk_robot/pull/1148