### PR TITLE
[fetcheus] override :move-to-wait to set :correction nil

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -332,6 +332,10 @@ Example: (send self :gripper :position) => 0.00"
                 d-vel (* (if (>= d-vel 0) 1.0 -1.0) min-rotation-abs-vel))))
           (ros::sleep))
         t)))
+  (:move-to-wait (&rest args)
+    (send-super* :move-to-wait
+                 (if (member :correction args) args
+                     (append args (list :correction nil)))))
 ) ;; fetch-interface (simple base actions)
 
 (defun fetch-init (&optional (create-viewer))

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -332,10 +332,8 @@ Example: (send self :gripper :position) => 0.00"
                 d-vel (* (if (>= d-vel 0) 1.0 -1.0) min-rotation-abs-vel))))
           (ros::sleep))
         t)))
-  (:move-to-wait (&rest args)
-    (send-super* :move-to-wait
-                 (if (member :correction args) args
-                     (append args (list :correction nil)))))
+  (:move-to-wait (&rest args &key (correction nil) &allow-other-keys)
+                 (send-super* :move-to-wait :correction correction args))
 ) ;; fetch-interface (simple base actions)
 
 (defun fetch-init (&optional (create-viewer))


### PR DESCRIPTION
~waiting upstream https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/418~
this PR skip correction step in `:move-to`, which is not useful for Fetch robot.