### PR TITLE
[fetcheus] skip undocking when subscribe timeout in go-to-spot

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -60,6 +60,8 @@
     (fetch-init))
   (dotimes (i 3)
     (let ((msg (one-shot-subscribe "/battery_state" power_msgs::batterystate :timeout 1500)))
+      ;; You may fail to subscribe /battery_state
+      ;; because of message md5 difference between melodic and indigo.
       (unless msg
         (ros::ros-warn "Failed to subscribe /battery_state")
         (ros::ros-warn "Skip undocking, so please make sure that Fetch is already undocked.")

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -59,12 +59,16 @@
     (require :fetch-interface "package://fetcheus/fetch-interface.l")
     (fetch-init))
   (dotimes (i 3)
-    (setq *is-charging* (send (one-shot-subscribe "/battery_state" power_msgs::batterystate) :is_charging))
-    (if *is-charging*
-      (progn (undock)))
-    (unless *is-charging*
-      (return))
-    (if (eq i 2) (progn (send *ri* :speak "Fail to undock") (ros::ros-error "Fail to undock"))))
+    (let ((msg (one-shot-subscribe "/battery_state" power_msgs::batterystate :timeout 1500)))
+      (unless msg
+        (ros::ros-warn "Failed to subscribe /battery_state")
+        (ros::ros-warn "Skip undocking, so please make sure that Fetch is already undocked.")
+        (return))
+      (setq *is-charging* (send msg :is_charging))
+      (if *is-charging*
+        (progn (undock)))
+      (unless *is-charging* (return))
+      (if (eq i 2) (progn (send *ri* :speak "Fail to undock") (ros::ros-error "Fail to undock")))))
   ;; go to spot
   (unless *spots*
     (setq *spots* (one-shot-subscribe "/spots_marker_array" visualization_msgs::MarkerArray)))


### PR DESCRIPTION
Because of message type difference between melodic and indigo, `go-to-spot` stacks in subscription of `/battery_state`.
I change to skip the subscription in `go-to-spot` when the subscription is timeout.