### PR TITLE
[WIP] Trial to speed up travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
   pip: true
   directories:
     - $HOME/.ccache
+    - $HOME/apt-cacher-ng
 sudo: required
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ env:
   global:
     - USE_TRAVIS=true
     - USE_DOCKER=true
-    - ROS_PARALLEL_JOBS="-j2"
+    - ROS_PARALLEL_JOBS="-j4"
     - CATKIN_PARALLEL_JOBS="-p2"
-    - ROS_PARALLEL_TEST_JOBS="-j1"
+    - ROS_PARALLEL_TEST_JOBS="-j2"
     - CATKIN_PARALLEL_TEST_JOBS="-p1"
     - NOT_TEST_INSTALL=true
   matrix:


### PR DESCRIPTION
Includes #1171 
- Upload apt-cacher-ng cache to speed up rosdep install 
- Increase number of jobs in travis test

See https://github.com/jsk-ros-pkg/jsk_robot/pull/1171#issuecomment-554206118