### PR TITLE
[jsk_pr2_startup] Modified power_monitor frequency

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/pr2_bringup.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2_bringup.launch
@@ -50,8 +50,14 @@
     <param name="port3" type="string" value="/etc/ros/sensors/battery3" />
     <param name="debug_level" type="int" value="0" />
   </node>
-  <node pkg="power_monitor" type="power_monitor"  name="power_monitor" respawn="true"/>
-  
+  <node name="power_monitor"
+        pkg="power_monitor" type="power_monitor"
+        respawn="true" >
+    <rosparam>
+      frequency: 1.0
+    </rosparam>
+  </node>
+
   <!-- Base Laser -->
   <node machine="c2" pkg="hokuyo_node" type="hokuyo_node" name="base_hokuyo_node" args="scan:=base_scan">
     <param name="port" type="string" value="/etc/ros/sensors/base_hokuyo" />


### PR DESCRIPTION
`power_monitor`'s default frequency is 0.1Hz (http://wiki.ros.org/power_monitor)
In current, `cable_warning` node subscribes `power_state` topic and the node looks at the state of the power supply to determine whether pr2 can move.
This PR modifies the frequency to 1Hz to make the check fast.