### PR TITLE
[jsk_pr2_startup] add logwarn in pr2_reset_motors.py

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/pr2_reset_motors.py
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/pr2_reset_motors.py
@@ -36,7 +36,6 @@ class PR2ResetMotorsNode(object):
         rospy.logdebug("runstop: %s, halted: %s" % (self.run_stop, halted))
         if self.run_stop and halted:
             rospy.logwarn("motor halted, but run stop is true")
-            rospy.logwarn("resetting motors")
             stamp = rospy.Time.now()
             history = filter(
                 lambda s: (stamp-s).to_sec() < self.watch_duration,
@@ -44,6 +43,7 @@ class PR2ResetMotorsNode(object):
             if len(history) > self.max_retry_num:
                 rospy.logerr("Maximum retry count reached. Give up resetting motors")
                 return
+            rospy.logwarn("resetting motors")
             self.reset_srv()
             self.history = history + [stamp]
 

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/pr2_reset_motors.py
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/pr2_reset_motors.py
@@ -35,6 +35,8 @@ class PR2ResetMotorsNode(object):
         halted = msg.data
         rospy.logdebug("runstop: %s, halted: %s" % (self.run_stop, halted))
         if self.run_stop and halted:
+            rospy.logwarn("motor halted, but run stop is true")
+            rospy.logwarn("resetting motors")
             stamp = rospy.Time.now()
             history = filter(
                 lambda s: (stamp-s).to_sec() < self.watch_duration,


### PR DESCRIPTION
add `logwarn` when pr2 reset motors.
we can get when PR2 reset motors in log file.
this is useful for debugging packet drop.