### PR TITLE
[jsk_baxter_startup] fix arg order in baxter.launch

### DIFF
--- a/jsk_baxter_robot/jsk_baxter_startup/baxter.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/baxter.launch
@@ -7,14 +7,14 @@
   <arg name="launch_voice_echo" default="true"/>
   <arg name="launch_moveit" default="true"/>
   <arg name="launch_teleop" default="false"/>
-  <arg name="launch_db" default="$(arg launch_mongodb)"
-       doc="launch jsk_robot_lifelog logging"/>
   <arg name="launch_mongodb" default="false"
        doc="Deprecated. Please use launch_db instead."/>
-  <arg name="launch_twitter" default="$(arg launch_tweet)"
-       doc="launch twitter" />
+  <arg name="launch_db" default="$(arg launch_mongodb)"
+       doc="launch jsk_robot_lifelog logging"/>
   <arg name="launch_tweet" default="false"
        doc="Deprecated. Please use launch_twitter instead." />
+  <arg name="launch_twitter" default="$(arg launch_tweet)"
+       doc="launch twitter" />
   <arg name="launch_wrench" default="true"/>
   <arg name="launch_time_signal" default="true"/>
   <arg name="sanity_check_joint_trajectory" default="true" />


### PR DESCRIPTION
`launch_mongodb` and `launch_tweet` should be defined before `launch_db` and `launch_twitter`.