### PR TITLE
[fetcheus] Fix :use-torso in *ri* :angle-vector and :angle-vector-sequence when simulation mode

### DIFF
--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -96,7 +96,7 @@
    ;; for simulation mode
    (when (send self :simulation-modep)
      (if (member :use-torso args)
-	 (setq args (append (subseq args 0 (position :use-torso args)) (if (> (length args) (+ 2 (position :use-torso args))) (subseq args (+ (position :use-torso args) 2))))))
+       (setq args (append (subseq args 0 (position :use-torso args)) (if (> (length args) (+ 2 (position :use-torso args))) (subseq args (+ (position :use-torso args) 2))))))
      (return-from :angle-vector (send* self :angle-vector-raw av tm ctype start-time args)))
    ;;
    (when (not (numberp tm))
@@ -368,7 +368,7 @@ Example: (send self :gripper :position) => 0.00"
   (unless (boundp '*co*)
     (ros::ros-warn ";; collision-object-publisher wait for \"apply_planning_scene\" service for ~A sec~%" 5)
     (if (ros::wait-for-service "apply_planning_scene" 5)
-	(setq *co* (instance collision-object-publisher :init))
+      (setq *co* (instance collision-object-publisher :init))
       (ros::ros-warn ";; could not find \"apply_planning_scene\" skip creating *co*~%")))
   (unless (boundp '*ri*) (setq *ri* (instance fetch-interface :init)))
 

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -96,7 +96,9 @@
    ;; for simulation mode
    (when (send self :simulation-modep)
      (if (member :use-torso args)
-       (setq args (append (subseq args 0 (position :use-torso args)) (if (> (length args) (+ 2 (position :use-torso args))) (subseq args (+ (position :use-torso args) 2))))))
+       (setq args (append (subseq args 0 (position :use-torso args))
+                          (if (> (length args) (+ 2 (position :use-torso args)))
+                            (subseq args (+ (position :use-torso args) 2))))))
      (return-from :angle-vector (send* self :angle-vector-raw av tm ctype start-time args)))
    ;;
    (when (not (numberp tm))

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -127,6 +127,10 @@
    (if (member :clear-velocities args) (setq clear-velocities (cadr (member :clear-velocities args))))
    ;; for simulation mode
    (when (send self :simulation-modep)
+     (if (member :use-torso args)
+       (setq args (append (subseq args 0 (position :use-torso args))
+                          (if (> (length args) (+ 2 (position :use-torso args)))
+                            (subseq args (+ (position :use-torso args) 2))))))
      (return-from :angle-vector-sequence
                   (send* self :angle-vector-sequence-raw avs tms ctype start-time args)))
    (unless (and (listp tms) (every #'numberp tms))

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -363,7 +363,11 @@ Example: (send self :gripper :position) => 0.00"
 (defun fetch-init (&optional (create-viewer))
   (unless (boundp '*fetch*) (fetch) (send *fetch* :reset-pose))
   (unless (ros::ok) (ros::roseus "fetch_eus_interface"))
-  (unless (boundp '*co*) (setq *co* (instance collision-object-publisher :init)))
+  (unless (boundp '*co*)
+    (ros::ros-warn ";; collision-object-publisher wait for \"apply_planning_scene\" service for ~A sec~%" 5)
+    (if (ros::wait-for-service "apply_planning_scene" 5)
+	(setq *co* (instance collision-object-publisher :init))
+      (ros::ros-warn ";; could not find \"apply_planning_scene\" skip creating *co*~%")))
   (unless (boundp '*ri*) (setq *ri* (instance fetch-interface :init)))
 
   (ros::spin-once)

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -95,6 +95,8 @@
    (if (member :clear-velocities args) (setq clear-velocities (cadr (member :clear-velocities args))))
    ;; for simulation mode
    (when (send self :simulation-modep)
+     (if (member :use-torso args)
+	 (setq args (append (subseq args 0 (position :use-torso args)) (if (> (length args) (+ 2 (position :use-torso args))) (subseq args (+ (position :use-torso args) 2))))))
      (return-from :angle-vector (send* self :angle-vector-raw av tm ctype start-time args)))
    ;;
    (when (not (numberp tm))

--- a/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
+++ b/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
@@ -129,7 +129,8 @@
 (deftest fetch-use-torso
   (let ()
     (setq *ri* (instance fetch-interface :init))
-    (assert (send *ri* :angle-vector (send *fetch* :angle-vector) 3000 :use-torso t))
+    (assert (send *ri* :angle-vector (send *fetch* :angle-vector) 3000 :use-torso t)
+            "failed to do :angle-vector with :use-torso in kinematics simulator")
     (assert (send *ri* :angle-vector-sequence
                   (list (send *fetch* :init-pose) (send *fetch* :angle-vector))
                   (list 3000 3000) :use-torso t)

--- a/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
+++ b/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
@@ -130,6 +130,10 @@
   (let ()
     (setq *ri* (instance fetch-interface :init))
     (assert (send *ri* :angle-vector (send *fetch* :angle-vector) 3000 :use-torso t))
+    (assert (send *ri* :angle-vector-sequence
+                  (list (send *fetch* :init-pose) (send *fetch* :angle-vector))
+                  (list 3000 3000) :use-torso t)
+            "failed to do :angle-vector-sequence with :use-torso in kinematics simulator")
     ))
 
 (deftest fetch-init-test

--- a/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
+++ b/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
@@ -126,6 +126,9 @@
             (format nil ":go-velocity returns t with argument ~A" go-vel-arg))
     ))
 
+(deftest fetch-init-test
+  (let ()
+    (fetch-init)))
 
 (run-all-tests)
 (exit)

--- a/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
+++ b/jsk_fetch_robot/fetcheus/test/test-fetcheus.l
@@ -126,6 +126,12 @@
             (format nil ":go-velocity returns t with argument ~A" go-vel-arg))
     ))
 
+(deftest fetch-use-torso
+  (let ()
+    (setq *ri* (instance fetch-interface :init))
+    (assert (send *ri* :angle-vector (send *fetch* :angle-vector) 3000 :use-torso t))
+    ))
+
 (deftest fetch-init-test
   (let ()
     (fetch-init)))


### PR DESCRIPTION
```
(send *ri* :angle-vector (send *fetch* :angle-vector) 3000 :use-torso t)
```
fails with 
```
Call Stack (max depth: 20):
  0: at (apply #'send-message self (class . super) :angle-vector av tm args)
  1: at (apply #'send-message self (class . super) :angle-vector av tm args)
  2: at (apply #'send-message self (class . super) :angle-vector av tm args)
  3: at (send-super* :angle-vector av tm args)
  4: at (let* ((prev-av (send self :state :potentio-vector :wait-until-update t)) (diff-av (v- av prev-av))) (when (send self :check-continuous-joint-move-over-180 diff-av) (let* (avs (minjerk (instance minjerk-interpolator :init)) (scale-av (send self :sub-angle-vector av prev-av)) dist div) (setq dist (abs (find-extream (coerce diff-av cons) #'abs #'>=))) (setq div (round (/ dist 120.0))) (send minjerk :reset :position-list (list prev-av (v+ prev-av scale-av)) :time-list (list tm)) (send minjerk :start-interpolation) (send minjerk :pass-time (/ tm div)) (dotimes (i div) (setq avs (append avs (list (send minjerk :pass-time (/ tm div)))))) (send* self :angle-vector-sequence-raw avs (make-list div :initial-element (/ tm div)) args) (return-from :angle-vector-raw (car (last avs))))) (send-super* :angle-vector av tm args))
  5: at (apply #'send self :angle-vector-raw av tm ctype start-time args)
  6: at (apply #'send self :angle-vector-raw av tm ctype start-time args)
  7: at (send* self :angle-vector-raw av tm ctype start-time args)
  8: at (return-from :angle-vector (send* self :angle-vector-raw av tm ctype start-time args))
  9: at (progn (return-from :angle-vector (send* self :angle-vector-raw av tm ctype start-time args)))
  10: at (if (send self :simulation-modep) (progn (return-from :angle-vector (send* self :angle-vector-raw av tm ctype start-time args))))
  11: at (when (send self :simulation-modep) (return-from :angle-vector (send* self :angle-vector-raw av tm ctype start-time args)))
  12: at (let ((ctype controller-type) (start-time 0) (start-offset-time nil) (use-torso t) (clear-velocities t)) (if (= (length args) 1) (setq ctype (car args) args (cdr args))) (if (and (>= (length args) 2) (null (member (car args) '(:use-torso :start-time :clear-velocities)))) (setq ctype (car args) start-time (cadr args) args (cddr args))) (if (member :use-torso args) (setq use-torso (cadr (member :use-torso args)))) (if (member :start-time args) (setq start-time (cadr (member :start-time args)))) (if (member :start-offset-time args) (setq start-offset-time (cadr (member :start-offset-time args)))) (if (member :clear-velocities args) (setq clear-velocities (cadr (member :clear-velocities args)))) (when (send self :simulation-modep) (return-from :angle-vector (send* self :angle-vector-raw av tm ctype start-time args))) (when (not (numberp tm)) (warn ":angle-vector tm is not a number, use :angle-vector av tm args")) (send* self :angle-vector-motion-plan av :ctype ctype :move-arm :rarm :total-time tm :start-offset-time (if start-offset-time start-offset-time start-time) :clear-velocities clear-velocities :use-torso use-torso args))
  13: at (send *ri* :angle-vector (send *fetch* :angle-vector) 4000 :use-torso nil)
  14: at (apply #'ros::load-org-for-ros ros::fullname args)
  15: at (apply #'ros::load-org-for-ros ros::fullname args)
  16: at (let ((ros::fullname fname)) (when (substringp "package://" fname) (setq ros::fullname (ros::resolve-ros-path fname)) (when ros::*compile-message* (let* ((ros::urlname (url-pathname fname)) (package-name (send ros::urlname :host)) (ros::path-name (format nil "~A_~A" package-name (substitute 95 47 (concatenate string (subseq (send ros::urlname :directory-string) 1) (send ros::urlname :name))))) (ros::old-module (find ros::path-name *loaded-modules* :key #'lisp::load-module-file-name :test #'equal))) (unless ros::old-module (let* ((ros::ppath (unix:getenv "CMAKE_PREFIX_PATH")) (dir (format nil "~A/share/roseus/ros/~A" (subseq ros::ppath 0 (position 58 ros::ppath)) package-name))) (unless (probe-file dir) (unix:mkdir dir)) (compiler:compile-file-if-src-newer ros::fullname (format nil "~A/~A" dir ros::path-name)) (return-from load (load (format nil "~A/~A.so" dir ros::path-name) :entry (format nil "___~A" ros::path-name)))))))) (if (null ros::fullname) (error "file ~s not found" fname)) (apply #'ros::load-org-for-ros ros::fullname args))
  17: at (load "amabe_hand_only.l")
  18: at #<compiled-code #X563d99089e18>
/opt/ros/melodic/share/euslisp/jskeus/eus/Linux64/bin/irteusgl 0 error: no such keyword :use-torso in (apply #'send-message self (class . super) :angle-vector av tm args)
```                                                                                                                
cc: @k-okada