### PR TITLE
Update jsk_travis to 0.5.17 and fix travis

### DIFF
--- a/.travis.rosinstall.indigo
+++ b/.travis.rosinstall.indigo
@@ -18,3 +18,10 @@
     local-name: strands-project/mongodb_store
     uri: https://github.com/strands-project/mongodb_store.git
     version: 0.4.5
+# jsk_fetch_startup requires fetch_ros with following PRs.
+# https://github.com/fetchrobotics/fetch_ros/pull/144
+# https://github.com/fetchrobotics/fetch_ros/pull/146
+- git:
+    local-name: fetchrobotics/fetch_ros
+    uri: https://github.com/fetchrobotics/fetch_ros.git
+    version: 0ad250a996a2ef68172fc064698f253bc9cf08d0

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -25,9 +25,3 @@
    uri: https://github.com/tork-a/jsk_demos-release.git
    local-name: jsk_maps
    version: release/kinetic/jsk_maps
-# Need to wait for app_manager 1.1.1 for kinetic and later. For indigo, we could not expect newer releases.....
-# https://github.com/PR2/app_manager/issues/12 (Relerase request 1.1.1)
-- git:
-    local-name: PR2/app_manager
-    uri: https://github.com/PR2/app_manager.git
-    version: kinetic-devel

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -25,3 +25,10 @@
    uri: https://github.com/tork-a/jsk_demos-release.git
    local-name: jsk_maps
    version: release/kinetic/jsk_maps
+# jsk_fetch_startup requires fetch_ros with following PRs.
+# https://github.com/fetchrobotics/fetch_ros/pull/144
+# https://github.com/fetchrobotics/fetch_ros/pull/146
+- git:
+    local-name: fetchrobotics/fetch_ros
+    uri: https://github.com/fetchrobotics/fetch_ros.git
+    version: 0ad250a996a2ef68172fc064698f253bc9cf08d0

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -23,19 +23,12 @@
    uri: https://github.com/tork-a/jsk_demos-release.git
    local-name: jsk_maps
    version: release/kinetic/jsk_maps
-- git: # wait until releasing (https://github.com/PR2/app_manager/issues/12)
-   uri: https://github.com/pr2/app_manager.git
-   local-name: app_manager
 - git: # wait for melodic release https://github.com/ros-naoqi/pepper_robot/issues/50
    uri: https://github.com/ros-naoqi/pepper_robot.git
    local-name: pepper_robot
 - git: # https://github.com/ros-naoqi/nao_robot/issues/40
    uri: https://github.com/ros-naoqi/nao_robot.git
    local-name: nao_robot
-- git: # use latest pr2_computer_monitor, wait for melodic release https://github.com/PR2/pr2_robot/issues/261
-   uri: https://github.com/pr2-gbp/pr2_robot-release.git
-   local-name: pr2_computer_monitor
-   version: release/kinetic/pr2_computer_monitor
 - git: # use naoqi_pose, wait for melodic release https://github.com/ros-naoqi/naoqi_bridge/issues/94
    uri: https://github.com/ros-naoqi/naoqi_bridge-release.git
    local-name: naoqi_pose

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -33,3 +33,10 @@
    uri: https://github.com/ros-naoqi/naoqi_bridge-release.git
    local-name: naoqi_pose
    version: release/kinetic/naoqi_pose
+# jsk_fetch_startup requires fetch_ros with following PRs.
+# https://github.com/fetchrobotics/fetch_ros/pull/144
+# https://github.com/fetchrobotics/fetch_ros/pull/146
+- git:
+    local-name: fetchrobotics/fetch_ros
+    uri: https://github.com/fetchrobotics/fetch_ros.git
+    version: ba4bafdb802e474487d1e0d893aa25c9535dc55f

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ before_script:
   - if [ "$ROS_DISTRO" == "melodic" ]; then export BEFORE_SCRIPT="pwd; ls -al ; ls -al jsk_robot/; ls -al jsk_robot/.travis.rosinstall.melodic; wstool merge jsk_robot/.travis.rosinstall.melodic; wstool update"; fi
   # skip running postinst for ros-ROS_DISTRO-julius https://gist.github.com/jordansissel/748313#file-stripdeb-sh
   - export BEFORE_SCRIPT="apt-get download ros-$ROS_DISTRO-julius; wget -O stripdeb.sh https://gist.githubusercontent.com/jordansissel/748313/raw/8aebce360bc082e33af7bba3c90f755eb655783b/stripdeb.sh; bash stripdeb.sh ros-$ROS_DISTRO-julius*.deb; sudo dpkg --force-all -i ros-$ROS_DISTRO-julius*.deb; sudo apt-get -y -f install; sudo apt-mark hold ros-$ROS_DISTRO-julius; $BEFORE_SCRIPT"
-script: source .travis/travis.sh
+script: .travis/travis.sh


### PR DESCRIPTION
- use `jsk_travis` `0.5.17`
- remove released packages from `.travis.rosinstall.$ROS_DISTRO`
- add `fetch_ros` in `.travis.rosinstall.$ROS_DISTRO` (https://github.com/fetchrobotics/fetch_ros/pull/144, https://github.com/fetchrobotics/fetch_ros/pull/146)