### PR TITLE
[jsk_pr2_startup] add watch duration comment for pr2_reset_motors

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/pr2_reset_motors.py
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/pr2_reset_motors.py
@@ -52,6 +52,7 @@ class PR2ResetMotorsNode(object):
                 self.history)
             if len(history) > self.max_retry_num:
                 rospy.logerr("Maximum retry count reached. Give up resetting motors")
+                rospy.logerr("Waiting for {} seconds for other retries".format(self.watch_duration))
                 return
             rospy.logwarn("resetting motors")
             self.reset_srv()

--- a/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
@@ -153,7 +153,11 @@
            file="$(find jsk_pr2_startup)/jsk_pr2_moveit/start_pr2_moveit.launch" />
 
   <node if="$(arg launch_reset_motors)"
-        name="pr2_reset_motors" pkg="jsk_pr2_startup" type="pr2_reset_motors.py"/>
+        name="pr2_reset_motors" pkg="jsk_pr2_startup" type="pr2_reset_motors.py">
+    <rosparam>
+      watch_duration: 30
+    </rosparam>
+  </node>
 
   <node pkg="jsk_robot_startup" type="finish_launch_sound.py"
         machine="c2"


### PR DESCRIPTION
update `watch_duration` to `30` and reset motors more frequently.