### PR TITLE
[WIP] convert t265 odom frame to initial base_link pose

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/body_on_odom_publisher.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/body_on_odom_publisher.py
@@ -22,7 +22,8 @@ def update_position():
 
 if __name__ == "__main__":
     rospy.init_node("body_on_odom_publisher")
-    tfl = tf.TransformListener(True, rospy.Duration(10))
+    # tfl = tf.TransformListener(True, rospy.Duration(10))
+    tfl = tf.TransformListener()
     tfb = tf.TransformBroadcaster()
     robot_frame = rospy.get_param("~robot_frame", "BODY")
     rospy.loginfo("robot frame: {}".format(robot_frame))

--- a/jsk_robot_common/jsk_robot_startup/scripts/body_on_odom_publisher.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/body_on_odom_publisher.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+import rospy
+import tf
+import time
+
+def update_position():
+    global position
+    global orientation
+    global stamp
+
+    rospy.logdebug("update body_on_odom")
+    try:
+        # stamp = rospy.Time(0)
+        tfl.waitForTransform(robot_frame, odom_ground_frame, stamp, rospy.Duration(1.0))
+        (trans, rot) = tfl.lookupTransform(robot_frame, odom_ground_frame, stamp)
+        position = [0, 0, trans[2]]
+        orientation = [0, 0, 0, 1]
+    except:
+        rospy.logerr("Failed to update body_on_odom")
+        return
+
+if __name__ == "__main__":
+    rospy.init_node("body_on_odom_publisher")
+    tfl = tf.TransformListener(True, rospy.Duration(10))
+    tfb = tf.TransformBroadcaster()
+    robot_frame = rospy.get_param("~robot_frame", "BODY")
+    rospy.loginfo("robot frame: {}".format(robot_frame))
+    odom_ground_frame = rospy.get_param("~odom_ground_frame", "odom_ground")
+    rospy.loginfo("odom ground frame: {}".format(odom_ground_frame))
+    rate = rospy.get_param("~rate", 100)
+    r = rospy.Rate(rate)
+
+    position = None
+    orientation = None
+
+    while not rospy.is_shutdown():
+        stamp = rospy.Time.now()
+        update_position()
+        try:
+            tfb.sendTransform(position, orientation, stamp, "body_on_odom", robot_frame)
+            # tfb.sendTransform(position, orientation, rospy.Time(0), "body_on_odom", robot_frame)
+        except:
+            rospy.logerr("Failed to broadcast {} to {} transform".format("body_on_odom", robot_frame))
+            time.sleep(1)
+        r.sleep()

--- a/jsk_robot_common/jsk_robot_startup/scripts/odom_ground_publisher.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/odom_ground_publisher.py
@@ -12,8 +12,9 @@ def callback(msg):
 
     rospy.loginfo("reset odom_ground")
     try:
-        stamp = rospy.Time(0)
+        tfl.waitForTransform(odom_frame, "/lleg_end_coords", stamp, rospy.Duration(1.0))
         (l_trans,l_rot) = tfl.lookupTransform(odom_frame, "lleg_end_coords", stamp)
+        tfl.waitForTransform(odom_frame, "/rleg_end_coords", stamp, rospy.Duration(1.0))
         (r_trans,r_rot) = tfl.lookupTransform(odom_frame, "rleg_end_coords", stamp)
         position = numpy.mean([l_trans, r_trans], axis=0)
         orientation = [0, 0, 0, 1]
@@ -37,9 +38,12 @@ if __name__ == "__main__":
     orientation = None
 
     while not rospy.is_shutdown():
+        # stamp = rospy.Time(0)
+        stamp = rospy.Time.now()
         if position is not None:
             try:
-                tfb.sendTransform(position, orientation, rospy.Time.now(), odom_ground_frame, odom_frame)
+                # tfb.sendTransform(position, orientation, rospy.Time.now(), odom_ground_frame, odom_frame)
+                tfb.sendTransform(position, orientation, stamp, odom_ground_frame, odom_frame)
             except:
                 rospy.logerr("Failed to broadcast {} to {} transform".format(odom_frame, odom_ground_frame))
         else:

--- a/jsk_robot_common/jsk_robot_startup/scripts/odom_ground_publisher.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/odom_ground_publisher.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import rospy
+import numpy
+from std_msgs.msg import Empty as EmptyMsg
+import tf
+import time
+
+def callback(msg):
+    rospy.loginfo("reset odom_ground")
+    try:
+        stamp = rospy.Time(0)
+        (l_trans,l_rot) = tfl.lookupTransform(odom_frame, "lleg_end_coords", stamp)
+        (r_trans,r_rot) = tfl.lookupTransform(odom_frame, "rleg_end_coords", stamp)
+        position = numpy.mean([l_trans, r_trans], axis=0)
+        orientation = [0, 0, 0, 1]
+    except:
+        rospy.logerr("Failed to reset {} frame".format(odom_ground_frame))
+        return
+
+if __name__ == "__main__":
+    rospy.init_node("odom_ground_publisher")
+    sub = rospy.Subscriber("/odom_init_trigger", EmptyMsg, callback)
+    tfl = tf.TransformListener(True, rospy.Duration(10))
+    tfb = tf.TransformBroadcaster()
+    odom_frame = rospy.get_param("~odom_frame", "odom")
+    odom_ground_frame = rospy.get_param("~odom_ground_frame", "odom_ground")
+    rate = rospy.get_param("~rate", 1)
+    r = rospy.Rate(rate)
+
+    position = None
+    orientation = None
+
+    while not rospy.is_shutdown():
+        if position is not None:
+            try:
+                tfb.sendTransform(position, orientation, rospy.Time(0), odom_ground_frame, odom_frame)
+            except:
+                rospy.logerr("Failed to broadcast {} to {} transform".format(odom_frame, odom_ground_frame))
+        else:
+            print("make {} frame".format(odom_ground))
+            dummy_msg = EmptyMsg()
+            callback(dummy_msg)
+            time.sleep(1) # wait to make odom ground tf
+        r.sleep()

--- a/jsk_robot_common/jsk_robot_startup/scripts/odom_ground_publisher.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/odom_ground_publisher.py
@@ -7,6 +7,9 @@ import tf
 import time
 
 def callback(msg):
+    global position
+    global orientation
+
     rospy.loginfo("reset odom_ground")
     try:
         stamp = rospy.Time(0)
@@ -24,8 +27,10 @@ if __name__ == "__main__":
     tfl = tf.TransformListener(True, rospy.Duration(10))
     tfb = tf.TransformBroadcaster()
     odom_frame = rospy.get_param("~odom_frame", "odom")
+    rospy.loginfo("odom frame: {}".format(odom_frame))
     odom_ground_frame = rospy.get_param("~odom_ground_frame", "odom_ground")
-    rate = rospy.get_param("~rate", 1)
+    rospy.loginfo("odom ground frame: {}".format(odom_ground_frame))
+    rate = rospy.get_param("~rate", 500)
     r = rospy.Rate(rate)
 
     position = None
@@ -34,11 +39,11 @@ if __name__ == "__main__":
     while not rospy.is_shutdown():
         if position is not None:
             try:
-                tfb.sendTransform(position, orientation, rospy.Time(0), odom_ground_frame, odom_frame)
+                tfb.sendTransform(position, orientation, rospy.Time.now(), odom_ground_frame, odom_frame)
             except:
                 rospy.logerr("Failed to broadcast {} to {} transform".format(odom_frame, odom_ground_frame))
         else:
-            print("make {} frame".format(odom_ground))
+            rospy.loginfo("make {} frame".format(odom_ground_frame))
             dummy_msg = EmptyMsg()
             callback(dummy_msg)
             time.sleep(1) # wait to make odom ground tf

--- a/jsk_robot_common/jsk_robot_startup/scripts/odom_ground_publisher.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/odom_ground_publisher.py
@@ -25,7 +25,8 @@ def callback(msg):
 if __name__ == "__main__":
     rospy.init_node("odom_ground_publisher")
     sub = rospy.Subscriber("/odom_init_trigger", EmptyMsg, callback)
-    tfl = tf.TransformListener(True, rospy.Duration(10))
+    # tfl = tf.TransformListener(True, rospy.Duration(10))
+    tfl = tf.TransformListener()
     tfb = tf.TransformBroadcaster()
     odom_frame = rospy.get_param("~odom_frame", "odom")
     rospy.loginfo("odom frame: {}".format(odom_frame))


### PR DESCRIPTION
This is WIP. I will make this branch clean when PR.

Extend current CameraToBaseOffset.py
```jsk_robot_common/jsk_robot_startup/scripts/CameraToBaseOffset.py```

Camera optical frame and initial odom frame have to be same in the current one.
This extension is for the case when they are not same like RealSense T265.