### PR TITLE
[jsk_robot_startup] add viso2_ros to package.xml

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/package.xml
+++ b/jsk_robot_common/jsk_robot_startup/package.xml
@@ -40,6 +40,7 @@
   <run_depend>tf2_py</run_depend>
   <run_depend>tf2_geometry_msgs</run_depend>
   <run_depend>urdf</run_depend>
+  <run_depend>viso2_ros</run_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>pr2_gazebo</test_depend>


### PR DESCRIPTION
`jsk_robot_startup` depends on `viso2_ros`, but `viso2_ros` does not exist in package.xml of `jsk_robot_startup`.

https://github.com/jsk-ros-pkg/jsk_robot/blob/acb5000cd23249b38ad69bb5df3ae593fabbb1d5/jsk_robot_common/jsk_robot_startup/launch/viso.launch#L19

This caused me an error when I set up real HRP2JSK and HRP2JSKNT environment.
I added viso2_ros to run_depend in package.xml.
