### PR TITLE
remove deprecated planning_context and add load_robot_description arg…

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_moveit/start_pr2_moveit.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_moveit/start_pr2_moveit.launch
@@ -12,10 +12,6 @@
        name="sensor_params_file"
        value="$(find jsk_pr2_startup)/jsk_pr2_moveit/sensors_kinect.yaml" />
 
-  <include file="$(find pr2_moveit_config)/launch/planning_context.launch">
-    <arg name="load_robot_description" value="false"/>
-  </include>
-
   <!--node pkg="tf" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 odom_combined base_footprint 100" /-->
   <!--node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
     <param name="/use_gui" value="true"/>
@@ -24,6 +20,7 @@
 
   <include file="$(find pr2_moveit_config)/launch/move_group.launch">
     <arg name="allow_trajectory_execution" value="true"/>
+    <arg name="load_robot_description" value="false"/>
     <arg name="moveit_octomap_sensor_params_file"
          value="$(arg sensor_params_file)" />
   </include>


### PR DESCRIPTION
… in move_group.launch

this PR is for pr2_moveit_config in melodic.

with this commit, `planning_context.launch` and `load_robot_decription` is moved to move_group.launch
this PR remove the deprecated `planning_context.launch` in `start_pr2_moveit.launch` and move `load_robot_description` in `move_group.launch`
https://github.com/ros-planning/moveit_pr2/commit/32e9b32b63bbb1072749113a91ce33f5a32c29c8