### PR TITLE
drop hydro because precise is removed from archieve.ubuntu.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,6 @@ env:
     - CATKIN_PARALLEL_TEST_JOBS="-p1"
     - NOT_TEST_INSTALL=true
   matrix:
-    - ROS_DISTRO=hydro   USE_DEB=true
-    - ROS_DISTRO=hydro   USE_DEB=false EXTRA_DEB="ros-hydro-convex-decomposition ros-hydro-ivcon" BUILD_PKGS="jsk_pr2_calibration jsk_robot_startup pr2_base_trajectory_action jsk_pr2_startup jsk_pr2_desktop"
     - ROS_DISTRO=indigo  USE_DEB=true  TEST_PKGS="jsk_robot_startup" # app_manager required to pass jsk_fetch test, so this job mainly test if we can build sources
     - ROS_DISTRO=indigo  USE_DEB=false EXTRA_DEB="ros-indigo-convex-decomposition ros-indigo-ivcon"
     - ROS_DISTRO=kinetic USE_DEB=true
@@ -39,7 +37,6 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: ROS_DISTRO=hydro   USE_DEB=false EXTRA_DEB="ros-hydro-convex-decomposition ros-hydro-ivcon" BUILD_PKGS="jsk_pr2_calibration jsk_robot_startup pr2_base_trajectory_action jsk_pr2_startup jsk_pr2_desktop"
     - env: ROS_DISTRO=kinetic USE_DEB=true
     - env: ROS_DISTRO=melodic USE_DEB=true
 before_script:


### PR DESCRIPTION
we cannot do `apt-get update` in `12.04 precise` because it is removed from `archive.ubuntu.com`
http://archive.ubuntu.com/ubuntu/dists/precise
this PR drop hydro test.