### PR TITLE
[jsk_fetch_startup] Do not replace sound when other node is speaking

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -71,6 +71,7 @@
     local-name: mikeferguson/robot_calibration
     uri: https://github.com/mikeferguson/robot_calibration.git
     version: 0.5.5
+# https://github.com/ros-drivers/audio_common/pull/173
 - git:
     local-name: ros-drivers/audio_common
     uri: https://github.com/ros-drivers/audio_common.git

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -34,6 +34,7 @@
   </node>
   <node if="$(arg boot_sound)" pkg="jsk_robot_startup" name="boot_sound" type="boot_sound.py" >
     <param name="wav_file" value="$(find jsk_fetch_startup)/data/boot_sound.wav" />
+    <param name="preferred_interface" value="wlan0" />
   </node>
 
   <!-- look at human for Fetch -->

--- a/jsk_robot_common/jsk_robot_startup/scripts/boot_sound.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/boot_sound.py
@@ -18,10 +18,10 @@ if __name__ == "__main__":
     sound = SoundClient(sound_action='sound_play', blocking=True)
     sound.actionclient.wait_for_server()
 
-    if len(ni.ifaddresses('eth0')) > 2:
-        ip = ni.ifaddresses('eth0')[2][0]['addr']
-    elif len(ni.ifaddresses('wlan0')) > 2:
-        ip = ni.ifaddresses('wlan0')[2][0]['addr']
+    interfaces = [x for x in ni.interfaces() if x[0:3] in ['eth', 'enp', 'wla', 'wlp'] and
+                  2 in ni.ifaddresses(x).keys()]
+    if len(interfaces) > 0:
+        ip = ni.ifaddresses(interfaces[0])[2][0]['addr']
     else:
         ip = None
 

--- a/jsk_robot_common/jsk_robot_startup/scripts/boot_sound.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/boot_sound.py
@@ -3,14 +3,10 @@
 # https://www.youtube.com/watch?v=HM-xG0qXaeA&&
 # ffmpeg -i R2D2\ all\ Sounds\ -\ Star\ Wars\ free\ sounds.mp4 -ss 48 -t 10 R2D2.wav
 
-import rospy
-import time, socket, os
 import netifaces as ni
-import rospkg
+import rospy
 
 from sound_play.libsoundplay import SoundClient
-import actionlib
-from sound_play.msg import SoundRequestAction
 
 if __name__ == "__main__":
     rospy.init_node("boot_sound")
@@ -19,32 +15,22 @@ if __name__ == "__main__":
     else:
         wav_file = "/usr/share/sounds/alsa/Front_Center.wav"
 
-    sound = SoundClient()
-    time.sleep(1) # ???
-    ac = actionlib.SimpleActionClient('sound_play', SoundRequestAction)
-    ac.wait_for_server()
+    sound = SoundClient(sound_action='sound_play', blocking=True)
+    sound.actionclient.wait_for_server()
 
-
-    interfaces =  [x for x in ni.interfaces() if x[0:3] in ['eth', 'enp', 'wla', 'wlp'] and
-                   2 in ni.ifaddresses(x).keys()]
-    if len(interfaces) > 0 :
-        ip = ni.ifaddresses(interfaces[0])[2][0]['addr']
+    if len(ni.ifaddresses('eth0')) > 2:
+        ip = ni.ifaddresses('eth0')[2][0]['addr']
+    elif len(ni.ifaddresses('wlan0')) > 2:
+        ip = ni.ifaddresses('wlan0')[2][0]['addr']
     else:
         ip = None
 
     # play sound
     rospy.loginfo("Playing {}".format(wav_file))
-    sound.playWave(wav_file)
-    time.sleep(10) # make sure to topic is going out
+    sound.playWave(wav_file, replace=False)
 
     # notify ip address
     ip_text = "My internet address is {}".format(ip)
     rospy.loginfo(ip_text)
     ip_text = ip_text.replace('.', ', ')
-    sound.say(ip_text)
-    time.sleep(1) # make sure to topic is going out
-
-
-
-
-
+    sound.say(ip_text, replace=False)

--- a/jsk_robot_common/jsk_robot_startup/scripts/boot_sound.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/boot_sound.py
@@ -20,6 +20,14 @@ if __name__ == "__main__":
 
     interfaces = [x for x in ni.interfaces() if x[0:3] in ['eth', 'enp', 'wla', 'wlp'] and
                   2 in ni.ifaddresses(x).keys()]
+
+    # If preferred interface is given, it is placed at the top of the interfaces list
+    if rospy.has_param("~preferred_interface"):
+        preferred_interface = rospy.get_param("~preferred_interface")
+        if preferred_interface in interfaces:
+            interfaces.remove(preferred_interface)
+        interfaces.insert(0, preferred_interface)
+
     if len(interfaces) > 0:
         ip = ni.ifaddresses(interfaces[0])[2][0]['addr']
     else:


### PR DESCRIPTION
this PR enables fetch to wait speaking until other node is speaking.

cc. @708yamaguchi 

related: https://github.com/ros-drivers/audio_common/pull/173