### PR TITLE
Update jsk_kinova_startup dependencies to reflect kinova upstream

### DIFF
--- a/jsk_kinova_robot/kinova.rosinstall
+++ b/jsk_kinova_robot/kinova.rosinstall
@@ -2,10 +2,13 @@
     local-name: jsk_robot
     uri: https://github.com/jsk-ros-pkg/jsk_robot.git
     version: master
+# ros_kortex is updating to v2.3.0 in master branch
+# but the internal firmware in JSK kinova is still ver2.2.0
 - git:
     local-name: ros_kortex
     uri: https://github.com/Kinovarobotics/ros_kortex
-    version: kinetic-devel
+    version: 996ffaffd33c135c6888ae624271aa2742fd83d4
 - git:
     local-name: ros_kortex_vision
     uri: https://github.com/Kinovarobotics/ros_kortex_vision
+    version: 442dde78897560b947e9edf16955b1fb40435309

--- a/jsk_kinova_robot/kinovaeus/package.xml
+++ b/jsk_kinova_robot/kinovaeus/package.xml
@@ -25,11 +25,11 @@
   <run_depend>pr2eus_moveit</run_depend>
 
   <test_depend>kortex_gazebo</test_depend>
-  <!-- TODO: Remove this dependency after below PR is merged -->
-  <!-- https://github.com/Kinovarobotics/ros_kortex/pull/140 -->
+  <!-- TODO: Remove this dependency after kinova's internal firmware >= v2.3.0 and below commit is included by kinova.rosinstall -->
+  <!-- See https://github.com/Kinovarobotics/ros_kortex/pull/140 -->
   <test_depend>kortex_control</test_depend>
-  <!-- TODO: Remove these dependencies after below PR is merged -->
-  <!-- https://github.com/Kinovarobotics/ros_kortex/pull/142 -->
+  <!-- TODO: Remove this dependency after kinova's internal firmware >= v2.3.0 and below commit is included by kinova.rosinstall -->
+  <!-- See https://github.com/Kinovarobotics/ros_kortex/pull/142 -->
   <test_depend>gen3_robotiq_2f_85_move_it_config</test_depend>
   <test_depend>gen3_robotiq_2f_140_move_it_config</test_depend>
   <test_depend>gen3_lite_gen3_lite_2f_move_it_config</test_depend>


### PR DESCRIPTION
I update jsk_kinova_startup dependencies to reflect kinova upstream

- kortex_ros v2.3.0 is merged, but our kinova arm's firmware is v2.2.0, so I use v2.2.0 kortex_ros in kinova.rosinstall (Note that kortex_ros v2.3.0 is incompatible with kinova arm of firmware v2.2.0)
  - https://github.com/Kinovarobotics/ros_kortex/tags
- The following PRs are merged, but the merge is after v2.3.0 tag. I write the details in package.xml
  - https://github.com/Kinovarobotics/ros_kortex/pull/140
  - https://github.com/Kinovarobotics/ros_kortex/pull/142