### PR TITLE
Set MoveIt! sample_duration to avoid too dense trajectory in MoveIt!

### DIFF
--- a/jsk_kinova_robot/jsk_kinova_startup/launch/kinova_bringup.launch
+++ b/jsk_kinova_robot/jsk_kinova_startup/launch/kinova_bringup.launch
@@ -18,6 +18,14 @@
     <arg name="vision" value="$(arg vision)" />
   </include>
 
+  <!-- Do not create too dense trajectory in MoveIt! -->
+  <!-- Decreasing the number of waypoint reduces minjerk interpolation calculation time by roseus-->
+  <group ns="$(arg robot_name)">
+    <group ns="move_group">
+    <param name="sample_duration" value="0.3" /> <!-- Default: 0.05 -->
+    </group>
+  </group>
+
   <!-- Vision -->
   <include if="$(arg vision)" file="$(find kinova_vision)/launch/kinova_vision_rgbd.launch">
     <arg name="device" value="$(arg ip_address)" />


### PR DESCRIPTION
In this PR, I set bigger `sample_duration` param to reduce minjerk interpolation calculation time in kinovaeus.

In kortex_ros v2.2.0, `~sample_duration` param is set as 0.001. (default is 0.05)
https://github.com/Kinovarobotics/ros_kortex/blob/v2.2.2/kortex_move_it_config/gen3_lite_gen3_lite_2f_move_it_config/launch/ompl_planning_pipeline.launch.xml#L23
This means that MoveIt! returns trajectory interpolated at 0.001[s] intervals.
http://wiki.ros.org/industrial_trajectory_filters

In kinovaeus, the MoveIt! trajectory is stretched several times, and then minjerk interpolation is performed again to create trajectory interpolated at 0.001[s] intervals.
The more waypoints the MoveIt! trajectory has, the longer the minjerk interpolation calculation time will be.

So, In this PR, I set bigger `sample_duration` param and reduce minjerk interpolation calculation time in kinovaeus.