### PR TITLE
[jsk_fetch_startup] add roslaunch_add_file_check for fetch.launch

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/CMakeLists.txt
+++ b/jsk_fetch_robot/jsk_fetch_startup/CMakeLists.txt
@@ -64,6 +64,7 @@ if(CATKIN_ENABLE_TESTING)
   # https://github.com/ros/ros_comm/pull/998 respect if/unless for roslaunch-check (1.13.1)
   # https://github.com/ros/ros_comm/pull/1455 make roslaunch-check respect arg remappings with command line argument (1.14.4)
   set(roslaunch_check_script ${PROJECT_SOURCE_DIR}/scripts/roslaunch-check)
+  roslaunch_add_file_check(launch/fetch.launch)
   roslaunch_add_file_check(launch/fetch_bringup.launch launch_teleop:=false) # disable launch_teleop because fetch_auto_dock package exists only in the fetch's PC
   roslaunch_add_file_check(launch/rviz.launch)
   roslaunch_add_file_check(launch/fetch_gazebo_bringup.launch)


### PR DESCRIPTION
I add `fetch.launch` roslaunch check.
#1383 also has this roslaunch check, too.
this PR may fail in CI, and #1383 may pass the CI.