### PR TITLE
Add ros node to send email based on received ros topic

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
+++ b/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
@@ -57,6 +57,7 @@ generate_dynamic_reconfigure_options(
 add_message_files(
   FILES
   RoomLight.msg
+  Email.msg
 )
 
 generate_messages(

--- a/jsk_robot_common/jsk_robot_startup/msg/Email.msg
+++ b/jsk_robot_common/jsk_robot_startup/msg/Email.msg
@@ -1,0 +1,5 @@
+std_msgs/Header header
+string sender_address # Sender's email address
+string receiver_address # receiver's email address
+string subject # Email subject
+string body # Email body

--- a/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+# automatically reset slam as robot put on the ground
+
+from jsk_robot_startup.msg import Email
+import os
+import rospy
+import subprocess
+import yaml
+
+
+class EmailTopic(object):
+    def __init__(self):
+        address_yaml = rospy.get_param(
+            '~address_yaml', "/var/lib/robot/email_topic.yaml")
+        if os.path.exists(address_yaml):
+            with open(address_yaml) as yaml_f:
+                yaml_addresses = yaml.load(yaml_f)
+                self.sender_address = yaml_addresses['sender_address']
+                self.receiver_address = yaml_addresses['receiver_address']
+        self.subscriber = rospy.Subscriber(
+            'email', Email, self._cb, queue_size=1)
+
+    def _cb(self, msg):
+        # If sender_address or receiver_address is empty, use address in yaml
+        if msg.sender_address == '':
+            sender_address = self.sender_address
+        else:
+            sender_address = msg.sender_address
+        if msg.receiver_address == '':
+            receiver_address = self.receiver_address
+        else:
+            receiver_address = msg.receiver_address
+        # Send email
+        self._send_mail(
+            msg.subject, msg.body, sender_address, receiver_address)
+
+    def _send_mail(self, subject, body, sender_address, receiver_address):
+        cmd = "LC_CTYPE=en_US.UTF-8 /bin/echo -e \"{}\"".format(body)
+        cmd += " | /usr/bin/mail -s \"{}\" -r {} {}".format(
+            subject, sender_address, receiver_address)
+        exit_code = subprocess.call(cmd, shell=True)
+        rospy.loginfo('Title: {}'.format(subject))
+        if exit_code > 0:
+            rospy.logerr(
+                'Failed to send e-mail:  {} -> {}'.format(
+                    sender_address, receiver_address))
+            rospy.logerr("You may need to do '$ sudo apt install mailutils'")
+        else:
+            rospy.loginfo(
+                'Succeeded to send e-mail: {} -> {}'.format(
+                    sender_address, receiver_address))
+
+
+if __name__ == "__main__":
+    rospy.init_node("email_topic")
+    app = EmailTopic()
+    rospy.spin()


### PR DESCRIPTION
From https://github.com/jsk-ros-pkg/jsk_robot/pull/1374#issuecomment-923757369

I add ros node to send email based on received ros topic.
Default email address can be set by using `/var/lib/robot/email_topic.yaml`

Usage:
```bash
$ catkin build jsk_robot_startup
$ rosrun jsk_robot_startup email_topic.py
$ rostopic pub /email jsk_robot_startup/Email "header:
  seq: 0
  stamp: {secs: 0, nsecs: 0}
  frame_id: ''
sender_address: '708yamaguchi@gmail.com'
receiver_address: '708yamaguchi@gmail.com'
subject: 'email test'
body: 'body test'" 
```