### PR TITLE
Publish resized panorama images

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_indigo.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_indigo.launch
@@ -11,4 +11,20 @@
     <!-- for indigo -->
     <arg name="use_usb_cam" value="true" />
   </include>
+
+  <group ns="dual_fisheye_to_panorama">
+    <node name="panorama_downsample_quater"
+          pkg="nodelet" type="nodelet"
+          args="standalone image_proc/resize"
+          respawn="true">
+      <remap from="image" to="output" />
+      <remap from="~image" to="quater/output" />
+      <remap from="~camera_info" to="quater/camera_info" />
+      <rosparam>
+        scale_width: 0.25
+        scale_height: 0.25
+      </rosparam>
+    </node>
+  </group>
+
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_melodic.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_insta360_melodic.launch
@@ -11,4 +11,20 @@
     <!-- for melodic -->
     <arg name="use_usb_cam" value="false" />
   </include>
+
+  <group ns="dual_fisheye_to_panorama">
+    <node name="panorama_downsample_quater"
+          pkg="nodelet" type="nodelet"
+          args="standalone image_proc/resize"
+          respawn="true">
+      <remap from="image" to="output" />
+      <remap from="~image" to="quater/output" />
+      <remap from="~camera_info" to="quater/camera_info" />
+      <rosparam>
+        scale_width: 0.25
+        scale_height: 0.25
+      </rosparam>
+    </node>
+  </group>
+
 </launch>


### PR DESCRIPTION
from https://github.com/jsk-ros-pkg/jsk_robot/pull/1321

cherry-pick https://github.com/jsk-ros-pkg/jsk_robot/commit/f7b5dd4f9eae5cf2c4455985056614cbb46d5a3a

add image_proc/resize for dual_fisheye_to_panorama

This feature is useful when we want to check panorama image with low CPU usage.