### PR TITLE
Remove edgetpu udev rules which is automatically installed by libedgetpu1-legacy-max

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/udev_rules/99-edgetpu-accelerator.rules
+++ b/jsk_fetch_robot/jsk_fetch_startup/udev_rules/99-edgetpu-accelerator.rules
@@ -1,8 +1,0 @@
-# Coral TPU USB changes it's ID during runtime.
-# When we connect the device to the computer. It says
-#   Bus 002 Device 002: ID 1a6e:089a Global Unichip Corp.
-# But after the first run, the device is recognized as following.
-#   Bus 002 Device 003: ID 18d1:9302 Google Inc.
-
-SUBSYSTEM=="usb",ATTRS{idVendor}=="1a6e",GROUP="plugdev"
-SUBSYSTEM=="usb",ATTRS{idVendor}=="18d1",GROUP="plugdev"


### PR DESCRIPTION
Based on https://github.com/knorth55/coral_usb_ros/pull/69#issue-1028234171, I remove unnecessary udev rule file for edgetpu.