### PR TITLE
Add node to shut down or reboot robot itself

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -173,6 +173,42 @@ This node publish the luminance calculated from input image and room light statu
 
   Image transport hint.
 
+## scripts/shutdown.py
+
+This node shuts down or reboots the robot itself according to the rostopic. Note that this node needs to be run with sudo privileges.
+
+### Subscribing Topics
+
+* `shutdown` (`std_msgs/Empty`)
+
+  Input topic that trigger shutdown
+
+* `reboot` (`std_msgs/Empty`)
+
+  Input topic that trigger reboot
+
+### Parameters
+
+* `~shutdown_command` (String, default: "/sbin/shutdown -h now")
+
+  Command to shutdown the system. You can specify the shutdown command according to your system.
+
+* `~reboot_command` (String, default: "/sbin/shutdown -r now")
+
+  Command to reboot the system. You can specify the reboot command according to your system.
+
+### Usage
+
+```
+# Launch node
+$ su [sudo user] -c ". [setup.bash]; rosrun jsk_robot_startup shutdown.py"
+# To shutdown robot
+rostopic pub /shutdown std_msgs/Empty
+# To restart robot
+rostopic pub /reboot std_msgs/Empty
+```
+
+
 ## launch/safe_teleop.launch
 
 This launch file provides a set of nodes for safe teleoperation common to mobile robots. Robot-specific nodes such as `/joy`, `/teleop` or `/cable_warning` must be included in the teleop launch file for each robot, such as [safe_teleop.xml for PR2](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/safe_teleop.xml) or [safe_teleop.xml for fetch](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml).

--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -208,6 +208,58 @@ rostopic pub /shutdown std_msgs/Empty
 rostopic pub /reboot std_msgs/Empty
 ```
 
+## scripts/power_management.py
+
+This node manages the power system of the robot. Currently, you can shutdown/reboot robot after notifying with email.
+
+### Subscribing Topics
+
+* `~shutdown` (`jsk_robot_startup/Email`)
+
+  Input topic indicating the mail content to be sent before shutting down the robot
+
+* `~reboot` (`jsk_robot_startup/Email`)
+
+  Input topic indicating the mail content to be sent before rebooting the robot
+
+### Publishing Topics
+
+* `shutdown` (`std_msgs/Empty`)
+
+  Topic to shutdown the robot
+
+* `reboot` (`std_msgs/Empty`)
+
+  Topic to reboot the robot
+
+* `email` (`jsk_robot_startup/Email`)
+
+  Content of the email
+
+
+### Usage
+
+```
+# Launch shutdown node
+$ su [sudo user] -c ". [setup.bash]; rosrun jsk_robot_startup shutdown.py"
+
+# Launch power management node and email node
+$ roslaunch jsk_robot_startup power_management.launch
+
+# Shutdown robot after notifying with email
+$ rostopic pub /power_management/shutdown jsk_robot_startup/Email "header:
+  seq: 0
+  stamp: {secs: 0, nsecs: 0}
+  frame_id: ''
+subject: ''
+body: ''
+sender_address: ''
+receiver_address: ''
+smtp_server: ''
+smtp_port: ''
+attached_files: []"
+```
+
 
 ## launch/safe_teleop.launch
 

--- a/jsk_robot_common/jsk_robot_startup/launch/power_management.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/power_management.launch
@@ -1,0 +1,16 @@
+<launch>
+
+  <arg name="email_info_yaml" default="/var/lib/robot/email_info.yaml" doc="Default email settings can be saved as yaml file. (e.g. subject, body, receiver address, ...)" />
+
+  <!-- Send email before shutdown/reboot to notify users -->
+  <node name="power_management" pkg="jsk_robot_startup" type="power_management.py"
+        output="screen" />
+
+  <!-- Send email via rostopic -->
+  <node pkg="jsk_robot_startup" type="email_topic.py" name="email_topic">
+    <rosparam subst_value="true">
+      email_info: $(arg email_info_yaml)
+    </rosparam>
+  </node>
+
+</launch>

--- a/jsk_robot_common/jsk_robot_startup/scripts/power_management.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/power_management.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+import rospy
+from std_msgs.msg import Empty
+from jsk_robot_startup.msg import Email
+
+
+class PowerManagement(object):
+    """
+    This node manages the power system of the robot.
+
+    Usage:
+    # Launch shutdown node
+    $ su [sudo user] -c ". [setup.bash]; rosrun jsk_robot_startup shutdown.py"
+
+    # Launch power management node and email node
+    $ roslaunch jsk_robot_startup power_management.launch
+
+    # Shutdown robot after notifying with email
+    $ rostopic pub /power_management/shutdown jsk_robot_startup/Email "header:
+      seq: 0
+      stamp: {secs: 0, nsecs: 0}
+      frame_id: ''
+    subject: ''
+    body: ''
+    sender_address: ''
+    receiver_address: ''
+    smtp_server: ''
+    smtp_port: ''
+    attached_files: []"
+    """
+
+    def __init__(self):
+        rospy.loginfo('Start power management node.')
+        rospy.Subscriber(
+            '~shutdown', Email, self.shutdown)
+        rospy.Subscriber(
+            '~reboot', Email, self.reboot)
+        self.shutdown_pub = rospy.Publisher('shutdown', Empty, queue_size=1)
+        self.reboot_pub = rospy.Publisher('reboot', Empty, queue_size=1)
+        self.email_pub = rospy.Publisher('email', Email, queue_size=1)
+
+    def shutdown(self, msg):
+        rospy.loginfo('Shut down robot after notifying with email.')
+        self.email_pub.publish(msg)
+        self.shutdown_pub.publish(Empty())
+
+    def reboot(self, msg):
+        rospy.loginfo('Reboot robot after notifying with email.')
+        self.email_pub.publish(msg)
+        self.reboot_pub.publish(Empty())
+
+
+if __name__ == '__main__':
+    rospy.init_node('power_management')
+    s = PowerManagement()
+    rospy.spin()

--- a/jsk_robot_common/jsk_robot_startup/scripts/shutdown.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/shutdown.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+import os
+import rospy
+from std_msgs.msg import Empty
+
+
+class Shutdown(object):
+    """
+    This node shuts down or reboots the robot itself
+    according to the rostopic.
+
+    Note that this node needs to be run with sudo privileges.
+
+    Usage:
+    # Launch node
+    $ su [sudo user] -c ". [setup.bash]; rosrun jsk_robot_startup shutdown.py"
+
+    # To shutdown robot
+    rostopic pub /shutdown std_msgs/Empty
+    # To restart robot
+    rostopic pub /reboot std_msgs/Empty
+    """
+
+    def __init__(self):
+        rospy.loginfo('Start shutdown node.')
+        rospy.Subscriber('shutdown', Empty, self.shutdown)
+        rospy.Subscriber('reboot', Empty, self.reboot)
+
+    def shutdown(self, msg):
+        rospy.loginfo('Shut down robot.')
+        shutdown_command = '/sbin/shutdown -h now'
+        ret = os.system(shutdown_command)
+        if ret != 0:
+            rospy.logerr("Failed to call '$ {}'. Check authentication.".format(
+                shutdown_command))
+
+    def reboot(self, msg):
+        rospy.loginfo('Reboot robot.')
+        reboot_command = '/sbin/shutdown -r now'
+        ret = os.system(reboot_command)
+        if ret != 0:
+            rospy.logerr("Failed to call '$ {}'. Check authentication.".format(
+                reboot_command))
+
+
+if __name__ == '__main__':
+    rospy.init_node('shutdown')
+    s = Shutdown()
+    rospy.spin()

--- a/jsk_robot_common/jsk_robot_startup/scripts/shutdown.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/shutdown.py
@@ -26,22 +26,24 @@ class Shutdown(object):
         rospy.loginfo('Start shutdown node.')
         rospy.Subscriber('shutdown', Empty, self.shutdown)
         rospy.Subscriber('reboot', Empty, self.reboot)
+        self.shutdown_command = rospy.get_param(
+            '~shutdown_command', '/sbin/shutdown -h now')
+        self.reboot_command = rospy.get_param(
+            '~reboot_command', '/sbin/shutdown -r now')
 
     def shutdown(self, msg):
         rospy.loginfo('Shut down robot.')
-        shutdown_command = '/sbin/shutdown -h now'
-        ret = os.system(shutdown_command)
+        ret = os.system(self.shutdown_command)
         if ret != 0:
             rospy.logerr("Failed to call '$ {}'. Check authentication.".format(
-                shutdown_command))
+                self.shutdown_command))
 
     def reboot(self, msg):
         rospy.loginfo('Reboot robot.')
-        reboot_command = '/sbin/shutdown -r now'
-        ret = os.system(reboot_command)
+        ret = os.system(self.reboot_command)
         if ret != 0:
             rospy.logerr("Failed to call '$ {}'. Check authentication.".format(
-                reboot_command))
+                self.reboot_command))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add node to shutdown/reboot robot by rostopic.

This node can be used, for example, to shut down the robot so that it does not consume battery power when it gets navigation stuck.

Note that this node needs to be started with sudo privileges.