### PR TITLE
Error handling when the email field is not appropriate.

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
@@ -74,6 +74,9 @@ class EmailTopic(object):
         msg.attach(MIMEText(body, 'plain', 'utf-8'))
         # Attach file
         for attached_file in attached_files:
+            if attached_file == '':
+                rospy.logwarn('File name is empty. Skipped.')
+                continue
             if not os.path.exists(attached_file):
                 rospy.logerr('File {} is not found.'.format(attached_file))
                 return

--- a/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
@@ -61,7 +61,11 @@ class EmailTopic(object):
                 if field in self.email_info:
                     send_mail_args[field] = self.email_info[field]
         # Send email
-        self._send_mail(**send_mail_args)
+        try:
+            self._send_mail(**send_mail_args)
+        except TypeError as e:
+            rospy.logerr(e)
+            rospy.logerr("'receiver_address' may not be specified.")
 
     def _send_mail(
             self, subject, body, sender_address, receiver_address,


### PR DESCRIPTION
This PR has two error handling.

#### Skip if an empty string is given for attached_file

In the default rostopic tab completion, `attached_files` field is list of empty string.

In that case, instead of giving an error and not sending out an email, I send out an email with a warning.

```
$ rostopic pub /email jsk_robot_startup/Email "header:
  seq: 0
  stamp: {secs: 0, nsecs: 0}
  frame_id: ''
subject: ''
body: ''
sender_address: ''
receiver_address: ''                      
smtp_server: ''
smtp_port: ''
attached_files: ['']" 
```

```
[ERROR] [1640613571.408953]: File  is not found.
```

#### Catch error when _send_mail() arguments are not correct

When the `receiver_address` of rostopic was not specified, the `receiver_address` of the argument of _send_mail() was not specified and an error occurred.

This PR will catch such errors.

```
$ rosrun jsk_robot_startup email_topic.py                                                                                                                                                                   
Unable to register with master node [http://localhost:11311]: master may not be running yet. Will keep trying.                                                                                              
[INFO] [1640613519.009014]: Received an msg: header:                                                                                                                                                        
  seq: 1                                                                                                                                                                                                    
  stamp:                                                                                                                                                                                                    
    secs: 0                                                                                                                                                                                                 
    nsecs:         0                                                                                                                                                                                        
  frame_id: ''                                                                                                                                                                                              
subject: ''                                                                                                                                                                                                 
body: ''                                                                                                                                                                                                    
sender_address: ''                                                                                                                                                                                          
receiver_address: ''                                                                                                                                                                                        
smtp_server: ''                                                                                                                                                                                             
smtp_port: ''                                                                                                                                                                                               
attached_files:                                                                                                                                                                                             
  - ''
[ERROR] [1640613519.011489]: bad callback: <bound method EmailTopic._cb of <__main__.EmailTopic object at 0x7f39ac4d7490>>
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/home/leus/ros/melodic/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py", line 64, in _cb
    self._send_mail(**send_mail_args)
TypeError: _send_mail() takes exactly 8 arguments (7 given)
```