### PR TITLE
[jsk_fetch_startup] Add node to shut down or reboot robot itself

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -22,7 +22,8 @@
         respawn="true" output="screen">
     <rosparam>
       duration: 180
-      charge_level_threshold: 40.0
+      charge_level_threshold: 80.0
+      shutdown_level_threshold: 60.0
       charge_level_step: 10.0
       volume: 1.0
     </rosparam>

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-shutdown.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-shutdown.conf
@@ -1,0 +1,12 @@
+[program:jsk-shutdown]
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && rosrun jsk_robot_startup shutdown.py --wait"
+
+stopsignal=TERM
+directory=/home/fetch/ros/melodic
+autostart=true
+autorestart=false
+stdout_logfile=/var/log/ros/jsk-shutdown.log
+stderr_logfile=/var/log/ros/jsk-shutdown.log
+user=root
+environment=ROSCONSOLE_FORMAT="[${severity}] [${time}] [${node}:${logger}]: ${message}",PYTHONUNBUFFERED=1
+priority=200

--- a/jsk_fetch_robot/jsk_fetch_startup/tmuxinator_yaml/log.yml
+++ b/jsk_fetch_robot/jsk_fetch_startup/tmuxinator_yaml/log.yml
@@ -40,3 +40,4 @@ windows:
   - jsk-coral: tail -f -n 1000 /var/log/ros/jsk-coral.log
   - jsk-dialog: tail -f -n 1000 /var/log/ros/jsk-dialog.log
   - jsk-gdrive: tail -f -n 1000 /var/log/ros/jsk-gdrive.log
+  - jsk-shutdown: tail -f -n 1000 /var/log/ros/jsk-shutdown.log

--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -173,6 +173,42 @@ This node publish the luminance calculated from input image and room light statu
 
   Image transport hint.
 
+## scripts/shutdown.py
+
+This node shuts down or reboots the robot itself according to the rostopic. Note that this node needs to be run with sudo privileges.
+
+### Subscribing Topics
+
+* `shutdown` (`std_msgs/Empty`)
+
+  Input topic that trigger shutdown
+
+* `reboot` (`std_msgs/Empty`)
+
+  Input topic that trigger reboot
+
+### Parameters
+
+* `~shutdown_command` (String, default: "/sbin/shutdown -h now")
+
+  Command to shutdown the system. You can specify the shutdown command according to your system.
+
+* `~reboot_command` (String, default: "/sbin/shutdown -r now")
+
+  Command to reboot the system. You can specify the reboot command according to your system.
+
+### Usage
+
+```
+# Launch node
+$ su [sudo user] -c ". [setup.bash]; rosrun jsk_robot_startup shutdown.py"
+# To shutdown robot
+rostopic pub /shutdown std_msgs/Empty
+# To restart robot
+rostopic pub /reboot std_msgs/Empty
+```
+
+
 ## launch/safe_teleop.launch
 
 This launch file provides a set of nodes for safe teleoperation common to mobile robots. Robot-specific nodes such as `/joy`, `/teleop` or `/cable_warning` must be included in the teleop launch file for each robot, such as [safe_teleop.xml for PR2](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/safe_teleop.xml) or [safe_teleop.xml for fetch](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml).

--- a/jsk_robot_common/jsk_robot_startup/scripts/shutdown.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/shutdown.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+import os
+import rospy
+from std_msgs.msg import Empty
+
+
+class Shutdown(object):
+    """
+    This node shuts down or reboots the robot itself
+    according to the rostopic.
+
+    Note that this node needs to be run with sudo privileges.
+
+    Usage:
+    # Launch node
+    $ su [sudo user] -c ". [setup.bash]; rosrun jsk_robot_startup shutdown.py"
+
+    # To shutdown robot
+    rostopic pub /shutdown std_msgs/Empty
+    # To restart robot
+    rostopic pub /reboot std_msgs/Empty
+    """
+
+    def __init__(self):
+        rospy.loginfo('Start shutdown node.')
+        rospy.Subscriber('shutdown', Empty, self.shutdown)
+        rospy.Subscriber('reboot', Empty, self.reboot)
+
+    def shutdown(self, msg):
+        rospy.loginfo('Shut down robot.')
+        shutdown_command = '/sbin/shutdown -h now'
+        ret = os.system(shutdown_command)
+        if ret != 0:
+            rospy.logerr("Failed to call '$ {}'. Check authentication.".format(
+                shutdown_command))
+
+    def reboot(self, msg):
+        rospy.loginfo('Reboot robot.')
+        reboot_command = '/sbin/shutdown -r now'
+        ret = os.system(reboot_command)
+        if ret != 0:
+            rospy.logerr("Failed to call '$ {}'. Check authentication.".format(
+                reboot_command))
+
+
+if __name__ == '__main__':
+    rospy.init_node('shutdown')
+    s = Shutdown()
+    rospy.spin()

--- a/jsk_robot_common/jsk_robot_startup/scripts/shutdown.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/shutdown.py
@@ -26,22 +26,24 @@ class Shutdown(object):
         rospy.loginfo('Start shutdown node.')
         rospy.Subscriber('shutdown', Empty, self.shutdown)
         rospy.Subscriber('reboot', Empty, self.reboot)
+        self.shutdown_command = rospy.get_param(
+            '~shutdown_command', '/sbin/shutdown -h now')
+        self.reboot_command = rospy.get_param(
+            '~reboot_command', '/sbin/shutdown -r now')
 
     def shutdown(self, msg):
         rospy.loginfo('Shut down robot.')
-        shutdown_command = '/sbin/shutdown -h now'
-        ret = os.system(shutdown_command)
+        ret = os.system(self.shutdown_command)
         if ret != 0:
             rospy.logerr("Failed to call '$ {}'. Check authentication.".format(
-                shutdown_command))
+                self.shutdown_command))
 
     def reboot(self, msg):
         rospy.loginfo('Reboot robot.')
-        reboot_command = '/sbin/shutdown -r now'
-        ret = os.system(reboot_command)
+        ret = os.system(self.reboot_command)
         if ret != 0:
             rospy.logerr("Failed to call '$ {}'. Check authentication.".format(
-                reboot_command))
+                self.reboot_command))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
From https://github.com/jsk-ros-pkg/jsk_robot/pull/1426#issuecomment-1001838437

- I add rosnode to shut down or reboot robot by rostopic
- In battery_warning.py, I make fetch shut down when the battery level is low.