### PR TITLE
[jsk_fetch_startup] Send an email when fetch is low battery

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -241,4 +241,11 @@
   <node name="check_board_info" pkg="jsk_fetch_diagnosis" type="check_driver_boards.py" output="screen">
   </node>
 
+  <!-- send email by rostopic -->
+  <node name="email_topic" pkg="jsk_robot_startup" type="email_topic.py" output="screen">
+    <rosparam>
+      email_info: /var/lib/robot/email_topic.yaml
+    </rosparam>
+  </node>
+
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/battery_warning.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/battery_warning.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import actionlib
+from jsk_robot_startup.msg import Email
 import rospy
 from sound_play.libsoundplay import SoundClient
 
@@ -23,6 +24,7 @@ class BatteryWarning(object):
         self.subscriber = rospy.Subscriber(
             '/battery_state', BatteryState, self._cb, queue_size=1)
         self.shutdown_pub = rospy.Publisher('/shutdown', Empty, queue_size=1)
+        self.email_pub = rospy.Publisher('/email', Email, queue_size=1)
         self.timer = rospy.Timer(rospy.Duration(self.duration), self._timer_cb)
         self.charge_level = None
         self.prev_charge_level = None
@@ -37,6 +39,14 @@ class BatteryWarning(object):
         client.actionclient.wait_for_result()
         return client.actionclient.get_result()
 
+    def _send_mail(self, subject, body):
+        # sender_address and receiver_address are empty
+        # because we use email_topic node's sender_address and receiver_address
+        email = Email()
+        email.subject = subject
+        email.body = body
+        self.email_pub.publish(email)
+
     def _warn(self):
         if self.charge_level < self.shutdown_threshold and not self.is_charging:
             rospy.logerr("Low battery: only {}% remaining".format(self.charge_level))
@@ -49,13 +59,18 @@ class BatteryWarning(object):
             self.shutdown_pub.publish(Empty())
         elif self.charge_level < self.charge_threshold and not self.is_charging:
             rospy.logerr("Low battery: only {}% remaining".format(self.charge_level))
-            sentence_jp = "バッテリー残り{}パーセントです。".format(self.charge_level)
-            sentence_jp += "もう限界ですので、僕をお家にかえしてください。"
-            sentence_en = "My battery is {} percent remaining.".format(self.charge_level)
-            sentence_en += "I want to go back home to charge my battery."
-            self._speak(self.client_jp, sentence_jp, 'jp')
-            self._speak(self.client_en, sentence_en)
+            sentence_battery_jp = "バッテリー残り{}パーセントです。".format(self.charge_level)
+            sentence_action_jp = "もう限界ですので、僕をお家にかえしてください。"
+            sentence_battery_en = "My battery is {} percent remaining.".format(self.charge_level)
+            sentence_action_en = "I want to go back home to charge my battery."
+            self._speak(
+                self.client_jp, sentence_battery_jp + sentence_action_jp, 'jp')
+            self._speak(
+                self.client_en, sentence_battery_en + sentence_action_en)
             self.prev_charge_level = self.charge_level
+            self._send_mail(
+                subject="Fetch is low battery",
+                body=sentence_battery_en + ' ' + sentence_action_en)
         elif (self.prev_charge_level // self.step) > (self.charge_level // self.step):
             rospy.loginfo("Battery: {}% remaining".format(self.charge_level))
             sentence_jp = "バッテリー残り{}パーセントです。".format(self.charge_level)


### PR DESCRIPTION
From https://github.com/jsk-ros-pkg/jsk_robot/pull/1374

In `battery_warning.py`, fetch send an email when low battery.

I use `/email` topic to send email
https://github.com/jsk-ros-pkg/jsk_robot/tree/master/jsk_robot_common/jsk_robot_startup#scriptsemail_topicpy

Example email:
![battery_warning](https://user-images.githubusercontent.com/19769486/149472445-8013948b-8548-4361-aed5-105c800d7e2d.png)

