### PR TITLE
Remove empty 'kinova' package

### DIFF
--- a/jsk_kinova_robot/kinovaeus/kinova-interface.l
+++ b/jsk_kinova_robot/kinovaeus/kinova-interface.l
@@ -3,9 +3,6 @@
 (require "package://pr2eus_moveit/euslisp/robot-moveit.l")
 (ros::load-ros-manifest "kortex_driver")
 
-(if (not (find-package "kinova"))
-    (make-package "kinova"))
-
 (defclass kinova-interface
   :super robot-interface
   :slots (controller-handle robot-handle move-robot)


### PR DESCRIPTION
kinova-interface.l has an unnecessary package definition for "kinova" (also, correct (usual) syntax would be with capital letters).

@a-ichikura