### PR TITLE
[jsk_fetch_diagnosis] Print board name in addition to board id

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_diagnosis/node_scripts/check_driver_boards.py
+++ b/jsk_fetch_robot/jsk_fetch_diagnosis/node_scripts/check_driver_boards.py
@@ -54,7 +54,7 @@ class CheckDriverBoardsNode:
                 msg.board_info = 'ERROR: command returned non-zero exit status'
                 rospy.logerr(
                     'command returned non-zero exit status while read board with id '\
-                    '{}: {}'.format(board_id, list_board_id[board_id]))
+                    '{:#04x}: {}'.format(board_id, list_board_id[board_id]))
 
             self.publisher.publish(msg)
 

--- a/jsk_fetch_robot/jsk_fetch_diagnosis/node_scripts/check_driver_boards.py
+++ b/jsk_fetch_robot/jsk_fetch_diagnosis/node_scripts/check_driver_boards.py
@@ -11,24 +11,25 @@ import rospy
 from jsk_fetch_diagnosis.msg import BoardInfo
 
 binary_str = '/opt/ros/' + os.environ['ROS_DISTRO'] + '/lib/fetch_drivers/read_board'
-list_board_id = [0,    # mainboard
-                 17,   # l_wheel
-                 18,   # r_wheel
-                 19,   # torso_lift
-                 20,   # head_pan
-                 21,   # heal_tilt
-                 # 35,   # ?? cart_dock_mcb
-                 38,   # shoulder_pan
-                 39,   # shoulder_lift
-                 40,   # upperarm_roll
-                 41,   # elbow_flex
-                 42,   # forearm_roll
-                 43,   # wrist_flex
-                 44,   # wrist_roll
-                 # 81,   # ?? mcb Base motor test stand
-                 # 82,   # ?? mcb Base motor test stand
-                 63,   # charger
-                 128]  # gripper
+list_board_id = {0:   'mainboard',
+                 17:  'l_wheel',
+                 18:  'r_wheel',
+                 19:  'torso_lift',
+                 20:  'head_pan',
+                 21:  'heal_tilt',
+                 # 35:  '?? cart_dock_mcb',
+                 38:  'shoulder_pan',
+                 39:  'shoulder_lift',
+                 40:  'upperarm_roll',
+                 41:  'elbow_flex',
+                 42:  'forearm_roll',
+                 43:  'wrist_flex',
+                 44:  'wrist_roll',
+                 # 81:  '?? mcb Base motor test stand',
+                 # 82:  '?? mcb Base motor test stand',
+                 63:  'charger',
+                 128: 'gripper',
+                 }
 
 
 class CheckDriverBoardsNode:
@@ -51,7 +52,9 @@ class CheckDriverBoardsNode:
                 rospy.logdebug('read_board command with id {} succeeded'.format(board_id))
             except subprocess.CalledProcessError:
                 msg.board_info = 'ERROR: command returned non-zero exit status'
-                rospy.logerr('command returned non-zero exit status while read board with id {}'.format(board_id))
+                rospy.logerr(
+                    'command returned non-zero exit status while read board with id '\
+                    '{}: {}'.format(board_id, list_board_id[board_id]))
 
             self.publisher.publish(msg)
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -236,4 +236,8 @@
     </rosparam>
   </node>
 
+  <!-- Check fetch's boards in a constant period -->
+  <node name="check_board_info" pkg="jsk_fetch_diagnosis" type="check_driver_boards.py" output="screen">
+  </node>
+
 </launch>


### PR DESCRIPTION
Cherry-picked from https://github.com/knorth55/jsk_robot/pull/180

Recently, fetch1075 board sometimes becomes inaccessible.
After some time, the communication state returned to normal, which made it difficult to debug.

In this pull request, we will always monitor the communication status with the board and print `rospy.logerr` when an error occurs.

Example of logging:
```
[ERROR] [1642931150.336007] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x26: shoulder_pan
[ERROR] [1642931150.479744817] [${node}:ros.fetch_drivers]: Error occured while running : No response to readBoardRegisterTable
[ERROR] [1642931150.481028] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x27: shoulder_lift
[ERROR] [1642931150.622124972] [${node}:ros.fetch_drivers]: Error occured while running : No response to readBoardRegisterTable
[ERROR] [1642931150.624114] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x28: upperarm_roll
[ERROR] [1642931150.768381696] [${node}:ros.fetch_drivers]: Error occured while running : No response to readBoardRegisterTable
[ERROR] [1642931150.769740] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x29: elbow_flex
[ERROR] [1642931150.912707884] [${node}:ros.fetch_drivers]: Error occured while running : No response to readBoardRegisterTable
[ERROR] [1642931150.914305] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x2a: forearm_roll
[ERROR] [1642931151.061445571] [${node}:ros.fetch_drivers]: Error occured while running : No response to readBoardRegisterTable
[ERROR] [1642931151.063916] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x2b: wrist_flex
[ERROR] [1642931151.207091165] [${node}:ros.fetch_drivers]: Error occured while running : No response to readBoardRegisterTable
[ERROR] [1642931151.208688] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x2c: wrist_roll
[ERROR] [1642931151.403753983] [${node}:ros.fetch_drivers]: Error occured while running : No response to readBoardRegisterTable
[ERROR] [1642931151.405388] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x80: gripper
[ERROR] [1642931151.552997124] [${node}:ros.fetch_drivers]: Error occured while running : No response to readBoardRegisterTable
[ERROR] [1642931151.555835] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x11: l_wheel
[ERROR] [1642931151.701776486] [${node}:ros.fetch_drivers]: Error occured while running : No response to readBoardRegisterTable
[ERROR] [1642931151.703166] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x12: r_wheel
[ERROR] [1642931151.847237670] [${node}:ros.fetch_drivers]: Error occured while running : No response to readBoardRegisterTable
[ERROR] [1642931151.849229] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x13: torso_lift
[ERROR] [1642931151.998213891] [${node}:ros.fetch_drivers]: Error occured while running : No response to readBoardRegisterTable
[ERROR] [1642931152.000278] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x14: head_pan
[ERROR] [1642931152.144720991] [${node}:ros.fetch_drivers]: Error occured while running : No response to readBoardRegisterTable
[ERROR] [1642931152.146377] [/check_board_info:rosout]: command returned non-zero exit status while read board with id 0x15: heal_tilt
```

cc @mqcmd196 @tkmtnt7000