### PR TITLE
move is_speaking to top of __init__ function

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/nav_speak.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/nav_speak.py
@@ -29,6 +29,7 @@ def goal_status(status):
 
 class NavSpeak(object):
     def __init__(self):
+        self.is_speaking = False
         self.move_base_goal_sub = rospy.Subscriber(
             "/move_base/goal", MoveBaseActionGoal,
             self.move_base_goal_callback, queue_size=1)
@@ -44,7 +45,6 @@ class NavSpeak(object):
         self.client = actionlib.SimpleActionClient(
             'robotsound_jp', SoundRequestAction)
         self.client.wait_for_server()
-        self.is_speaking = False
 
     def move_base_goal_callback(self, msg):
         self.sound.play(2, volume=self.volume)


### PR DESCRIPTION
sometimes it calls callback function before we initialized `is_speaking`
```
[ INFO] [1648713664.832008331, 46.397000000]: Goal reached
[ERROR] [1648713664.833388, 46.397000]: bad callback: <bound method NavSpeak.move_base_result_callback of <__main__.NavSpeak object at 0x7f1f4a693450>>
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/home/k-okada/catkin_ws/ws_jsk_robot/src/jsk_robot/jsk_robot_common/jsk_robot_startup/scripts/nav_speak.py", line 54, in move_base_result_callback
    while self.is_speaking is True:
AttributeError: 'NavSpeak' object has no attribute 'is_speaking'
```