### PR TITLE
Add roseus code to call app_notification_saver service

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -4,6 +4,8 @@ launch: jsk_fetch_startup/go_to_kitchen.xml
 interface: jsk_fetch_startup/go_to_kitchen.interface
 icon: jsk_fetch_startup/go_to_kitchen.png
 plugins:
+  - name: service_notification_saver_plugin
+    type: app_notification_saver/service_notification_saver
   - name: head_camera_video_recorder_plugin
     type: app_recorder/audio_video_recorder_plugin
     launch_args:
@@ -115,6 +117,7 @@ plugins:
 plugin_order:
   start_plugin_order:
     - move_base_cancel_plugin
+    - service_notification_saver_plugin
     - head_camera_video_recorder_plugin
     - object_detection_video_recorder_plugin
     - panorama_video_recorder_plugin
@@ -126,6 +129,7 @@ plugin_order:
     - mail_notifier_plugin
   stop_plugin_order:
     - move_base_cancel_plugin
+    - service_notification_saver_plugin
     - head_camera_video_recorder_plugin
     - object_detection_video_recorder_plugin
     - panorama_video_recorder_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -395,6 +395,7 @@
                  (send *ri* :clear-costmap)
                  (store-params)
                  (inflation-loose)
+                 (clear-app-notification)
                  t))
             (:report-start-go-to-kitchen
               '(lambda (userdata)

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -1,4 +1,5 @@
 (load "package://jsk_robot_startup/lifelog/tweet_client.l")
+(load "package://jsk_fetch_startup/euslisp/notify-app.l")
 (load "package://switchbot_ros/scripts/switchbot.l")
 (require :state-machine "package://roseus_smach/src/state-machine.l")
 (require :state-machine-ros "package://roseus_smach/src/state-machine-ros.l")
@@ -6,6 +7,7 @@
 
 (ros::load-ros-manifest "fetch_auto_dock_msgs")
 (ros::load-ros-manifest "jsk_robot_startup")
+(ros::load-ros-manifest "jsk_recognition_msgs")
 (ros::load-ros-manifest "power_msgs")
 
 (defparameter *dock-action* nil)
@@ -293,9 +295,20 @@
   (ros::ros-info "room light is off.")
   (send *ri* :speak-jp "電気が消えています。" :wait t))
 
+(defun notify-recognition ()
+  (let* ((msg (one-shot-subscribe "/edgetpu_object_detector/output/class"
+                                  jsk_recognition_msgs::ClassificationResult))
+         (label-names (send msg :label_names)))
+    (when label-names
+      (ros::ros-info (format nil "Notify app that ~A is found." label-names))
+      (notify-app "object recognition"
+                  (send msg :header :stamp)
+                  "kitchen"
+                  (format nil "~A is found." label-names)))))
 
 (defun inspect-kitchen (&key (tweet t))
   (report-move-to-sink-front-success)
+  (notify-recognition)
   (if tweet
     (progn
       ;; stove

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/notify-app.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/notify-app.l
@@ -1,4 +1,5 @@
 (ros::load-ros-manifest "app_notification_saver")
+(ros::load-ros-manifest "std_srvs")
 
 (defun notify-app (title stamp location message)
   "
@@ -18,3 +19,7 @@ Returns:
     (send req :location location)
     (send req :message message)
     (ros::service-call "/service_notification_saver/save_app_notification" req)))
+
+(defun clear-app-notification ()
+  (ros::service-call "/service_notification_saver/clear_app_notification"
+                     (instance std_srvs::EmptyRequest :init)))

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/notify-app.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/notify-app.l
@@ -1,0 +1,20 @@
+(ros::load-ros-manifest "app_notification_saver")
+
+(defun notify-app (title stamp location message)
+  "
+This method sends service call to app_notification_saver to save app notification to json file.
+
+Args:
+  stamp(ros::time): UNIX time when the event occurred
+  title (str)  : Notification title (e.g. object detection, navigation faliure ...) # NOQA
+  message (str): Notification message
+
+Returns:
+  Result of whether the json was saved. (bool)
+"
+  (let ((req (instance app_notification_saver::SaveAppNotificationRequest :init)))
+    (send req :title title)
+    (send req :stamp stamp)
+    (send req :location location)
+    (send req :message message)
+    (ros::service-call "/service_notification_saver/save_app_notification" req)))


### PR DESCRIPTION
From https://github.com/knorth55/jsk_robot/pull/133

For `go_to_kitchen` demo, I added app_manager plugin for email notification.

With this PR, fetch can send the following notifications in the dailiy mail.

```
Following object recognition is reported.
 - At 2022-04-20T16:43:59, (kettle) is found in kitchen stove.
 - At 2022-04-20T16:44:54, (dish chair) is found in trash cans.
```