### PR TITLE
Launch smach_notification_saver by default

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -6,6 +6,8 @@ icon: jsk_fetch_startup/go_to_kitchen.png
 plugins:
   - name: service_notification_saver_plugin
     type: app_notification_saver/service_notification_saver
+  - name: smach_notification_saver_plugin
+    type: app_notification_saver/smach_notification_saver
   - name: head_camera_video_recorder_plugin
     type: app_recorder/audio_video_recorder_plugin
     launch_args:
@@ -118,6 +120,7 @@ plugin_order:
   start_plugin_order:
     - move_base_cancel_plugin
     - service_notification_saver_plugin
+    - smach_notification_saver_plugin
     - head_camera_video_recorder_plugin
     - object_detection_video_recorder_plugin
     - panorama_video_recorder_plugin
@@ -130,6 +133,7 @@ plugin_order:
   stop_plugin_order:
     - move_base_cancel_plugin
     - service_notification_saver_plugin
+    - smach_notification_saver_plugin
     - head_camera_video_recorder_plugin
     - object_detection_video_recorder_plugin
     - panorama_video_recorder_plugin


### PR DESCRIPTION
From https://github.com/knorth55/jsk_robot/pull/134

Launch smach_notification_saver plugin by default in go-to-kitchen demo

Fetch reports smach states in email.

```
Fetch kitchen patrol demo: 2021/07/30 (16:55:10)
===
Following smach is reported.
 - At 2021-07-30T16:52:17, Active states is REPORT-START-GO-TO-KITCHEN
 - At 2021-07-30T16:52:22, Active states is GET-LIGHT-ON
 - At 2021-07-30T16:52:22, Active states is REPORT-LIGHT-ON
 - At 2021-07-30T16:52:26, Active states is MOVE-TO-SINK-FRONT
 - At 2021-07-30T16:52:52, Active states is INSPECT-KITCHEN
 - At 2021-07-30T16:53:19, Active states is AUTO-DOCK
 - At 2021-07-30T16:54:01, Active states is ROOM-LIGHT-OFF
 - At 2021-07-30T16:54:01, Active states is FINISH
 - At 2021-07-30T16:54:03, Active states is

Following object recognition is reported.
 - In kitchen at 2021-07-30T16:52:57, (kettle cup) is found.
```