### PR TITLE
send /move_base/cancel when go-to-kitchen stopped

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -96,6 +96,13 @@ plugins:
       mail_title: Fetch kitchen patrol demo
       use_timestamp_title: true
     plugin_arg_yaml: /var/lib/robot/fetch_mail_notifier_plugin.yaml
+  - name: move_base_cancel_plugin
+    type: app_publisher/rostopic_publisher_plugin
+    plugin_args:
+      stop_topics:
+        - name: "/move_base/cancel"
+          pkg: actionlib_msgs
+          type: GoalID
 plugin_order:
   start_plugin_order:
     - head_camera_video_recorder_plugin
@@ -106,6 +113,7 @@ plugin_order:
     - gdrive_uploader_plugin
     - speech_notifier_plugin
     - mail_notifier_plugin
+    - move_base_cancel_plugin
   stop_plugin_order:
     - head_camera_video_recorder_plugin
     - object_detection_video_recorder_plugin
@@ -115,3 +123,4 @@ plugin_order:
     - gdrive_uploader_plugin
     - speech_notifier_plugin
     - mail_notifier_plugin
+    - move_base_cancel_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -105,6 +105,7 @@ plugins:
           type: GoalID
 plugin_order:
   start_plugin_order:
+    - move_base_cancel_plugin
     - head_camera_video_recorder_plugin
     - object_detection_video_recorder_plugin
     - respeaker_audio_recorder_plugin
@@ -113,8 +114,8 @@ plugin_order:
     - gdrive_uploader_plugin
     - speech_notifier_plugin
     - mail_notifier_plugin
-    - move_base_cancel_plugin
   stop_plugin_order:
+    - move_base_cancel_plugin
     - head_camera_video_recorder_plugin
     - object_detection_video_recorder_plugin
     - respeaker_audio_recorder_plugin
@@ -123,4 +124,3 @@ plugin_order:
     - gdrive_uploader_plugin
     - speech_notifier_plugin
     - mail_notifier_plugin
-    - move_base_cancel_plugin


### PR DESCRIPTION
From https://github.com/knorth55/jsk_robot/pull/141

Send `/move_base/cancel` when `go-to-kitchen` app is stopped.

Sometimes, `move_base` continues to work though `go-to-kitchen` is stopped.
