### PR TITLE
Publish /shutdown topic if go-to-kitchen demo fails

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -60,12 +60,10 @@
     local-name: jsk-ros-pkg/jsk_robot
     uri: https://github.com/knorth55/jsk_robot.git
     version: fetch15
-# Use https://github.com/knorth55/app_manager_utils master branch
-# after https://github.com/knorth55/app_manager_utils/pull/40 is merged
 - git:
     local-name: knorth55/app_manager_utils
-    uri: https://github.com/708yamaguchi/app_manager_utils
-    version: fetch15
+    uri: https://github.com/knorth55/app_manager_utils
+    version: master
 - git:
     local-name: locusrobotics/catkin_virtualenv
     uri: https://github.com/locusrobotics/catkin_virtualenv.git

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -1,10 +1,12 @@
 # This is rosinstall file for melodic PC inside fetch.
 # $ ln -s $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HOME/ros/$ROS_DISTRO/src/.rosinstall
 
+# Use https://github.com/PR2/app_manager.git kinetic-devel branch
+# after https://github.com/PR2/app_manager/pull/49 is merged
 - git:
     local-name: PR2/app_manager
-    uri: https://github.com/PR2/app_manager.git
-    version: kinetic-devel
+    uri: https://github.com/708yamaguchi/app_manager.git
+    version: fetch15
 - git:
     local-name: RobotWebTools/rosbridge_suite
     uri: https://github.com/RobotWebTools/rosbridge_suite.git
@@ -58,10 +60,12 @@
     local-name: jsk-ros-pkg/jsk_robot
     uri: https://github.com/knorth55/jsk_robot.git
     version: fetch15
+# Use https://github.com/knorth55/app_manager_utils master branch
+# after https://github.com/knorth55/app_manager_utils/pull/40 is merged
 - git:
     local-name: knorth55/app_manager_utils
-    uri: https://github.com/knorth55/app_manager_utils
-    version: master
+    uri: https://github.com/708yamaguchi/app_manager_utils
+    version: fetch15
 - git:
     local-name: locusrobotics/catkin_virtualenv
     uri: https://github.com/locusrobotics/catkin_virtualenv.git

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -5,7 +5,7 @@
 # after https://github.com/PR2/app_manager/pull/49 is merged
 - git:
     local-name: PR2/app_manager
-    uri: https://github.com/708yamaguchi/app_manager.git
+    uri: https://github.com/knorth55/app_manager.git
     version: fetch15
 - git:
     local-name: RobotWebTools/rosbridge_suite

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -1,12 +1,10 @@
 # This is rosinstall file for melodic PC inside fetch.
 # $ ln -s $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HOME/ros/$ROS_DISTRO/src/.rosinstall
 
-# Use https://github.com/PR2/app_manager.git kinetic-devel branch
-# after https://github.com/PR2/app_manager/pull/49 is merged
 - git:
     local-name: PR2/app_manager
-    uri: https://github.com/knorth55/app_manager.git
-    version: fetch15
+    uri: https://github.com/PR2/app_manager.git
+    version: kinetic-devel
 - git:
     local-name: RobotWebTools/rosbridge_suite
     uri: https://github.com/RobotWebTools/rosbridge_suite.git

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -112,6 +112,14 @@ plugins:
         - name: "/move_base/cancel"
           pkg: actionlib_msgs
           type: GoalID
+  - name: shutdown_plugin
+    type: app_publisher/rostopic_publisher_plugin
+    plugin_args:
+      stop_topics:
+        - name: "/shutdown"
+          pkg: std_msgs
+          type: Empty
+          cond: fail
 plugin_order:
   start_plugin_order:
     - move_base_cancel_plugin
@@ -124,6 +132,7 @@ plugin_order:
     - gdrive_uploader_plugin
     - speech_notifier_plugin
     - mail_notifier_plugin
+    - shutdown_plugin
   stop_plugin_order:
     - move_base_cancel_plugin
     - head_camera_video_recorder_plugin
@@ -135,3 +144,4 @@ plugin_order:
     - gdrive_uploader_plugin
     - speech_notifier_plugin
     - mail_notifier_plugin
+    - shutdown_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -119,7 +119,7 @@ plugins:
         - name: "/shutdown"
           pkg: std_msgs
           type: Empty
-          cond: fail
+          cond: timeout
 plugin_order:
   start_plugin_order:
     - move_base_cancel_plugin


### PR DESCRIPTION
From https://github.com/knorth55/jsk_robot/pull/169
(I don't cherry-pick the first two commits, because these commits are already merged.)


With this PR, fetch shuts down itself when `go-to-kitchen` demo fails by timeout.

The purpose of this PR is to prevent fetch battery degradation.