### PR TITLE
[jsk_fetch_startup] Shutdown robot if go-to-kitchen timeout or fail

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -60,12 +60,10 @@
     local-name: jsk-ros-pkg/jsk_robot
     uri: https://github.com/knorth55/jsk_robot.git
     version: fetch15
-# Use https://github.com/knorth55/app_manager_utils master branch
-# after https://github.com/knorth55/app_manager_utils/pull/40 is merged
 - git:
     local-name: knorth55/app_manager_utils
-    uri: https://github.com/708yamaguchi/app_manager_utils
-    version: fetch15
+    uri: https://github.com/knorth55/app_manager_utils
+    version: master
 - git:
     local-name: locusrobotics/catkin_virtualenv
     uri: https://github.com/locusrobotics/catkin_virtualenv.git

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -1,10 +1,12 @@
 # This is rosinstall file for melodic PC inside fetch.
 # $ ln -s $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HOME/ros/$ROS_DISTRO/src/.rosinstall
 
+# Use https://github.com/PR2/app_manager.git kinetic-devel branch
+# after https://github.com/PR2/app_manager/pull/49 is merged
 - git:
     local-name: PR2/app_manager
-    uri: https://github.com/PR2/app_manager.git
-    version: kinetic-devel
+    uri: https://github.com/708yamaguchi/app_manager.git
+    version: fetch15
 - git:
     local-name: RobotWebTools/rosbridge_suite
     uri: https://github.com/RobotWebTools/rosbridge_suite.git
@@ -58,10 +60,12 @@
     local-name: jsk-ros-pkg/jsk_robot
     uri: https://github.com/knorth55/jsk_robot.git
     version: fetch15
+# Use https://github.com/knorth55/app_manager_utils master branch
+# after https://github.com/knorth55/app_manager_utils/pull/40 is merged
 - git:
     local-name: knorth55/app_manager_utils
-    uri: https://github.com/knorth55/app_manager_utils
-    version: master
+    uri: https://github.com/708yamaguchi/app_manager_utils
+    version: fetch15
 - git:
     local-name: locusrobotics/catkin_virtualenv
     uri: https://github.com/locusrobotics/catkin_virtualenv.git

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -5,7 +5,7 @@
 # after https://github.com/PR2/app_manager/pull/49 is merged
 - git:
     local-name: PR2/app_manager
-    uri: https://github.com/708yamaguchi/app_manager.git
+    uri: https://github.com/knorth55/app_manager.git
     version: fetch15
 - git:
     local-name: RobotWebTools/rosbridge_suite

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -1,12 +1,10 @@
 # This is rosinstall file for melodic PC inside fetch.
 # $ ln -s $(rospack find jsk_fetch_startup)/../jsk_fetch.rosinstall.$ROS_DISTRO $HOME/ros/$ROS_DISTRO/src/.rosinstall
 
-# Use https://github.com/PR2/app_manager.git kinetic-devel branch
-# after https://github.com/PR2/app_manager/pull/49 is merged
 - git:
     local-name: PR2/app_manager
-    uri: https://github.com/knorth55/app_manager.git
-    version: fetch15
+    uri: https://github.com/PR2/app_manager.git
+    version: kinetic-devel
 - git:
     local-name: RobotWebTools/rosbridge_suite
     uri: https://github.com/RobotWebTools/rosbridge_suite.git

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -119,7 +119,7 @@ plugins:
         - name: "/shutdown"
           pkg: std_msgs
           type: Empty
-          cond: timeout
+          cond: fail
 plugin_order:
   start_plugin_order:
     - move_base_cancel_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -112,6 +112,14 @@ plugins:
         - name: "/move_base/cancel"
           pkg: actionlib_msgs
           type: GoalID
+  - name: shutdown_plugin
+    type: app_publisher/rostopic_publisher_plugin
+    plugin_args:
+      stop_topics:
+        - name: "/shutdown"
+          pkg: std_msgs
+          type: Empty
+          cond: fail
 plugin_order:
   start_plugin_order:
     - move_base_cancel_plugin
@@ -124,6 +132,7 @@ plugin_order:
     - gdrive_uploader_plugin
     - speech_notifier_plugin
     - mail_notifier_plugin
+    - shutdown_plugin
   stop_plugin_order:
     - move_base_cancel_plugin
     - head_camera_video_recorder_plugin
@@ -135,3 +144,4 @@ plugin_order:
     - gdrive_uploader_plugin
     - speech_notifier_plugin
     - mail_notifier_plugin
+    - shutdown_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -119,7 +119,9 @@ plugins:
         - name: "/shutdown"
           pkg: std_msgs
           type: Empty
-          cond: timeout
+          cond:
+            - timeout
+            - failure
 plugin_order:
   start_plugin_order:
     - move_base_cancel_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -119,7 +119,7 @@ plugins:
         - name: "/shutdown"
           pkg: std_msgs
           type: Empty
-          cond: fail
+          cond: timeout
 plugin_order:
   start_plugin_order:
     - move_base_cancel_plugin


### PR DESCRIPTION
~Please merge after https://github.com/jsk-ros-pkg/jsk_robot/pull/1452~

From https://github.com/knorth55/jsk_robot/pull/170

The other day, fetch is stucked during AUTO-DOCK after INSPECT-TRASHCAN.

```
Following smach is reported.
 - At 2021-12-25T09:00:22, Active states is REPORT-START-GO-TO-KITCHEN.
 - At 2021-12-25T09:00:25, Active states is GET-LIGHT-ON.
 - At 2021-12-25T09:00:26, Active states is ROOM-LIGHT-ON.
 - At 2021-12-25T09:00:32, Active states is MOVE-TO-SINK-FRONT.
 - At 2021-12-25T09:01:07, Active states is INSPECT-KITCHEN.
 - At 2021-12-25T09:01:26, Active states is MOVE-TO-TRASHCAN-FRONT.
 - At 2021-12-25T09:01:35, Active states is INSPECT-TRASHCAN.
```

From a battery protection point of view, we want fetch to shutdown in this situation.

With PR, fetch shuts down itself when fetch detects timeout or failure in `go-to-kitchen` demo.

`timeout` is useful when robot stuck by navigation problem. (e.g. robot gets too close to the wall and cannot move anymore)
`failure` is useful when robot stuck by program problem. (e.g. go-to-kitchen main roseus program stops by program bugs.)