### PR TITLE
[jsk_fetch_startup] Update switchbot device name in navigation-utils.l

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -234,8 +234,8 @@
     (send *ri* :angle-vector-raw (send *fetch* :angle-vector) 3000 :head-controller)
     (send *ri* :wait-interpolation))
    ((eq control-switchbot :api)
-    (control-device "/eng2/7f/73b2/light/upper/switch" "turnOn" :wait t)
-    (control-device "/eng2/7f/73b2/light/lower/switch" "turnOn" :wait t)
+    (control-device "/eng2/7f/73b2_bot_kitchen" "turnOn" :wait t)
+    (control-device "/eng2/7f/73b2_bot_window" "turnOn" :wait t)
     (send *ri* :speak-jp "電気をつけました" :wait t))))
 
 
@@ -259,8 +259,8 @@
     (send *ri* :angle-vector-raw (send *fetch* :angle-vector) 3000 :head-controller)
     (send *ri* :wait-interpolation))
    ((eq control-switchbot :api)
-    (control-device "/eng2/7f/73b2/light/upper/switch" "turnOff" :wait t)
-    (control-device "/eng2/7f/73b2/light/lower/switch" "turnOff" :wait t)
+    (control-device "/eng2/7f/73b2_bot_kitchen" "turnOff" :wait t)
+    (control-device "/eng2/7f/73b2_bot_window" "turnOff" :wait t)
     (send *ri* :speak-jp "電気を消しました" :wait t))))
 
 


### PR DESCRIPTION
Duplicate of knorth55/jsk_robot#179

Update switchbot device name due to common operation of switchbot token with dialogflow users.

(We have fixed the problem that the lights in the room could not be controlled by switchbot in the morning kitchen demo due to old switchbot token. )