### PR TITLE
Use VOICEVOX by default

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -4,7 +4,8 @@
   <arg name="launch_move_base" default="true" />
   <arg name="launch_sound_play" default="true" />
   <arg name="launch_insta360" default="true" />
-  <arg name="use_voice_text" default="true" />
+  <arg name="use_voice_text" default="false" />
+  <arg name="default_speaker" default="2" />
   <arg name="boot_sound" default="false" />
   <arg name="map_frame" default="eng2" />
   <arg name="map_file" default="$(find jsk_maps)/raw_maps/eng2-7f-0.05.yaml"/>
@@ -61,9 +62,8 @@
     <arg name="launch_sound_play" value="$(arg launch_sound_play)" />
     <arg name="sound_play_respawn" value="true" />
   </include>
-  <include unless="$(arg use_voice_text)" file="$(find aques_talk)/launch/aques_talk.launch">
-    <arg name="launch_sound_play" value="$(arg launch_sound_play)" />
-    <arg name="sound_play_respawn" value="true" />
+  <include unless="$(arg use_voice_text)" file="$(find voicevox)/launch/voicevox_texttospeech.launch">
+    <arg name="default_speaker" value="$(arg default_speaker)" />
   </include>
 
   <!-- Buffer Server -->

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-fetch-startup.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-fetch-startup.conf
@@ -1,5 +1,5 @@
 [program:jsk-fetch-startup]
-command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && rosrun jsk_fetch_startup setup_audio.bash && roslaunch jsk_fetch_startup fetch_bringup.launch boot_sound:=true use_voice_text:=false --wait"
+command=/bin/bash -c ". /opt/ros/roscore_poststart.bash && . /home/fetch/ros/melodic/devel/setup.bash && rosrun jsk_fetch_startup setup_audio.bash && if [ $(hostname) = 'fetch15' ]; then DEFAULT_SPEAKER=13; elif [ $(hostname) = 'fetch1075' ]; then DEFAULT_SPEAKER=2; fi && roslaunch jsk_fetch_startup fetch_bringup.launch boot_sound:=true default_speaker:=$DEFAULT_SPEAKER --wait"
 stopsignal=TERM
 directory=/home/fetch/ros/melodic
 autostart=true


### PR DESCRIPTION
From https://github.com/knorth55/jsk_robot/pull/206

To make all the 73B2 robots voice different, fetch speaks in the voices of VOICEVOX #2 and #13.