### PR TITLE
[jsk_fetch_startup] Supress L515 ERROR messages

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -104,6 +104,9 @@
     version: 0.2.4
 # Avoid "An error has occurred during frame callback: map::at"
 # https://github.com/IntelRealSense/realsense-ros/issues/1872
+# If you upgrade realsense-ros version, please upgrade librealsense packages.
+# Currently, realsense-ros 2.3.0 (source) and librealsense 2.45.0 (apt) works
+# https://github.com/IntelRealSense/librealsense/issues/10304#issuecomment-1067354378
 - git:
     local-name: IntelRealSense/realsense-ros
     uri: https://github.com/IntelRealSense/realsense-ros.git

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -102,10 +102,12 @@
     local-name: GT-RAIL/robot_pose_publisher
     uri: https://github.com/GT-RAIL/robot_pose_publisher.git
     version: 0.2.4
+# Avoid "An error has occurred during frame callback: map::at"
+# https://github.com/IntelRealSense/realsense-ros/issues/1872
 - git:
     local-name: IntelRealSense/realsense-ros
     uri: https://github.com/IntelRealSense/realsense-ros.git
-    version: 2.2.21
+    version: 2.3.0
 - git:
     local-name: fetchrobotics/fetch_open_auto_dock
     uri: https://github.com/fetchrobotics/fetch_open_auto_dock.git


### PR DESCRIPTION
Cherry-pick 
https://github.com/knorth55/jsk_robot/pull/190
https://github.com/knorth55/jsk_robot/pull/191

I use new version `realsense-ros` to supress L515 error 'An error has occurred during frame callback: map::at'

Cherry-pick
https://github.com/knorth55/jsk_robot/pull/192

I add notes about `realsense-ros` version compatibility.