### PR TITLE
do not run add_rostest when CATKIN_ENABLE_TESTING=OFF, remove depends to naoqi_msgs, we use naoqi_bridge_msgs since indigo

### DIFF
--- a/jsk_naoqi_robot/naoqieus/CMakeLists.txt
+++ b/jsk_naoqi_robot/naoqieus/CMakeLists.txt
@@ -15,7 +15,9 @@ find_package(nao_interaction_msgs QUIET)
 find_package(naoqi_bridge_msgs QUIET)
 if(nao_interaction_msgs_FOUND AND naoqi_bridge_msgs_FOUND)
 
+if(CATKIN_ENABLE_TESTING)
   add_rostest(test/naoqieus.test)
+endif()
 
 install(DIRECTORY test
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/jsk_naoqi_robot/naoqieus/package.xml
+++ b/jsk_naoqi_robot/naoqieus/package.xml
@@ -15,7 +15,7 @@
   <build_depend>rostest</build_depend>
 
   <run_depend>nao_interaction_msgs</run_depend>
-  <run_depend>naoqi_msgs</run_depend>
+  <!-- <run_depend>naoqi_msgs</run_depend> --> <!-- naoqi_msgs becomes naoqi_bridge_msgs since indigo -->
   <run_depend>naoqi_bridge_msgs</run_depend>
   <run_depend>pr2eus</run_depend> <!-- for robot interface -->
 

--- a/jsk_naoqi_robot/peppereus/CMakeLists.txt
+++ b/jsk_naoqi_robot/peppereus/CMakeLists.txt
@@ -16,7 +16,7 @@ catkin_package()
 ### pepper.l generation
 ###
 compile_naoqi_model(pepper pepper1.0_generated_urdf)
-if(pepper_meshes_FOUND)
+if(pepper_meshes_FOUND AND CATKIN_ENABLE_TESTING)
   add_rostest(test/peppereus.test)
 endif()
 

--- a/jsk_robot_common/speak_and_wait_recovery/CMakeLists.txt
+++ b/jsk_robot_common/speak_and_wait_recovery/CMakeLists.txt
@@ -58,7 +58,7 @@ install(FILES speak_and_wait_plugin.xml
 )
 
 #
-# Testgin
+# Testing
 #
 if (CATKIN_ENABLE_TESTING)
     find_package(rostest REQUIRED)


### PR DESCRIPTION
aabbdfb1a (Kei Okada, 21 seconds ago)
    naoqi_msgs becomes naoqi_bridge_msgs since indigo

 ac7c04fc5 (Kei Okada, 2 minutes ago)
    jsk_naoqi_robot/{peppereus,naoqieus}/CMakeLists.txt: run add_rostest only
    CATKIN_ENABLE_TESTING

 542f65c75 (Kei Okada, 3 minutes ago)
    jsk_robot_common/speak_and_wait_recovery/CMakeLists.txt: fix typo # Testgin
    -> # Testing