### PR TITLE
[jsk_fetch_startup] Remove duplicated diagnostics aggregator

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
@@ -3,6 +3,7 @@
   <arg name="launch_teleop" default="true" />
   <arg name="use_base_camera_mount" default="true" />
   <arg name="use_head_box" default="true" />
+  <arg name="launch_diagnostics_agg" default="false" />
   <arg name="use_realsense" default="true" />
   <arg name="use_fetch_description" default="false" />
 
@@ -162,6 +163,7 @@
   </include>
 
   <!-- Diagnostics Aggregator -->
-  <include file="$(find fetch_bringup)/launch/include/aggregator.launch.xml"/>
+  <include if="$(arg launch_diagnostics_agg)"
+           file="$(find fetch_bringup)/launch/include/aggregator.launch.xml"/>
 
 </launch>


### PR DESCRIPTION
Copy https://github.com/knorth55/jsk_robot/pull/221

There are two `diagnostic_aggregator` node in fetch's launch file.
`fetch_bringup.launch`'s aggregator includes `fetch.launch`'s aggregator.
So I remove the `fetch.launch`'s aggregator.

https://github.com/jsk-ros-pkg/jsk_robot/blob/f9cce5aec920ea7c8a96b790fac2af8411b56d94/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch#L164-L165
https://github.com/jsk-ros-pkg/jsk_robot/blob/f9cce5aec920ea7c8a96b790fac2af8411b56d94/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch#L80-L84