### PR TITLE
[jsk_fetch_startup] Publish diagnostics for important topics and nodes

### DIFF
--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -28,3 +28,9 @@
     local-name: fetchrobotics/fetch_ros
     uri: https://github.com/fetchrobotics/fetch_ros.git
     version: 0ad250a996a2ef68172fc064698f253bc9cf08d0
+# Remove this dependency if jsk_common version 2.2.12 is released in kinetic
+# See https://github.com/jsk-ros-pkg/jsk_robot/pull/1481#issuecomment-1209544704
+- git:
+    local-name: jsk-ros-pkg/jsk_common
+    uri: https://github.com/jsk-ros-pkg/jsk_common.git
+    version: 2.2.12

--- a/jsk_fetch_robot/jsk_fetch_startup/config/fetch_analyzers.yaml
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/fetch_analyzers.yaml
@@ -144,3 +144,35 @@ analyzers:
         type: diagnostic_aggregator/GenericAnalyzer
         path: CPU Usage
         startswith: 'my_machine CPU Usage'
+  topics:
+    type: diagnostic_aggregator/AnalyzerGroup
+    path: Topics
+    analyzers:
+      audio:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Audio
+        contains: '/audio'
+        timeout: 100
+        discard_stale: true
+      head_depth_image:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: HeadDepthImage
+        contains: '/head_camera/depth/image_raw'
+        timeout: 100
+        discard_stale: true
+      head_rgb_image:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: HeadRGBImage
+        contains: '/head_camera/rgb/image_raw'
+        timeout: 100
+        discard_stale: true
+  nodes:
+    type: diagnostic_aggregator/AnalyzerGroup
+    path: Nodes
+    analyzers:
+      head_camera_manager:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: HeadCameraManager
+        contains: '/head_camera/head_camera_nodelet_manager'
+        timeout: 100
+        discard_stale: true

--- a/jsk_fetch_robot/jsk_fetch_startup/config/fetch_analyzers.yaml
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/fetch_analyzers.yaml
@@ -119,7 +119,7 @@ analyzers:
       joy:
         type: diagnostic_aggregator/GenericAnalyzer
         path: PS3 Controller
-        find_and_remove_prefix: "joy:"
+        find_and_remove_prefix: "jsk_joy_node:"
   system:
     type: diagnostic_aggregator/AnalyzerGroup
     path: System

--- a/jsk_fetch_robot/jsk_fetch_startup/config/sanity_targets.yaml
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/sanity_targets.yaml
@@ -1,0 +1,7 @@
+topics:
+  - /audio
+  - /head_camera/depth/image_raw
+  - /head_camera/rgb/image_raw
+
+nodes:
+  - /head_camera/head_camera_nodelet_manager

--- a/jsk_fetch_robot/jsk_fetch_startup/config/sanity_targets.yaml
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/sanity_targets.yaml
@@ -1,5 +1,7 @@
 topics:
   - /audio
+  - /edgetpu_human_pose_estimator/output/image/compressed
+  - /edgetpu_object_detector/output/image/compressed
   - /head_camera/depth/image_raw
   - /head_camera/rgb/image_raw
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -270,4 +270,12 @@
     <include file="$(find jsk_fetch_startup)/launch/fetch_rosserial.launch" />
   </group>
 
+  <!-- Publish /diagnostics based on topics and nodes sanity check -->
+  <node name="sanity_diagnostics" pkg="jsk_tools" type="sanity_diagnostics.py">
+    <rosparam command="load" file="$(find jsk_fetch_startup)/config/sanity_targets.yaml" />
+    <rosparam subst_value="true">
+      duration: 60
+    </rosparam>
+  </node>
+
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/package.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/package.xml
@@ -15,17 +15,23 @@
 
   <run_depend>image_proc</run_depend>
   <run_depend>jsk_fetch_accessories</run_depend>
+  <run_depend>jsk_fetch_diagnosis</run_depend>
+  <run_depend>jsk_network_tools</run_depend>
   <run_depend>jsk_robot_startup</run_depend>
+  <run_depend version_gte="2.2.12">jsk_tools</run_depend>
   <run_depend>jsk_maps</run_depend>
   <run_depend>fetcheus</run_depend>
   <run_depend>fetch_navigation</run_depend>
   <run_depend>fetch_moveit_config</run_depend>
   <run_depend>fetch_open_auto_dock</run_depend>
   <run_depend>fetch_driver_msgs</run_depend>
+  <run_depend>nodelet</run_depend>
   <run_depend>pr2_computer_monitor</run_depend>
   <run_depend>robot_pose_publisher</run_depend>
   <run_depend>rviz</run_depend>
+  <run_depend>tf</run_depend>
   <run_depend>touchegg</run_depend>
+  <run_depend>sound_play</run_depend>
   <run_depend>switchbot_ros</run_depend>
   <run_depend>tf2_ros</run_depend>
   <run_depend>voice_text</run_depend>


### PR DESCRIPTION
This is refined version of https://github.com/jsk-ros-pkg/jsk_robot/pull/1460
Copied from https://github.com/knorth55/jsk_robot/pull/222
This depends on https://github.com/jsk-ros-pkg/jsk_common/pull/1727

I want fetch to indicate that topic has not come or node does not exist.
For example, I want to check existence of `/audio` or `/insta360`, whose publisher does not publish `/diagnostics`.

What I did in this PR is as follows:
- Change diagnostics aggregator prefix according to node name change.
- Add node to publish /diagnostics
