### PR TITLE
[jsk_robot_startup] Support embed image in email_topic.py

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
+++ b/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
@@ -59,6 +59,7 @@ add_message_files(
   FILES
   RoomLight.msg
   Email.msg
+  EmailBody.msg
 )
 
 generate_messages(

--- a/jsk_robot_common/jsk_robot_startup/euslisp/email-topic-client.l
+++ b/jsk_robot_common/jsk_robot_startup/euslisp/email-topic-client.l
@@ -1,5 +1,7 @@
 (ros::load-ros-manifest "jsk_robot_startup")
 
+(require :base64 "lib/llib/base64.l")
+
 (defun init-mail ()
   (ros::advertise "email" jsk_robot_startup::Email 1)
   (ros::spin-once)
@@ -16,7 +18,23 @@
   (setq msg (instance jsk_robot_startup::Email :init))
   (send msg :header :stamp (ros::time-now))
   (send msg :subject subject)
-  (send msg :body body)
+  (send msg :body
+        (mapcar #'(lambda (e)
+                    (cond ((derivedp e image-2d)
+                           (if (> (length (send e :entity)) (* 8 8192))
+                               (warning-message 3 "The size of img is too large (~A)~%You may encounter 'too long string' error, see https://github.com/euslisp/EusLisp/issues/2 for more info~%" (length (send e :entity))))
+                           (instance jsk_robot_startup::EmailBody :init :type "img"
+                                     :img_data (base64encode (send e :entity))
+                                     :img_size 100))
+                          ((probe-file e)
+                           (instance jsk_robot_startup::EmailBody :init :type "img" :file_path e :img_size 100))
+                          ((and (> (length e) 0) ;; check html
+                                (eq (elt e 0) #\<)
+                                (eq (elt e (1- (length e))) #\>))
+                           (instance jsk_robot_startup::EmailBody :init :type "html" :message e))
+                          (t
+                           (instance jsk_robot_startup::EmailBody :init :type "text" :message (format nil "~A" e)))))
+                (if (atom body) (list body) body)))
   (send msg :sender_address sender-address)
   (send msg :receiver_address receiver-address)
   (send msg :smtp_server smtp-server)

--- a/jsk_robot_common/jsk_robot_startup/euslisp/sample-email-topic-client.l
+++ b/jsk_robot_common/jsk_robot_startup/euslisp/sample-email-topic-client.l
@@ -7,10 +7,36 @@
 (ros::spin-once)
 (setq receiver-address (ros::get-param "~receiver_address"))
 (setq attached-files (ros::get-param "~attached_files" nil))
-(unix::sleep 10)  ;; wait for server
+(while (or (null (ros::get-num-subscribers "email"))
+           (<= (ros::get-num-subscribers "email") 0))
+  (ros::ros-warn "wait for email topic")
+  (unix::sleep 1))
 
 (ros::ros-info "Sending a mail to ~A" receiver-address)
-(send-mail "test-mail" receiver-address "test" :attached-files attached-files)
-(ros::ros-info "Sent a mail")
+(send-mail "test text mail" receiver-address "test")
+(ros::ros-info "Sent a text mail")
+(unix:sleep 1)
+
+(send-mail "test html mail" receiver-address "<h1>test with html mail</h1>")
+(ros::ros-info "Sent a html mail")
+(unix:sleep 1)
+
+(send-mail "test attached mail" receiver-address "test with attached image" :attached-files attached-files)
+(ros::ros-info "Sent a mail with attached files ~A" attached-files)
+(unix:sleep 1)
+
+(when attached-files
+  (send-mail "test image embedded mail (file)" receiver-address (append attached-files (list "test with embedded image")))
+  (ros::ros-info "sent a mail with embedded image ~a" attached-files)
+  (unix:sleep 1)
+  ;; read png/jpeg file, but do not extract to raw image, keep original compressed data in (img . entity)
+  (setq img (read-image-file (elt attached-files 0)))
+  (setq (img . entity) (make-string (elt (unix:stat (elt attached-files 0)) 7))) ;; size of file
+  (with-open-file (f (elt attached-files 0)) (unix:uread (send f :infd) (img . entity)))
+  (send-mail "test image embedded mail (string)" receiver-address (list "test with embedded image" img))
+  (ros::ros-info "Sent a mail with embedded image ~A" img)
+  (unix:sleep 1)
+  )
+
 (ros::roseus "shutdown")
 (exit)

--- a/jsk_robot_common/jsk_robot_startup/msg/Email.msg
+++ b/jsk_robot_common/jsk_robot_startup/msg/Email.msg
@@ -1,6 +1,6 @@
 std_msgs/Header header
 string subject # Email subject
-string body # Email body
+jsk_robot_startup/EmailBody[] body # Email body
 string sender_address # Sender's email address
 string receiver_address # receiver's email address
 string smtp_server # smtp server address

--- a/jsk_robot_common/jsk_robot_startup/msg/EmailBody.msg
+++ b/jsk_robot_common/jsk_robot_startup/msg/EmailBody.msg
@@ -1,0 +1,3 @@
+string type # text, html, img
+string message # For text type
+string file_path # For img type

--- a/jsk_robot_common/jsk_robot_startup/msg/EmailBody.msg
+++ b/jsk_robot_common/jsk_robot_startup/msg/EmailBody.msg
@@ -1,4 +1,5 @@
 string type # text, html, img
 string message # For text and html type
-string file_path # For img type
+string file_path # For img type, set file path
+string img_data # For img type, you can also use base64 encoded image data instead of file path
 uint8 img_size # For img type [percent]

--- a/jsk_robot_common/jsk_robot_startup/msg/EmailBody.msg
+++ b/jsk_robot_common/jsk_robot_startup/msg/EmailBody.msg
@@ -1,3 +1,4 @@
 string type # text, html, img
-string message # For text type
+string message # For text and html type
 string file_path # For img type
+uint8 img_size # For img type [percent]

--- a/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from email.mime.application import MIMEApplication
+from email.mime.image import MIMEImage
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 import errno
@@ -75,7 +76,31 @@ class EmailTopic(object):
         msg["Subject"] = subject
         msg["From"] = sender_address
         msg["To"] = receiver_address
-        msg.attach(MIMEText(body, 'plain', 'utf-8'))
+        # Support embed image
+        for content in body:
+            if content.type == 'text':
+                msg.attach(MIMEText(content.message, 'plain', 'utf-8'))
+            elif content.type == 'html':
+                msg.attach(MIMEText(content.message, 'html'))
+            elif content.type == 'img':
+                if content.file_path == '':
+                    rospy.logwarn('File name is empty. Skipped.')
+                    continue
+                if not os.path.exists(content.file_path):
+                    rospy.logerr(
+                        'File {} is not found.'.format(content.file_path))
+                    return
+                with open(content.file_path, 'rb') as img:
+                    embed_img = MIMEImage(img.read())
+                    embed_img.add_header(
+                        'Content-ID', '<{}>'.format(content.file_path))
+                    msg.attach(embed_img)  # This line is necessary to embed
+                text = '<img src="cid:{}">'.format(content.file_path)
+                bodytext = MIMEText(text, 'html')
+                msg.attach(bodytext)
+            else:
+                rospy.logwarn('Unknown content type {}'.format(content.type))
+                continue
         # Attach file
         for attached_file in attached_files:
             if attached_file == '':

--- a/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
@@ -94,6 +94,9 @@ class EmailTopic(object):
                     embed_img = MIMEImage(img.read())
                     embed_img.add_header(
                         'Content-ID', '<{}>'.format(content.file_path))
+                    embed_img.add_header(
+                        'Content-Disposition', 'inline; filename="{}"'.format(
+                            os.path.basename(content.file_path)))
                     msg.attach(embed_img)  # This line is necessary to embed
                 if content.img_size:
                     image_size = content.img_size

--- a/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
@@ -95,7 +95,12 @@ class EmailTopic(object):
                     embed_img.add_header(
                         'Content-ID', '<{}>'.format(content.file_path))
                     msg.attach(embed_img)  # This line is necessary to embed
-                text = '<img src="cid:{}">'.format(content.file_path)
+                if content.img_size:
+                    image_size = content.img_size
+                else:
+                    image_size = 100
+                text = '<img src="cid:{}" width={}%>'.format(
+                    content.file_path, image_size)
                 bodytext = MIMEText(text, 'html')
                 msg.attach(bodytext)
             else:


### PR DESCRIPTION
This PR supports sending embed image with email_topic.py. (Discussion in #1463)

------
TODO
- [x] Set image size 
---------
<img src="https://user-images.githubusercontent.com/67531577/170044565-402eabbb-d907-4af0-b84a-93dba81719dd.png">

- sample code
```python
#!/usr/bin/env python
# -*- coding: utf-8 -*-

import rospy
import time
from jsk_robot_startup.msg import Email
from jsk_robot_startup.msg import EmailBody

def main():
    rospy.init_node('embed_image_test')
    pub = rospy.Publisher("email", Email, queue_size=10)

    msg = Email()
    content_1 = EmailBody()
    content_1.type = 'text'
    content_1.message = 'こんにちは．\n'
    content_2 = EmailBody()
    content_2.type = 'img'
    content_2.file_path = '/home/tsukamoto/Pictures/spotkinova_attachment.jpg'
    content_4 = EmailBody()
    content_4.type = 'img'
    content_4.file_path = '/home/tsukamoto/Pictures/boston_template.png'
    content_5 = EmailBody()
    content_5.type = 'text'
    content_5.message = '\n 今日はSpotで遊んだよ\n'
    content_6 = EmailBody()
    content_6.type = 'img'
    content_6.file_path = '/home/tsukamoto/Pictures/fetch-door4.png'
    content_7 = EmailBody()
    content_7.type = 'text'
    content_7.message = '\n Fetchにも手伝ってもらったよ．\n'
    content_8 = EmailBody()
    content_8.type = 'text'
    content_8.message = '\n'

    msg.body = [content_1, content_2, content_8, content_4, content_5, content_6, content_7]
    msg.subject = 'embed_test'
    msg.sender_address = 'hoge@hoge.com'
    msg.receiver_address = 'fuga@fuga.com'
    print (msg)

    time.sleep(1)
    rospy.loginfo("Publish")
    pub.publish(msg)

main()

```

