### PR TITLE
[jsk_pr2_startup] Enable additional topic and options in rosbag_record.launch

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/rosbag_record.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/rosbag_record.launch
@@ -1,6 +1,9 @@
 <launch>
   <arg name="rosbag" doc="rosbag file path" />
   <arg name="compress" default="false" doc="whether compress rosbag or not." />
+  <arg name="other_topics" default=""/>
+  <arg name="regex_topics" default=""/>
+  <arg name="other_options" default=""/>
 
   <arg if="$(arg compress)" name="compress_flag" value="--bz2" />
   <arg unless="$(arg compress)" name="compress_flag" value="" />
@@ -31,7 +34,10 @@
           /kinect_head/depth_registered/throttled/camera_info
           /kinect_head/rgb/throttled/image_rect_color/compressed
           /kinect_head/depth_registered/throttled/image_rect/compressedDepth
-          /audio"
+          /audio
+          $(arg other_topics)
+          -e $(arg regex_topics)
+          $(arg other_options)"
       output="screen" />
 
 </launch>

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/rosbag_record.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/rosbag_record.launch
@@ -2,11 +2,13 @@
   <arg name="rosbag" doc="rosbag file path" />
   <arg name="compress" default="false" doc="whether compress rosbag or not." />
   <arg name="other_topics" default=""/>
-  <arg name="regex_topics" default=""/>
+  <arg name="use_regex" default="false" doc="whether include regex in topics or not." />
   <arg name="other_options" default=""/>
 
   <arg if="$(arg compress)" name="compress_flag" value="--bz2" />
   <arg unless="$(arg compress)" name="compress_flag" value="" />
+  <arg if="$(arg use_regex)" name="regex_flag" value="--regex" />
+  <arg unless="$(arg use_regex)" name="regex_flag" value="" />
 
   <node name="rosbag_record" pkg="rosbag" type="record"
       args="-q $(arg compress_flag) -O $(arg rosbag) -b 0 
@@ -36,7 +38,7 @@
           /kinect_head/depth_registered/throttled/image_rect/compressedDepth
           /audio
           $(arg other_topics)
-          -e $(arg regex_topics)
+          $(arg regex_flag)
           $(arg other_options)"
       output="screen" />
 

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/rosbag_record.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/rosbag_record.launch
@@ -2,7 +2,7 @@
   <arg name="rosbag" doc="rosbag file path" />
   <arg name="compress" default="false" doc="whether compress rosbag or not." />
   <arg name="other_topics" default=""/>
-  <arg name="use_regex" default="false" doc="whether include regex in topics or not." />
+  <arg name="use_regex" default="true" doc="whether include regex in topics or not." />
   <arg name="other_options" default=""/>
 
   <arg if="$(arg compress)" name="compress_flag" value="--bz2" />


### PR DESCRIPTION
Other than topics specified by default, you can record any topics including regex. 
You can also add other options as [common_record.launch](https://github.com/jsk-ros-pkg/jsk_common/blob/master/jsk_data/launch/common_record.launch) in jsk_data.

cc: @iory 