### PR TITLE
[jsk_fetch_startup] Do not use ConnectionBasedTransport in correct_position.py

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/correct_position.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/correct_position.py
@@ -2,20 +2,20 @@
 
 import rospy
 
-from jsk_topic_tools import ConnectionBasedTransport
 from power_msgs.msg import BatteryState
 from geometry_msgs.msg import PoseWithCovarianceStamped
 from geometry_msgs.msg import Pose
 from visualization_msgs.msg import MarkerArray
 
 
-class CorrectPosition(ConnectionBasedTransport):
+class CorrectPosition():
 
     def __init__(self):
-        super(CorrectPosition, self).__init__()
-        self.pub = self.advertise('initialpose',
-                                  PoseWithCovarianceStamped,
-                                  queue_size=1)
+        self.sub_dock = rospy.Subscriber(
+            '/battery_state', BatteryState, self._cb)
+        self.pub = rospy.Publisher('initialpose',
+                                   PoseWithCovarianceStamped,
+                                   queue_size=1)
         self.dock_pose = Pose()
         robot_name = rospy.get_param('/robot/name')
         if robot_name == 'fetch15':
@@ -28,13 +28,6 @@ class CorrectPosition(ConnectionBasedTransport):
 
         self.is_docking = False
         self.timer = rospy.Timer(rospy.Duration(1.0), self._cb_correct_position)
-
-    def subscribe(self):
-        self.sub_dock = rospy.Subscriber(
-            '/battery_state', BatteryState, self._cb)
-
-    def unsubscribe(self):
-        self.sub_dock.unregister()
 
     def _cb(self, msg):
         self.is_docking = msg.is_charging


### PR DESCRIPTION
From https://github.com/knorth55/jsk_robot/pull/254

Since https://github.com/jsk-ros-pkg/jsk_common/pull/1711 is merged, `correct_position.py` output the following diagnostics error.

```
"/Other/correct_position:  correct_position"
Other correct position:  correct position  correct position is not running for 1.0 sec
```

This is because `correct_position.py` does not publish `/initialpose` (in other words `self.last_published_time` is not updated) when fetch is un-docked.

With this PR, I suppress the diagnostics error by removing `ConnectionBasedTransport` from `correct_position.py`.
I think this PR does not increase fetch's CPU usage very much, because `correct_position.py` does not use CPU resource even if `/initialpose` is always published .