### PR TITLE
[jsk_fetch_startup] Add poke to correct_position.py to avoid diagnostics error

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -182,7 +182,11 @@
     </include>
 
     <!-- dock localization -->
-    <node pkg="jsk_fetch_startup" type="correct_position.py" name="correct_position" respawn="true" />
+    <node pkg="jsk_fetch_startup" type="correct_position.py" name="correct_position" respawn="true">
+      <rosparam>
+        vital_rate: 0.1
+      </rosparam>
+    </node>
 
     <!-- include fetch_navigation -->
     <include file="$(find fetch_navigation)/launch/fetch_nav.launch" unless="$(arg use_build_map)" >

--- a/jsk_fetch_robot/jsk_fetch_startup/scripts/correct_position.py
+++ b/jsk_fetch_robot/jsk_fetch_startup/scripts/correct_position.py
@@ -37,6 +37,7 @@ class CorrectPosition(ConnectionBasedTransport):
         self.sub_dock.unregister()
 
     def _cb(self, msg):
+        self.poke()
         self.is_docking = msg.is_charging
 
     def _cb_correct_position(self, event):


### PR DESCRIPTION
From https://github.com/knorth55/jsk_robot/pull/255

Depends on https://github.com/jsk-ros-pkg/jsk_common/pull/1740

In `correct_position.py`, fetch publishes `initialpose` topic to `amcl` node when the following 2 conditions are met.
- `initialpose` topic is subscribed by `amcl`
- fetch is docking

I this case, even if `initialpose` is subscribed, it does not necessarily mean that publish is performed.
So I manually call `poke()` in callback function in addition to  `publish()`.

cc @iory @knorth55 