### PR TITLE
Add t265 odometry transformer

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -5,6 +5,62 @@ jsk_robot_startup
 
 see [lifelog/README.md](lifelog/README.md)
 
+## t265_odometry_transformer.py
+
+This node publishes odometry topics and TF with raw odometry topics of Realsense T265. Realsense T265 can publish odometry TF in camera frames. This node helps to use them in robot base_link frames.
+
+<TODO: images>
+
+### Subscribers
+
+- `~odom_in` (type: nav_msgs/Odometry)
+
+Raw odometry topic from Realsense T265
+
+### Publishers
+
+- `~odom_out` (type: nav_msgs/Odometry)
+
+Transformed odometry topic.
+
+- `/tf` (type: tf2_msgs/TFMessage)
+
+### Parameters
+
+- `~frame_id_base_link` (type: `string`, default: `base_link`)
+
+Frame ID of robot base_link. It is assumed that this link is top frame of TF tree because TF from odom to this link will be broadcasted.
+
+- `~frame_id_odom` (type: `string`, default: `odom`)
+
+Frame ID name to be broadcasted as odometry frame 
+
+- `~translation_base_link_to_pose_frame_x` (type: `double`, default: `0.0`)
+- `~translation_base_link_to_pose_frame_y` (type: `double`, default: `0.0`)
+- `~translation_base_link_to_pose_frame_z` (type: `double`, default: `0.0`)
+- `~rotation_base_link_to_pose_frame_x` (type: `double`, default: `0.0`)
+- `~rotation_base_link_to_pose_frame_y` (type: `double`, default: `0.0`)
+- `~rotation_base_link_to_pose_frame_z` (type: `double`, default: `0.0`)
+- `~rotation_base_link_to_pose_frame_w` (type: `double`, default: `1.0`)
+
+Relative pose from robot base link to T265 pose frame. For pose_frame of Realsense T265, please see [this]().
+
+- `~publish_tf` (type: `bool`, default: `True`)
+
+If set to true, TF from odometry frame to base_link is broadcasted.
+
+- `~2d_mode` (type: `bool`, default: `True`)
+
+If 2D odometry is prefered, please set this to True.
+
+### How to use this
+
+Connect Realsense T265 to your computer and run
+
+```bash
+roslaunch jsk_robot_startup t265_odometry_transformer.launch
+```
+
 ## scripts/email_topic.py
 
 This node sends email based on received rostopic (jsk_robot_startup/Email).

--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -27,11 +27,11 @@ Transformed odometry topic.
 
 ### Parameters
 
-- `~frame_id_base_link` (type: `string`, default: `base_link`)
+- `~base_frame_id` (type: `string`, default: `base_link`)
 
 Frame ID of robot base_link. It is assumed that this link is top frame of TF tree because TF from odom to this link will be broadcasted.
 
-- `~frame_id_odom` (type: `string`, default: `odom`)
+- `~odom_frame_id` (type: `string`, default: `odom`)
 
 Frame ID name to be broadcasted as odometry frame 
 

--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -53,13 +53,21 @@ If set to true, TF from odometry frame to base_link is broadcasted.
 
 If 2D odometry is prefered, please set this to True.
 
-### How to use this
+### How to run a demo
 
 Connect Realsense T265 to your computer and run
 
 ```bash
 roslaunch jsk_robot_startup t265_odometry_transformer.launch
 ```
+
+### How to use t265_odometry_transformer with your robot.
+
+First, this program currently assumes that T265 is attached to the base link of the robot. Please make sure your robot's configuration.
+
+Then, please check the transform from your robot base frame to t265 pose frame ( transform from $\Sigma_{base}$ to $\Sigma_{t265}$ in the figure above.)
+
+And launch `t265_odometry_transformer.launch` with your configuration.
 
 ## scripts/email_topic.py
 

--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -9,7 +9,7 @@ see [lifelog/README.md](lifelog/README.md)
 
 This node publishes odometry topics and TF with raw odometry topics of Realsense T265. Realsense T265 can publish odometry TF in camera frames. This node helps to use them in robot base_link frames.
 
-<TODO: images>
+![t265_odometry_transformer](https://user-images.githubusercontent.com/9410362/172747852-9d78d710-528d-4c53-ba32-9af8021ce7eb.png)
 
 ### Subscribers
 
@@ -43,7 +43,7 @@ Frame ID name to be broadcasted as odometry frame
 - `~rotation_base_link_to_pose_frame_z` (type: `double`, default: `0.0`)
 - `~rotation_base_link_to_pose_frame_w` (type: `double`, default: `1.0`)
 
-Relative pose from robot base link to T265 pose frame. For pose_frame of Realsense T265, please see [this]().
+Relative pose from robot base link to T265 pose frame. For pose_frame of Realsense T265 on ROS, please see the figure above.
 
 - `~publish_tf` (type: `bool`, default: `True`)
 

--- a/jsk_robot_common/jsk_robot_startup/config/demo_t265_odometry_transformer.rviz
+++ b/jsk_robot_common/jsk_robot_startup/config/demo_t265_odometry_transformer.rviz
@@ -1,0 +1,146 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded: ~
+      Splitter Ratio: 0.5
+    Tree Height: 728
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 0.10000000149011612
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 100
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        base:
+          Value: true
+        odom:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        odom:
+          base:
+            {}
+      Update Interval: 0
+      Value: true
+    - Class: jsk_rviz_plugin/TFTrajectory
+      Enabled: true
+      Name: TFTrajectory
+      Value: true
+      color: 25; 255; 240
+      duration: 30
+      frame: base
+      line_width: 0.009999999776482582
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: odom
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 3.121720314025879
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.4153984487056732
+      Target Frame: base
+      Value: Orbit (rviz)
+      Yaw: 5.97359037399292
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1025
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd00000004000000000000015600000363fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000363000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000363fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000363000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000007800000003efc0100000002fb0000000800540069006d0065010000000000000780000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000006240000036300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1920
+  X: 0
+  Y: 27

--- a/jsk_robot_common/jsk_robot_startup/launch/t265_odometry_transformer.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/t265_odometry_transformer.launch
@@ -1,0 +1,95 @@
+<launch>
+  <arg name="topic_odom_in" default="/t265/odom/sample" />
+  <arg name="topic_odom_out" default="odom" />
+  <arg name="base_frame_id" default="base" />
+  <arg name="odom_frame_id" default="odom" />
+  <arg name="topic_tf" default="/tf" />
+
+  <arg name="publish_tf" default="true" />
+  <arg name="2d_mode" default="true" />
+
+  <arg name="translation_base_link_to_pose_frame_x" default="0" />
+  <arg name="translation_base_link_to_pose_frame_y" default="0" />
+  <arg name="translation_base_link_to_pose_frame_z" default="0" />
+  <arg name="rotation_base_link_to_pose_frame_x" default="0" />
+  <arg name="rotation_base_link_to_pose_frame_y" default="0" />
+  <arg name="rotation_base_link_to_pose_frame_z" default="0" />
+  <arg name="rotation_base_link_to_pose_frame_w" default="1.0" />
+
+  <arg name="launch_t265" default="true" />
+  <arg name="camera" default="t265" />
+
+  <arg name="launch_rviz" default="false" />
+
+  <node
+      pkg="jsk_robot_startup"
+      type="t265_odometry_transformer.py"
+      name="t265_odometry_transformer"
+      output="screen"
+      >
+      <remap from="~odom_in" to="/$(arg topic_odom_in)" />
+      <remap from="~odom_out" to="$(arg topic_odom_out)" />
+      <remap from="/tf" to="$(arg topic_tf)" />
+
+      <param name="~frame_id_base_link" value="$(arg base_frame_id)" />
+      <param name="~frame_id_odom" value="$(arg odom_frame_id)" />
+      <param name="~publish_tf" value="$(arg publish_tf)" />
+      <param name="~2d_mode" value="$(arg 2d_mode)" />
+
+      <!-- transform from base_link to t265 pose frame -->
+      <param name="~translation_base_link_to_pose_frame_x" value="$(arg translation_base_link_to_pose_frame_x)" />
+      <param name="~translation_base_link_to_pose_frame_y" value="$(arg translation_base_link_to_pose_frame_y)" />
+      <param name="~translation_base_link_to_pose_frame_z" value="$(arg translation_base_link_to_pose_frame_z)" />
+      <param name="~rotation_base_link_to_pose_frame_x" value="$(arg rotation_base_link_to_pose_frame_x)" />
+      <param name="~rotation_base_link_to_pose_frame_y" value="$(arg rotation_base_link_to_pose_frame_y)" />
+      <param name="~rotation_base_link_to_pose_frame_z" value="$(arg rotation_base_link_to_pose_frame_z)" />
+      <param name="~rotation_base_link_to_pose_frame_w" value="$(arg rotation_base_link_to_pose_frame_w)" />
+  </node>
+
+  <group ns="$(arg camera)" if="$(arg launch_t265)">
+    <rosparam>
+      /tracking_module/enable_mapping: false
+      /tracking_module/enable_relocalization: false
+      /tracking_module/enable_pose_jumping: false
+      /tracking_module/enable_dynamic_calibration: true
+      /tracking_module/enable_map_preservation: false
+    </rosparam>
+    <include file="$(find realsense2_camera)/launch/includes/nodelet.launch.xml">
+      <arg name="tf_prefix"                value="$(arg camera)"/>
+      <arg name="serial_no"                value=""/>
+      <arg name="usb_port_id"              value=""/>
+      <arg name="device_type"              value="t265"/>
+      <arg name="json_file_path"           value=""/>
+
+      <arg name="enable_sync"              value="false"/>
+
+      <arg name="fisheye_width"            value="-1"/>
+      <arg name="fisheye_height"           value="-1"/>
+      <arg name="enable_fisheye1"          value="false"/>
+      <arg name="enable_fisheye2"          value="false"/>
+
+      <arg name="fisheye_fps"              value="-1"/>
+      <arg name="gyro_fps"                 value="-1"/>
+      <arg name="accel_fps"                value="-1"/>
+      <arg name="enable_gyro"              value="true"/>
+      <arg name="enable_accel"             value="true"/>
+      <arg name="enable_pose"              value="true"/>
+
+      <arg name="linear_accel_cov"         value="0.01"/>
+      <arg name="initial_reset"            value="true"/>
+      <arg name="unite_imu_method"         value=""/>
+
+      <arg name="publish_odom_tf"          value="false"/>
+      <arg name="publish_tf"               value="false"/>
+
+      <arg name="respawn"                  value="$(arg respawn)"/>
+    </include>
+  </group>
+
+  <node
+      pkg="rviz"
+      type="rviz"
+      name="$(anon rviz)"
+      args="-d $(find jsk_robot_startup)/config/demo_t265_odometry_transformer.launch"
+      />
+</launch>

--- a/jsk_robot_common/jsk_robot_startup/launch/t265_odometry_transformer.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/t265_odometry_transformer.launch
@@ -31,8 +31,8 @@
       <remap from="~odom_out" to="$(arg topic_odom_out)" />
       <remap from="/tf" to="$(arg topic_tf)" />
 
-      <param name="~frame_id_base_link" value="$(arg base_frame_id)" />
-      <param name="~frame_id_odom" value="$(arg odom_frame_id)" />
+      <param name="~base_frame_id" value="$(arg base_frame_id)" />
+      <param name="~odom_frame_id" value="$(arg odom_frame_id)" />
       <param name="~publish_tf" value="$(arg publish_tf)" />
       <param name="~2d_mode" value="$(arg 2d_mode)" />
 

--- a/jsk_robot_common/jsk_robot_startup/launch/t265_odometry_transformer.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/t265_odometry_transformer.launch
@@ -89,5 +89,6 @@
       type="rviz"
       name="$(anon rviz)"
       args="-d $(find jsk_robot_startup)/config/demo_t265_odometry_transformer.rviz"
+      if="$(arg launch_rviz)"
       />
 </launch>

--- a/jsk_robot_common/jsk_robot_startup/launch/t265_odometry_transformer.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/t265_odometry_transformer.launch
@@ -6,7 +6,7 @@
   <arg name="topic_tf" default="/tf" />
 
   <arg name="publish_tf" default="true" />
-  <arg name="2d_mode" default="true" />
+  <arg name="2d_mode" default="false" />
 
   <arg name="translation_base_link_to_pose_frame_x" default="0" />
   <arg name="translation_base_link_to_pose_frame_y" default="0" />
@@ -81,8 +81,6 @@
 
       <arg name="publish_odom_tf"          value="false"/>
       <arg name="publish_tf"               value="false"/>
-
-      <arg name="respawn"                  value="$(arg respawn)"/>
     </include>
   </group>
 
@@ -90,6 +88,6 @@
       pkg="rviz"
       type="rviz"
       name="$(anon rviz)"
-      args="-d $(find jsk_robot_startup)/config/demo_t265_odometry_transformer.launch"
+      args="-d $(find jsk_robot_startup)/config/demo_t265_odometry_transformer.rviz"
       />
 </launch>

--- a/jsk_robot_common/jsk_robot_startup/scripts/t265_odometry_transformer.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/t265_odometry_transformer.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+
+import rospy
+import tf2_ros
+
+from pyquaternion import Quaternion
+import numpy as np
+
+from nav_msgs.msg import Odometry
+from geometry_msgs.msg import TransformStamped
+
+import math
+import sys
+
+
+class T265OdometryTransformer(object):
+
+    def __init__(self):
+
+        rospy.init_node('t265_odometry_transformer')
+
+        self._frame_id_base_link = str(
+            rospy.get_param('~frame_id_base_link', 'base_link'))
+        self._frame_id_odom = str(rospy.get_param('~frame_id_odom', 'odom'))
+        self._translation_base_link_to_pose_frame_x = float(
+            rospy.get_param('~translation_base_link_to_pose_frame_x'))
+        self._translation_base_link_to_pose_frame_y = float(
+            rospy.get_param('~translation_base_link_to_pose_frame_y'))
+        self._translation_base_link_to_pose_frame_z = float(
+            rospy.get_param('~translation_base_link_to_pose_frame_z'))
+        self._rotation_base_link_to_pose_frame_x = float(
+            rospy.get_param('~rotation_base_link_to_pose_frame_x'))
+        self._rotation_base_link_to_pose_frame_y = float(
+            rospy.get_param('~rotation_base_link_to_pose_frame_y'))
+        self._rotation_base_link_to_pose_frame_z = float(
+            rospy.get_param('~rotation_base_link_to_pose_frame_z'))
+        self._rotation_base_link_to_pose_frame_w = float(
+            rospy.get_param('~rotation_base_link_to_pose_frame_w'))
+
+        self._publish_tf = bool(rospy.get_param('~publish_tf', True))
+        self._2d_mode = bool(rospy.get_param('~2d_mode', True))
+
+        self._quat_t265_basebased = Quaternion(
+            self._rotation_base_link_to_pose_frame_w,
+            self._rotation_base_link_to_pose_frame_x,
+            self._rotation_base_link_to_pose_frame_y,
+            self._rotation_base_link_to_pose_frame_z
+        ).normalised
+        self._pos_t265_basebased = np.array([
+            self._translation_base_link_to_pose_frame_x,
+            self._translation_base_link_to_pose_frame_y,
+            self._translation_base_link_to_pose_frame_z
+        ])
+
+        if self._quat_t265_basebased.norm < 0.1:
+            rospy.logerr('Rotation of base_link to pose_frame is invalid.')
+            sys.exit(1)
+
+        self._quat_base_t265based = self._quat_t265_basebased.inverse
+        self._pos_base_t265based = self._quat_base_t265based.rotate(
+            -self._pos_t265_basebased)
+
+        self._tf_br = tf2_ros.TransformBroadcaster()
+        self._pub_odom = rospy.Publisher('~odom_out', Odometry, queue_size=1)
+        self._sub_odom = rospy.Subscriber(
+            '~odom_in', Odometry, self.cb_odometry)
+
+    def cb_odometry(self, msg):
+
+        # Nan check
+        if (math.isnan(msg.pose.pose.position.x) or
+            math.isnan(msg.pose.pose.position.y) or
+            math.isnan(msg.pose.pose.position.z) or
+            math.isnan(msg.pose.pose.orientation.x) or
+            math.isnan(msg.pose.pose.orientation.y) or
+            math.isnan(msg.pose.pose.orientation.z) or
+            math.isnan(msg.twist.twist.linear.x) or
+            math.isnan(msg.twist.twist.linear.y) or
+            math.isnan(msg.twist.twist.linear.z) or
+            math.isnan(msg.twist.twist.angular.x) or
+            math.isnan(msg.twist.twist.angular.y) or
+                math.isnan(msg.twist.twist.angular.z)):
+            rospy.logwarn_throttle(
+                10, 'Received an odom message with nan values')
+            return
+
+        pos_t265_odombased = np.array([
+            msg.pose.pose.position.x,
+            msg.pose.pose.position.y,
+            msg.pose.pose.position.z
+        ])
+        quat_t265_odombased = Quaternion(
+            msg.pose.pose.orientation.w,
+            msg.pose.pose.orientation.x,
+            msg.pose.pose.orientation.y,
+            msg.pose.pose.orientation.z
+        ).normalised
+
+        pos_base_odombased = pos_t265_odombased + \
+            quat_t265_odombased.rotate(self._pos_base_t265based)
+        quat_base_odombased = quat_t265_odombased * self._quat_base_t265based
+
+        pos_dot_t265_t265based = np.array([
+            msg.twist.twist.linear.x,
+            msg.twist.twist.linear.y,
+            msg.twist.twist.linear.z
+        ])
+        omega_t265_t265based = np.array([
+            msg.twist.twist.angular.x,
+            msg.twist.twist.angular.y,
+            msg.twist.twist.angular.z
+        ])
+        pos_dot_base_basebased = self._quat_t265_basebased.rotate(
+            pos_dot_t265_t265based +
+            np.cross(omega_t265_t265based, self._pos_base_t265based)
+        )
+        omega_base_basebased = self._quat_t265_basebased.rotate(
+            omega_t265_t265based)
+
+        pub_msg = Odometry()
+        pub_msg.header.stamp = rospy.Time.now()
+        pub_msg.header.frame_id = self._frame_id_odom
+        pub_msg.child_frame_id = self._frame_id_base_link
+        if self._2d_mode:
+            quat_base_odombased_2d = Quaternion(
+                quat_base_odombased.w,
+                0,
+                0,
+                quat_base_odombased.z
+            ).normalised
+            pub_msg.pose.pose.position.x = pos_base_odombased[0]
+            pub_msg.pose.pose.position.y = pos_base_odombased[1]
+            pub_msg.pose.pose.position.z = 0
+            pub_msg.pose.pose.orientation.x = quat_base_odombased_2d.x
+            pub_msg.pose.pose.orientation.y = quat_base_odombased_2d.y
+            pub_msg.pose.pose.orientation.z = quat_base_odombased_2d.z
+            pub_msg.pose.pose.orientation.w = quat_base_odombased_2d.w
+            pub_msg.twist.twist.linear.x = pos_dot_base_basebased[0]
+            pub_msg.twist.twist.linear.y = pos_dot_base_basebased[1]
+            pub_msg.twist.twist.linear.z = 0
+            pub_msg.twist.twist.angular.x = 0
+            pub_msg.twist.twist.angular.y = 0
+            pub_msg.twist.twist.angular.z = omega_base_basebased[2]
+        else:
+            pub_msg.pose.pose.position.x = pos_base_odombased[0]
+            pub_msg.pose.pose.position.y = pos_base_odombased[1]
+            pub_msg.pose.pose.position.z = pos_base_odombased[2]
+            pub_msg.pose.pose.orientation.x = quat_base_odombased.x
+            pub_msg.pose.pose.orientation.y = quat_base_odombased.y
+            pub_msg.pose.pose.orientation.z = quat_base_odombased.z
+            pub_msg.pose.pose.orientation.w = quat_base_odombased.w
+            pub_msg.twist.twist.linear.x = pos_dot_base_basebased[0]
+            pub_msg.twist.twist.linear.y = pos_dot_base_basebased[1]
+            pub_msg.twist.twist.linear.z = pos_dot_base_basebased[2]
+            pub_msg.twist.twist.angular.x = omega_base_basebased[0]
+            pub_msg.twist.twist.angular.y = omega_base_basebased[1]
+            pub_msg.twist.twist.angular.z = omega_base_basebased[2]
+        # Covariance is not transformed currently
+        pub_msg.pose.covariance = msg.pose.covariance
+        pub_msg.twist.covariance = msg.twist.covariance
+        self._pub_odom.publish(pub_msg)
+
+        if self._publish_tf:
+
+            t = TransformStamped()
+            t.header.stamp = rospy.Time.now()
+            t.header.frame_id = pub_msg.header.frame_id
+            t.child_frame_id = pub_msg.child_frame_id
+            t.transform.translation.x = pub_msg.pose.pose.position.x
+            t.transform.translation.y = pub_msg.pose.pose.position.y
+            t.transform.translation.z = pub_msg.pose.pose.position.z
+            t.transform.rotation.x = pub_msg.pose.pose.orientation.x
+            t.transform.rotation.y = pub_msg.pose.pose.orientation.y
+            t.transform.rotation.z = pub_msg.pose.pose.orientation.z
+            t.transform.rotation.w = pub_msg.pose.pose.orientation.w
+            self._tf_br.sendTransform(t)
+
+
+def main():
+
+    a = OdometryTransformer()
+    rospy.spin()
+
+
+if __name__ == '__main__':
+    main()

--- a/jsk_robot_common/jsk_robot_startup/scripts/t265_odometry_transformer.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/t265_odometry_transformer.py
@@ -178,7 +178,7 @@ class T265OdometryTransformer(object):
 
 def main():
 
-    a = OdometryTransformer()
+    a = T265OdometryTransformer()
     rospy.spin()
 
 

--- a/jsk_robot_common/jsk_robot_startup/scripts/t265_odometry_transformer.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/t265_odometry_transformer.py
@@ -19,9 +19,9 @@ class T265OdometryTransformer(object):
 
         rospy.init_node('t265_odometry_transformer')
 
-        self._frame_id_base_link = str(
-            rospy.get_param('~frame_id_base_link', 'base_link'))
-        self._frame_id_odom = str(rospy.get_param('~frame_id_odom', 'odom'))
+        self._base_frame_id = str(
+            rospy.get_param('~base_frame_id', 'base_link'))
+        self._odom_frame_id = str(rospy.get_param('~odom_frame_id', 'odom'))
         self._translation_base_link_to_pose_frame_x = float(
             rospy.get_param('~translation_base_link_to_pose_frame_x'))
         self._translation_base_link_to_pose_frame_y = float(
@@ -123,8 +123,8 @@ class T265OdometryTransformer(object):
 
         pub_msg = Odometry()
         pub_msg.header.stamp = rospy.Time.now()
-        pub_msg.header.frame_id = self._frame_id_odom
-        pub_msg.child_frame_id = self._frame_id_base_link
+        pub_msg.header.frame_id = self._odom_frame_id
+        pub_msg.child_frame_id = self._base_frame_id
         if self._2d_mode:
             quat_odom_base_to_base_2d = Quaternion(
                 quat_odom_base_to_base.w,


### PR DESCRIPTION
Add t265_odometry_transformer

This node calculates odometry topics and TF of robot base frame from raw odometry topics of Realsense T265. Realsense T265 can publish odometry TF in t265 camera frames. This node helps to use them in robot base_link frames.

![t265_odometry_transformer](https://user-images.githubusercontent.com/9410362/172748087-bd5a363c-e6df-4e1d-af4b-785231298339.png)

## How to use this

Connect Realsense T265 to your computer and run

```bash
roslaunch jsk_robot_startup t265_odometry_transformer.launch
```