### PR TITLE
[jsk_robot_startup/battery_logger.py] Add error handling for dweet

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/battery_logger.py
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/battery_logger.py
@@ -80,8 +80,13 @@ class DweetLogger(BatteryLogger):
 
     def write(self, date, info):
         info["date"] = date.secs
-        res = requests.post("http://dweet.io/dweet/for/{uid}".format(uid=self.uid),
-                            json=info)
+        try:
+            res = requests.post("http://dweet.io/dweet/for/{uid}".format(uid=self.uid),
+                                json=info)
+        except Exception as e:
+            rospy.logerr("{}".format(e))
+            rospy.logerr("Could not write to dweet.io")
+            return
         assert res.ok and json.loads(res.content)["this"] == "succeeded"
 
 


### PR DESCRIPTION
# What is this?

In current, dweet server has down.
https://twitter.com/dweet_io
This PR adds error handling for dweet logging.
cc: @nakane11