### PR TITLE
[jsk_fetch_startup/go_to_kitchen.app] Launch rviz's throttle nodes in rviz_record.launch for video record

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -75,6 +75,7 @@ plugins:
         - /head_camera/rgb/throttled/image_rect_color/compressed
         - /head_camera/depth_registered/throttled/image_rect/compressedDepth
         - /audio
+        - /rviz/throttled/image/compressed
   - name: result_recorder_plugin
     type: app_recorder/result_recorder_plugin
     plugin_args:

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -1,4 +1,8 @@
 <launch>
   <node name="go_to_kitchen" pkg="roseus" type="roseus"
         args="$(find jsk_fetch_startup)/euslisp/go-to-kitchen.l"/>
+
+  <!-- launch rviz with throttle -->
+  <include file="$(find jsk_fetch_startup)/launch/rviz_record.launch" />
+
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/rviz_record.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/rviz_record.launch
@@ -1,0 +1,40 @@
+<launch>
+
+  <!-- rviz to launch within fetch body for video record -->
+
+  <arg name="DISPLAY" value=":0" />
+  <arg name="HOME" value="/home/fetch" />
+  <arg name="rviz_namespace" default="rviz" />
+  <arg name="throttled_rate" default="5.0" />
+  <arg name="throttle_rviz" default="true" />
+
+  <node name="$(anon jsk_startup_rviz)"
+        pkg="rviz" type="rviz"
+        args="-d $(find jsk_fetch_startup)/config/jsk_startup_record.rviz" >
+    <env name="DISPLAY" value="$(arg DISPLAY)" />
+    <env name="HOME" value="$(arg HOME)" />
+    <remap from="/rviz/image" to="$(arg rviz_namespace)/image" />
+  </node>
+
+  <group ns="$(arg rviz_namespace)" >
+    <node name="throttle_image"
+          pkg="nodelet" type="nodelet"
+          args="standalone jsk_topic_tools/LightweightThrottle"
+          if="$(arg throttle_rviz)"
+          respawn="true">
+      <remap from="~input" to="image" />
+      <remap from="~output" to="throttled/image" />
+      <param name="update_rate" value="$(arg throttled_rate)" />
+    </node>
+    <node name="throttle_image_compressed"
+          pkg="nodelet" type="nodelet"
+          args="standalone jsk_topic_tools/LightweightThrottle"
+          if="$(arg throttle_rviz)"
+          respawn="true">
+      <remap from="~input" to="image/compressed" />
+      <remap from="~output" to="throttled/image/compressed" />
+      <param name="update_rate" value="$(arg throttled_rate)" />
+    </node>
+  </group>
+
+</launch>


### PR DESCRIPTION
# What is this?
Related to https://github.com/knorth55/jsk_robot/pull/284
This PR adds a throttle function for rviz.
I confirmed this PR works on fetch1075.