### PR TITLE
[jsk_fetch_startup] Add alternate rwt_app_chooser URL

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/README.md
+++ b/jsk_fetch_robot/jsk_fetch_startup/README.md
@@ -234,7 +234,7 @@ tmuxinator log
 You can not run this on Firefox. Please use Google Chrome.
 
 ### Add fetch to rwt_app_chooser
-1. Access [http://tork-a.github.io/visualization_rwt/rwt_app_chooser](http://tork-a.github.io/visualization_rwt/rwt_app_chooser "website"). Note that this website is not available now. Access `http://fetch's IP address:8000/rwt_app_chooser/`.
+1. Access [http://tork-a.github.io/visualization_rwt/rwt_app_chooser](http://tork-a.github.io/visualization_rwt/rwt_app_chooser "website").
 1. Click `ADD A ROBOT` button
 1. Select `Fetch` at `Robot type`
 1. Type `fetch15` at `Robot name`

--- a/jsk_fetch_robot/jsk_fetch_startup/README.md
+++ b/jsk_fetch_robot/jsk_fetch_startup/README.md
@@ -234,7 +234,7 @@ tmuxinator log
 You can not run this on Firefox. Please use Google Chrome.
 
 ### Add fetch to rwt_app_chooser
-1. Access [http://tork-a.github.io/visualization_rwt/rwt_app_chooser](http://tork-a.github.io/visualization_rwt/rwt_app_chooser "website").
+1. Access [http://tork-a.github.io/visualization_rwt/rwt_app_chooser](http://tork-a.github.io/visualization_rwt/rwt_app_chooser "website"). Note that this website is not available now. Access `http://fetch's IP address:8000/rwt_app_chooser/`.
 1. Click `ADD A ROBOT` button
 1. Select `Fetch` at `Robot type`
 1. Type `fetch15` at `Robot name`

--- a/jsk_fetch_robot/jsk_fetch_startup/README.md
+++ b/jsk_fetch_robot/jsk_fetch_startup/README.md
@@ -235,6 +235,8 @@ You can not run this on Firefox. Please use Google Chrome.
 
 ### Add fetch to rwt_app_chooser
 1. Access [http://tork-a.github.io/visualization_rwt/rwt_app_chooser](http://tork-a.github.io/visualization_rwt/rwt_app_chooser "website").
+  - Be careful to access the site via http, not https, to to enable websocket communication.
+  - Modern browsers may automatically redirect from http to https.
 1. Click `ADD A ROBOT` button
 1. Select `Fetch` at `Robot type`
 1. Type `fetch15` at `Robot name`


### PR DESCRIPTION
Currently, we cannot see app icons on http://tork-a.github.io/visualization_rwt/rwt_app_chooser.
This is because recent browsers (e.g. chrome, firefox) have become more secure.

I added the alternate URL to REDAME.