### PR TITLE
Update rosserial used in fetch to use ArduinoBluetoothHardware

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -75,7 +75,10 @@
     local-name: ros-drivers/audio_common
     uri: https://github.com/ros-drivers/audio_common.git
     version: master
-# Remove after https://github.com/ros-drivers/rosserial/pull/570 is merged and released
+# Remove after the following PRs are merged and released
+# https://github.com/ros-drivers/rosserial/pull/570
+# https://github.com/ros-drivers/rosserial/pull/594
+# https://github.com/ros-drivers/rosserial/pull/596
 - git:
     local-name: ros-drivers/rosserial
     uri: https://github.com/708yamaguchi/rosserial.git

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -75,6 +75,11 @@
     local-name: ros-drivers/audio_common
     uri: https://github.com/ros-drivers/audio_common.git
     version: master
+# Remove after https://github.com/ros-drivers/rosserial/pull/570 is merged and released
+- git:
+    local-name: ros-drivers/rosserial
+    uri: https://github.com/708yamaguchi/rosserial.git
+    version: fetch15
 - git:
     local-name: ros-perception/slam_gmapping
     uri: https://github.com/ros-perception/slam_gmapping.git


### PR DESCRIPTION
From https://github.com/jsk-ros-pkg/jsk_robot/issues/1531#issuecomment-1188066561

I update rosserial used in fetch to use ArduinoBluetoothHardware.

I cherry-picked the following commits.
[knorth55/jsk_robot@`ad65583` (#157)](https://github.com/knorth55/jsk_robot/pull/157/commits/ad65583e6365de090256385eb34673607e62f5c0)
https://github.com/knorth55/jsk_robot/pull/296