### PR TITLE
[jsk_pepper_startup/README.md] add some tips to deactivate the getting started wizard on Pepper's tablet

### DIFF
--- a/jsk_naoqi_robot/jsk_pepper_startup/README.md
+++ b/jsk_naoqi_robot/jsk_pepper_startup/README.md
@@ -139,3 +139,15 @@ front_cameraMight be a NAOqi problem. Try to restart the ALVideoDevice.
 ## Some tips
 
 - If the getting started wizard appears on Pepper's tablet, it may be better to turn it off because some functions are blocked. (ref: [issue 926](https://github.com/jsk-ros-pkg/jsk_robot/issues/926))
+
+- You may encounter the getting started wizard on Pepper's tablet when you turn on the Pepper robot. If you cannot turn it off, please try this: `roslaunch naoqi_apps behavior_manager.launch`. (`behavior_manager.launch` should exist in `naoqi_bridge` package (`kochigami-develop` branch).)  
+
+If `rosservice call /behavior_manager/is_behavior_running "data: 'boot-config'"` => `success: True`,  
+Please try `rosservice call /behavior_manager/stop_behavior "data: 'boot-config'"`.  
+If `success: True` returns, you should turn off the wizard.  
+
+You can also try `ssh nao@<Pepper's IP>` and
+```
+qicli call ALBehaviorManager.isBehaviorRunning boot-config
+qicli call ALBehaviorManager.stopBehavior boot-config
+```


### PR DESCRIPTION
You may encounter the getting started wizard on Pepper's tablet when you turn on the robot.
If it appears, it may be better to turn it off because some functions are blocked.
However, sometimes you cannot deactivate it by just pressing "X" mark on the tablet. 
So, I added some tips to deactivate it.

ペッパーの電源をつけた時に，タブレットに設定画面が出ることがあります．
これは，いくつかのコマンドを無効化するため，消した方が良いのですが，タブレットのバツマークを押しても消えないことがあります．その時の消し方のコツを書きました．