### PR TITLE
[jsk_pepper_startup/README.md] add trobleshooting about the error related to ROS-Driver-Audio

### DIFF
--- a/jsk_naoqi_robot/jsk_pepper_startup/README.md
+++ b/jsk_naoqi_robot/jsk_pepper_startup/README.md
@@ -139,3 +139,15 @@ front_cameraMight be a NAOqi problem. Try to restart the ALVideoDevice.
 ## Some tips
 
 - If the getting started wizard appears on Pepper's tablet, it may be better to turn it off because some functions are blocked. (ref: [issue 926](https://github.com/jsk-ros-pkg/jsk_robot/issues/926))
+
+- You may encounter the getting started wizard on Pepper's tablet when you turn on the Pepper robot. If you cannot turn it off, please try this: `roslaunch naoqi_apps behavior_manager.launch`. (`behavior_manager.launch` should exist in `naoqi_bridge` package (`kochigami-develop` branch).)  
+
+If `rosservice call /behavior_manager/is_behavior_running "data: 'boot-config'"` => `success: True`,  
+Please try `rosservice call /behavior_manager/stop_behavior "data: 'boot-config'"`.  
+If `success: True` returns, you should turn off the wizard.  
+
+You can also try `ssh nao@<Pepper's IP>` and
+```
+qicli call ALBehaviorManager.isBehaviorRunning boot-config
+qicli call ALBehaviorManager.stopBehavior boot-config
+```

--- a/jsk_naoqi_robot/jsk_pepper_startup/README.md
+++ b/jsk_naoqi_robot/jsk_pepper_startup/README.md
@@ -151,3 +151,10 @@ You can also try `ssh nao@<Pepper's IP>` and
 qicli call ALBehaviorManager.isBehaviorRunning boot-config
 qicli call ALBehaviorManager.stopBehavior boot-config
 ```
+
+- If you encounter the error below when you launch `naoqi_driver.launch`, please refer to [this issue](https://github.com/jsk-ros-pkg/jsk_robot/issues/1474).
+
+```
+what():	ALProxy::ALProxy
+Can't find service: ROS-Driver-Audio
+```


### PR DESCRIPTION
When you launch `naoqi_driver.launch`, you may encounter the error below:
```
what():  	ALProxy::ALProxy
Can't find service: ROS-Driver-Audio
```
I added troubleshooting for this issue.

related issue: https://github.com/jsk-ros-pkg/jsk_robot/issues/1474