### PR TITLE
[softhand_ros] fix device file name and readme for softhand

### DIFF
--- a/jsk_hand/softhand_ros/README.md
+++ b/jsk_hand/softhand_ros/README.md
@@ -238,11 +238,11 @@ git clone https://github.com/richardeoin/ftx-prog.git
 cd ftx-prog/
 make
 # for left softhand v1
-sudo ./ftx-prog --product LEFT-E160
+sudo ./ftx_prog --product LEFT-E160
 # for right softhand v1
-sudo ./ftx-prog --product RIGHT-E160
+sudo ./ftx_prog --product RIGHT-E160
 # for left softhand v2
-sudo ./ftx-prog --product LEFT-V2-E160
+sudo ./ftx_prog --product LEFT-V2-E160
 # for right softhand v2
-sudo ./ftx-prog --product RIGHT-V2-E160
+sudo ./ftx_prog --product RIGHT-V2-E160
 ```

--- a/jsk_hand/softhand_ros/launch/softhand_left.launch
+++ b/jsk_hand/softhand_ros/launch/softhand_left.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="device" default="/dev/lhand-e151" />
+  <arg name="device" default="/dev/lhand-e160" />
   <arg name="mode" default="position" />
 
   <include file="$(find softhand_ros)/launch/softhand.launch">

--- a/jsk_hand/softhand_ros/launch/softhand_right.launch
+++ b/jsk_hand/softhand_ros/launch/softhand_right.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="device" default="/dev/rhand-e151" />
+  <arg name="device" default="/dev/rhand-e160" />
   <arg name="mode" default="position" />
 
   <include file="$(find softhand_ros)/launch/softhand.launch">

--- a/jsk_hand/softhand_ros/launch/softhand_v2_left.launch
+++ b/jsk_hand/softhand_ros/launch/softhand_v2_left.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="device" default="/dev/lhand-v2-e151" />
+  <arg name="device" default="/dev/lhand-v2-e160" />
   <arg name="mode" default="position" />
 
   <include file="$(find softhand_ros)/launch/softhand_v2.launch">

--- a/jsk_hand/softhand_ros/launch/softhand_v2_right.launch
+++ b/jsk_hand/softhand_ros/launch/softhand_v2_right.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="device" default="/dev/rhand-v2-e151" />
+  <arg name="device" default="/dev/rhand-v2-e160" />
   <arg name="mode" default="position" />
 
   <include file="$(find softhand_ros)/launch/softhand_v2.launch">


### PR DESCRIPTION
this PR fixes udev file name error in #1522 
in #1522, I changed udev file name from `lhand-e151` to `lhand-e160`, but I forgot to change it in launch.
https://github.com/jsk-ros-pkg/jsk_robot/commit/954e0bfc186d16023a56fc84e2e50351c42f3cdf

this PR changes the udev device name in launch.
I also fix typo in readme, too.