### PR TITLE
[jsk_naoqi_robot/README.md] update naoqi_dashboard branch info

### DIFF
--- a/jsk_naoqi_robot/README.md
+++ b/jsk_naoqi_robot/README.md
@@ -106,7 +106,7 @@ sudo apt-get install ros-${ROS_DISTRO}-nao-meshes
 ```
 
 If you have ROS >= kinetic, please use [naoqi_dashboard (kochigami-develop)](https://github.com/kochigami/naoqi_dashboard/tree/kochigami-develop).  
-This includes [Important PR](https://github.com/ros-naoqi/naoqi_dashboard/pull/3) for ROS >= kinetic.
+This includes [Important PR](https://github.com/ros-naoqi/naoqi_dashboard/pull/6) for ROS >= kinetic.
 
 ```
 cd  catkin_ws/src
@@ -115,7 +115,7 @@ wstool update naoqi_dashboard
 cd naoqi_dashboard
 git remote add kochigami https://github.com/kochigami/naoqi_dashboard.git
 git fetch kochigami
-git checkout -b modify-for-kinetic kochigami/kochigami-develop
+git checkout -b kochigami-develop kochigami/kochigami-develop
 ```
 
 Finally, please compile them.  


### PR DESCRIPTION
Thanks to related issue1: https://github.com/k-okada/jsk_robot/issues/62#issuecomment-1185379536,
I modified `naoqi_dashboard` package as follows:
Related issue2: https://github.com/ros-naoqi/naoqi_dashboard/issues/5
Related PR: https://github.com/ros-naoqi/naoqi_dashboard/pull/6

(I confirmed this change works ubuntu 16.04 (kinetic) and 18.04 (melodic).)

So, I updated README.md of `jsk_naoqi_robot` to telling NAOqi users to use an updated branch.

@ayfujii @a-ichikura お時間ある時で大丈夫ですので、このドキュメントの記述でnaoqi_dashboardが動くか確認してくださるとありがたいです。（ROSのバージョンもお知らせしてくださるとありがたいです。）
（すみません、間違えてreviewボタンを押してしまいました・・・）
