### PR TITLE
Pr/make init function for tweet client

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client.l
@@ -4,37 +4,46 @@
 (ros::roseus-add-msgs "std_msgs")
 (ros::roseus-add-msgs "sensor_msgs")
 
-(load "package://pr2eus/speak.l")
+(require "package://pr2eus/speak.l")
 
-(ros::roseus "tweet_client")
-(ros::advertise "/tweet" std_msgs::String 1)
+(if (not (boundp `*initialized-tweet-client*))
+  (setq *initialized-tweet-client* nil))
 
-;; next tweet timing ( x(i+1) = x(i) * 2, 5 * 60 = 300 sec)
-(while (not (ros::has-param "/active_user/elapsed_time"))
-  (unix::sleep 3)
-  (ros::ros-info "Wait for /active_user/elapsed_time parameter ..."))
+(defun init-tweet-client ()
+  (ros::advertise "/tweet" std_msgs::String 1)
 
-(cond
- ((ros::has-param "/active_user/tweet_second")
-  (setq *tweet-second* (ros::get-param "/active_user/tweet_second")))
- (t
-  (setq *tweet-second* 300)
-  ))
+  ;; next tweet timing ( x(i+1) = x(i) * 2, 5 * 60 = 300 sec)
+  (while (not (ros::has-param "/active_user/elapsed_time"))
+    (unix::sleep 3)
+    (ros::ros-info "Wait for /active_user/elapsed_time parameter ..."))
 
-(setq *target-second* (+ (ros::get-param "/active_user/elapsed_time")
-                         *tweet-second*))
+  (cond
+   ((ros::has-param "/active_user/tweet_second")
+    (setq *tweet-second* (ros::get-param "/active_user/tweet_second")))
+   (t
+    (setq *tweet-second* 300)
+    ))
 
-(setq *waking-tweet-second* 3600.0)
-(cond
- ((ros::has-param "/active_user/start_time")
-  (let ((st (ros::get-param "/active_user/start_time")))
-    (setq *waking-target-second*
-          (+ (- (send (ros::time-now) :to-sec) st)
-             *waking-tweet-second*))))
- (t
-  (setq *waking-target-second* *waking-tweet-second*)))
+  (setq *target-second* (+ (ros::get-param "/active_user/elapsed_time")
+                           *tweet-second*))
+
+  (setq *waking-tweet-second* 3600.0)
+  (cond
+   ((ros::has-param "/active_user/start_time")
+    (let ((st (ros::get-param "/active_user/start_time")))
+      (setq *waking-target-second*
+            (+ (- (send (ros::time-now) :to-sec) st)
+               *waking-tweet-second*))))
+   (t
+    (setq *waking-target-second* *waking-tweet-second*)))
+
+  (setq *initialized-tweet-client* t)
+  )
 
 (defun tweet-string (twit-str &key (warning-time) (with-image) (image-wait 30) (speak t))
+  (if (not *initialized-tweet-client*)
+    (init-tweet-client)
+    )
   (let (prev-image-topic img)
   (when warning-time
     (unless (numberp warning-time)

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_tablet.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_tablet.l
@@ -5,6 +5,8 @@
 
 (load "package://jsk_robot_startup/lifelog/tweet_client.l")
 
+(init-tweet-client)
+
 (defun twit-cb (msg)
   (let ((twit-str (send msg :data)))
     (tweet-string twit-str

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_uptime.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_uptime.l
@@ -4,6 +4,8 @@
 
 (load "package://jsk_robot_startup/lifelog/tweet_client.l")
 
+(init-tweet-client)
+
 (setq *src-lines* nil)
 (setq *random-state* (coerce (unix::gettimeofday) integer-vector))
 

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_warning.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_warning.l
@@ -5,6 +5,8 @@
 (load "package://jsk_robot_startup/lifelog/tweet_client.l")
 (ros::load-ros-manifest "diagnostic_msgs")
 
+(init-tweet-client)
+
 (defun diagnostics-cb (msg)
   (let ((diagnostics (make-hash-table :test #'equal))
 	(tm (ros::time-now))

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_worktime.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_worktime.l
@@ -4,6 +4,8 @@
 
 (load "package://jsk_robot_startup/lifelog/tweet_client.l")
 
+(init-tweet-client)
+
 (defvar *robot-name* "robot")
 (when (ros::has-param "/active_user/robot_name")
   (setq *robot-name* (ros::get-param "/active_user/robot_name"))


### PR DESCRIPTION
navigation-utils in jsk_fetch_startup load tweet_client.l from jsk_robot_startup. And it will wait until `/active_user/elapsed_time` parameter is available. This will sometimes prevent euslisp script execution when the parameter is not set.

This PR will fix it.