### PR TITLE
[jsk_robot_startup] Fix username retrieval in active_user.l

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/active_user.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/active_user.l
@@ -81,6 +81,7 @@
     (with-open-file
         (f (format nil "/tmp/username_~d.txt" (unix::getpid)))
       (setq username (read-line f)))
+    (unix::unlink "/tmp/username_~d.txt" (unix::getpid))
     username
     )
   )
@@ -95,6 +96,7 @@
     (with-open-file
         (f (format nil "/tmp/fullname_~d.txt" (unix::getpid)))
       (setq fullname (read-line f)))
+    (unix::unlink "/tmp/fullname_~d.txt" (unix::getpid))
     fullname
     )
   )

--- a/jsk_robot_common/jsk_robot_startup/lifelog/active_user.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/active_user.l
@@ -75,7 +75,7 @@
   (let (username)
     (unix::system
      (format nil
-             "getent passwd `whoami` | cut -d ':' -f 1 > /tmp/username_~d.txt"
+             "whoami > /tmp/username_~d.txt"
              (unix::getpid)))
     (warn "Get PID ~A" (unix::getpid))
     (with-open-file

--- a/jsk_robot_common/jsk_robot_startup/lifelog/active_user.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/active_user.l
@@ -123,7 +123,7 @@
       (setq *user-name* tname))))
 (unless (and (boundp '*user-name*) *user-name*)
   (unix::system
-   (format nil "getent passwd `whoami` | cut -d ':' -f 5 | cut -d ',' -f 1 > /tmp/username_~d.txt"
+   (format nil "getent passwd `whoami` | cut -d ':' -f 1 > /tmp/username_~d.txt"
            (unix::getpid)))
   (warn "Get PID ~A" (unix::getpid))
   (with-open-file

--- a/jsk_robot_common/jsk_robot_startup/lifelog/active_user.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/active_user.l
@@ -71,6 +71,34 @@
   (update-activeness)
   )
 
+(defun get-username ()
+  (let (username)
+    (unix::system
+     (format nil
+             "getent passwd `whoami` | cut -d ':' -f 1 > /tmp/username_~d.txt"
+             (unix::getpid)))
+    (warn "Get PID ~A" (unix::getpid))
+    (with-open-file
+        (f (format nil "/tmp/username_~d.txt" (unix::getpid)))
+      (setq username (read-line f)))
+    username
+    )
+  )
+
+(defun get-fullname ()
+  (let (fullname)
+    (unix::system
+     (format nil
+             "getent passwd `whoami` | cut -d ':' -f 5 | cut -d ',' -f 1 > /tmp/fullname_~d.txt"
+             (unix::getpid)))
+    (warn "Get PID ~A" (unix::getpid))
+    (with-open-file
+        (f (format nil "/tmp/fullname_~d.txt" (unix::getpid)))
+      (setq fullname (read-line f)))
+    fullname
+    )
+  )
+
 (when (ros::has-param "/active_user/motor_subscribe")
   (if (ros::get-param "/active_user/motor_subscribe")
      (cond
@@ -122,14 +150,14 @@
     (unless (string= tname "false")
       (setq *user-name* tname))))
 (unless (and (boundp '*user-name*) *user-name*)
-  (unix::system
-   (format nil "getent passwd `whoami` | cut -d ':' -f 1 > /tmp/username_~d.txt"
-           (unix::getpid)))
-  (warn "Get PID ~A" (unix::getpid))
-  (with-open-file
-   (f (format nil "/tmp/username_~d.txt" (unix::getpid)))
-   (setq *user-name* (read-line f)))
-  (ros::set-param "/active_user/launch_user_name" *user-name*)
+  (let ((fullname (get-fullname))
+        (username (get-username)))
+    (if (string= fullname "")
+        (setq *user-name* username)
+      (setq *user-name* fullname)
+      )
+    (ros::set-param "/active_user/launch_user_name" *user-name*)
+    )
   )
 (warn "~%;; start user_name = ~A~%" *user-name*)
 


### PR DESCRIPTION
Fix the problem reported in https://github.com/jsk-ros-pkg/jsk_robot/pull/1548.

Sometimes `active_user.l` fails to retrieve a username. This PR fix it.