### PR TITLE
Smach to email/twitter

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -209,6 +209,59 @@ rostopic pub /reboot std_msgs/Empty
 ```
 
 
+## scripts/smach_to_mail.py
+
+This node sends smach messages to `/email`, `/tweet`, etc... to notify robot state transition.
+
+```mermaid
+flowchart TB
+    subgraph S[Demo Code Running on SMACH]
+      START --> State_1
+      State_1 --> State_2
+      State_2 --> END
+    end
+   subgraph E[SMACH To Notification]
+      id1[(state list<br>DESCRIPTION / IMAGE<br>DESCRIPTION / IMAGE<br>...)]
+     id1 --> email[[pub /email jsk_robot_startup::Email]]
+     id1 --> tweet[[pub /tweet std_msgs::String]] 
+     id1 --> chat[[pub /google_chat_ros/send/goal<br>google_chat_ros::SendMessageAction]] 
+   end
+   S -->|"[{'DESCRIPTION': string, 'IMAGE': base64}]"| E
+   email --> email_body(["DESCRIPTION[0]<br>DESCRIPTION[1]<br>IMAGE[1]<br>DESCRIPTION[1]<br>IMAGE[1]<br>..."])
+   tweet --> tweet_body1(["DESCRIPTION[0]"])
+   tweet_body1 --> tweet_body2(["DESCRIPTION[1]<br>IMAGE[1]"])
+   tweet_body2 --> tweet_body3(["DESCRIPTION[2]<br>IMAGE[2]"])
+   chat --> chat_body1(["DESCRIPTION[0]"])
+   chat_body1 --> chat_body2(["DESCRIPTION[1]<br>IMAGE[1]"])
+   chat_body2 --> chat_body3(["DESCRIPTION[2]<br>IMAGE[2]"])
+```
+
+### Subscribing Topics
+
+* `~smach/container_status` (`smach_msgs/SmachContainerStatus`)
+
+  Input topic smach status
+
+### Publishing Topics
+
+* `/email` (`jsk_robot_startup/Email`)
+
+  Email message with description and image
+
+* `/tweet` (`std_msgs/String`)
+
+  Tweet message with description and image
+
+### Parameters
+
+* `~sender_address` (String)
+  
+  Sender address
+
+* `~receiver_address` (String)
+
+  Receiver address
+
 ## launch/safe_teleop.launch
 
 This launch file provides a set of nodes for safe teleoperation common to mobile robots. Robot-specific nodes such as `/joy`, `/teleop` or `/cable_warning` must be included in the teleop launch file for each robot, such as [safe_teleop.xml for PR2](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/safe_teleop.xml) or [safe_teleop.xml for fetch](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_teleop.xml).

--- a/jsk_robot_common/jsk_robot_startup/package.xml
+++ b/jsk_robot_common/jsk_robot_startup/package.xml
@@ -36,6 +36,7 @@
   <run_depend>roseus_mongo</run_depend>
   <run_depend>rosgraph</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>rostwitter</run_depend>
   <run_depend>roswww</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>

--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -3,10 +3,9 @@
 import base64
 import cv2
 import datetime
-import imghdr
 import pickle
 import rospy
-import time
+import sys
 
 from cv_bridge import CvBridge
 from jsk_robot_startup.msg import Email
@@ -41,8 +40,12 @@ class SmachToMail():
             return
 
         # Print received messages
-        status_str = ', '.join(msg.active_states);
-        local_data_str = pickle.loads(msg.local_data)
+        status_str = ', '.join(msg.active_states)
+        if sys.version_info.major < 3:
+            local_data_str = pickle.loads(msg.local_data)
+        else:
+            local_data_str = pickle.loads(
+                msg.local_data.encode('utf-8'), encoding='utf-8')
         info_str = msg.info
         if not type(local_data_str) is dict:
             rospy.logerr("local_data_str:({}) is not dictionary".format(local_data_str))
@@ -51,11 +54,11 @@ class SmachToMail():
 
         rospy.loginfo("- status -> {}".format(status_str))
         rospy.loginfo("- info_str -> {}".format(info_str))
-        if local_data_str.has_key('DESCRIPTION'):
+        if 'DESCRIPTION' in local_data_str:
             rospy.loginfo("- description_str -> {}".format(local_data_str['DESCRIPTION']))
         else:
             rospy.logwarn("smach does not have DESCRIPTION, see https://github.com/jsk-ros-pkg/jsk_robot/tree/master/jsk_robot_common/jsk_robot_startup#smach_to_mailpy for more info")
-        if local_data_str.has_key('IMAGE') and local_data_str['IMAGE']:
+        if 'IMAGE' in local_data_str and local_data_str['IMAGE']:
             rospy.loginfo("- image_str -> {}".format(local_data_str['IMAGE'][:64]))
 
         # Store data for every callerid to self.smach_state_list[caller_id]
@@ -65,19 +68,19 @@ class SmachToMail():
         if status_str in ["START", "INIT"]:
             self.smach_state_list[caller_id] = []
             # DESCRIPTION of START is MAIL SUBJECT
-            if local_data_str.has_key('DESCRIPTION'):
+            if 'DESCRIPTION' in local_data_str:
                 self.smach_state_subject[caller_id] = local_data_str['DESCRIPTION']
                 del local_data_str['DESCRIPTION']
             else:
-                self.smach_state_subject[celler_id] = None
+                self.smach_state_subject[caller_id] = None
 
         # Build status_dict for every status
         # expected keys are 'DESCRIPTION' , 'IMAGE', 'STATE', 'INFO', 'TIME'
         status_dict = {}
-        if local_data_str.has_key('DESCRIPTION'):
+        if 'DESCRIPTION' in local_data_str:
             status_dict.update({'DESCRIPTION': local_data_str['DESCRIPTION']})
 
-        if local_data_str.has_key('IMAGE') and local_data_str['IMAGE']:
+        if 'IMAGE' in local_data_str and local_data_str['IMAGE']:
             imgmsg = CompressedImage()
             imgmsg.deserialize(base64.b64decode(local_data_str['IMAGE']))
             cv_image = self.bridge.compressed_imgmsg_to_cv2(imgmsg, "bgr8")
@@ -91,14 +94,15 @@ class SmachToMail():
         status_dict.update({'INFO': info_str})
         status_dict.update({'TIME': datetime.datetime.fromtimestamp(msg.header.stamp.to_sec())})
 
-        if ( not self.smach_state_list.has_key(caller_id) ) or self.smach_state_list[caller_id] == None:
+
+        if (caller_id not in self.smach_state_list) or self.smach_state_list[caller_id] is None:
             rospy.logwarn("received {}, but we did not find START node".format(status_dict))
         else:
             self.smach_state_list[caller_id].append(status_dict)
 
         # If we received END/FINISH status, send email, etc...
         if status_str in ["END", "FINISH"]:
-            if ( not self.smach_state_list.has_key(caller_id) ) or self.smach_state_list[caller_id] == None:
+            if (caller_id not in self.smach_state_list) or self.smach_state_list[caller_id] is None:
                 rospy.logwarn("received END node, but we did not find START node")
                 rospy.logwarn("failed to send {}".format(status_dict))
             else:
@@ -118,13 +122,13 @@ class SmachToMail():
         changeline.type = 'html'
         changeline.message = "<br>"
         for x in state_list:
-            if x.has_key('DESCRIPTION'):
+            if 'DESCRIPTION' in x:
                 description = EmailBody()
                 description.type = 'text'
                 description.message = x['DESCRIPTION']
                 email_msg.body.append(description)
                 email_msg.body.append(changeline)
-            if x.has_key('IMAGE') and x['IMAGE']:
+            if 'IMAGE' in x and x['IMAGE']:
                 image = EmailBody()
                 image.type = 'img'
                 image.img_size = 100
@@ -152,9 +156,9 @@ class SmachToMail():
 
         for x in state_list:
             text = ""
-            if x.has_key('DESCRIPTION'):
+            if 'DESCRIPTION' in x:
                 text = x['DESCRIPTION']
-            if x.has_key('IMAGE') and x['IMAGE']:
+            if 'IMAGE' in x and x['IMAGE']:
                 text += x['IMAGE']
             if len(text) > 1:
                 self.pub_twitter.publish(String(text))

--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+import base64
+import cv2
+import datetime
+import imghdr
+import pickle
+import rospy
+import time
+
+from cv_bridge import CvBridge
+from jsk_robot_startup.msg import Email
+from jsk_robot_startup.msg import EmailBody
+from sensor_msgs.msg import CompressedImage
+from smach_msgs.msg import SmachContainerStatus
+
+
+class SmachToMail():
+
+    def __init__(self):
+        rospy.init_node('server_name')
+        # it should be 'smach_to_mail', but 'server_name'
+        # is the default name of smach_ros
+        self.pub = rospy.Publisher("/email", Email, queue_size=10)
+        rospy.Subscriber(
+            "~smach/container_status", SmachContainerStatus, self._status_cb)
+        self.bridge = CvBridge()
+        self.smach_state_list = []  # for status list
+        self.sender_address = "tsukamoto@jsk.imi.i.u-tokyo.ac.jp"
+        self.receiver_address = "tsukamoto@jsk.imi.i.u-tokyo.ac.jp"
+
+    def _status_cb(self, msg):
+        '''
+        Recording starts when smach_state becomes start.
+        '''
+        if len(msg.active_states) == 0:
+            return
+        file_path = None
+        status_str = ', '.join(msg.active_states);
+        local_data_str = pickle.loads(msg.local_data)
+        info_str = msg.info
+        print("status -> {}".format(status_str))
+        print("description_str -> {}".format(local_data_str['DESCRIPTION']))
+
+        if status_str == "START" or "INIT":
+            self.smach_state_list = []
+        if local_data_str['IMAGE']:
+            imgmsg = CompressedImage()
+            imgmsg.deserialize(base64.b64decode(local_data_str['IMAGE']))
+            cv_image = self.bridge.compressed_imgmsg_to_cv2(imgmsg, "bgr8")
+            rospy.logerr(
+                "cv image type:{}".format(imghdr.what(None, cv_image)))  # for debugging
+            dt_now = datetime.datetime.now()   # header should be used??
+
+            file_path = "/tmp/{}_{}.jpg".format(
+                status_str.lower(), dt_now.strftime('%y%m%d%H%M%S'))
+            rospy.loginfo("filepath:{}".format(file_path))
+            # if (next((x for x in self.smach_state_list if x["IMAGE"] == file_path), None)):
+            #     rospy.loginfo("same file name!!!!")
+            # else:
+            #     rospy.loginfo("not same file name!!!")
+            cv2.imwrite(file_path, cv_image)
+            # cv2.imshow("Image", input_image)
+            cv2.waitKey(2)
+        else:
+            file_path = ""
+
+        status_dict = {'DESCRIPTION': local_data_str['DESCRIPTION'],
+                       'IMAGE': file_path}  # dict is complicated?
+        self.smach_state_list.append(status_dict)
+        print(self.smach_state_list)
+        print("info_str -> {}".format(info_str))
+
+        if status_str == "END" or "FINISH":
+            rospy.loginfo("END!!")
+            self._send_mail()
+
+    def _send_mail(self):
+        email_msg = Email()
+        email_msg.body = []
+        changeline = EmailBody()
+        changeline.type = 'html'
+        changeline.message = "<br>"
+        for x in self.smach_state_list:
+            description = EmailBody()
+            image = EmailBody()
+            description.type = 'text'
+            description.message = x['DESCRIPTION']
+            email_msg.body.append(description)
+            email_msg.body.append(changeline)
+            if x['IMAGE']:
+                image.type = 'img'
+                image.img_size = 50
+                image.file_path = x['IMAGE']
+                email_msg.body.append(image)
+                email_msg.body.append(changeline)
+        rospy.loginfo("body:{}".format(email_msg.body))
+
+        email_msg.subject = 'Smach mail test'
+
+        email_msg.sender_address = self.sender_address
+        email_msg.receiver_address = self.receiver_address
+
+        time.sleep(1)
+        self.pub.publish(email_msg)
+
+
+if __name__ == '__main__':
+    stm = SmachToMail()
+    rospy.spin()

--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -25,7 +25,8 @@ class SmachToMail():
         rospy.Subscriber(
             "~smach/container_status", SmachContainerStatus, self._status_cb)
         self.bridge = CvBridge()
-        self.smach_state_list = None  # for status list
+        self.smach_state_list = {}  # for status list
+        self.smach_state_subject = {}  # for status subject
         self.sender_address = "tsukamoto@jsk.imi.i.u-tokyo.ac.jp"
         self.receiver_address = "tsukamoto@jsk.imi.i.u-tokyo.ac.jp"
 
@@ -36,7 +37,8 @@ class SmachToMail():
         rospy.loginfo("Received SMACH status")
         if len(msg.active_states) == 0:
             return
-        file_path = None
+
+        # Print received messages
         status_str = ', '.join(msg.active_states);
         local_data_str = pickle.loads(msg.local_data)
         info_str = msg.info
@@ -54,15 +56,21 @@ class SmachToMail():
         if local_data_str.has_key('IMAGE') and local_data_str['IMAGE']:
             rospy.loginfo("- image_str -> {}".format(local_data_str['IMAGE'][:64]))
 
+        # Store data for every callerid to self.smach_state_list[caller_id]
+        caller_id = msg._connection_header['callerid']
+
+        # If we received START/INIT status, restart storing smach_state_list
         if status_str in ["START", "INIT"]:
-            self.smach_state_list = []
+            self.smach_state_list[caller_id] = []
             # DESCRIPTION of START is MAIL SUBJECT
             if local_data_str.has_key('DESCRIPTION'):
-                self.smach_state_subject = local_data_str['DESCRIPTION']
+                self.smach_state_subject[caller_id] = local_data_str['DESCRIPTION']
                 del local_data_str['DESCRIPTION']
             else:
-                self.smach_state_subject = None
+                self.smach_state_subject[celler_id] = None
 
+        # Build status_dict for every status
+        # expected keys are 'DESCRIPTION' , 'IMAGE', 'STATE', 'INFO', 'TIME'
         status_dict = {}
         if local_data_str.has_key('DESCRIPTION'):
             status_dict.update({'DESCRIPTION': local_data_str['DESCRIPTION']})
@@ -77,28 +85,36 @@ class SmachToMail():
             dim = (width, height)
             cv_image = cv2.resize(cv_image, dim, interpolation = cv2.INTER_AREA)
             status_dict.update({'IMAGE': base64.b64encode(cv2.imencode('.jpg', cv_image)[1].tostring())})  # dict is complicated?
+        status_dict.update({'STATE': status_str})
+        status_dict.update({'INFO': info_str})
+        status_dict.update({'TIME': datetime.datetime.fromtimestamp(msg.header.stamp.to_sec())})
 
-        if self.smach_state_list == None:
+        if ( not self.smach_state_list.has_key(caller_id) ) or self.smach_state_list[caller_id] == None:
             rospy.logwarn("received {}, but we did not find START node".format(status_dict))
         else:
-            self.smach_state_list.append(status_dict)
+            self.smach_state_list[caller_id].append(status_dict)
 
+        # If we received END/FINISH status, send email, etc...
         if status_str in ["END", "FINISH"]:
-            if self.smach_state_list == None:
+            if ( not self.smach_state_list.has_key(caller_id) ) or self.smach_state_list[caller_id] == None:
                 rospy.logwarn("received END node, but we did not find START node")
                 rospy.logwarn("failed to send {}".format(status_dict))
             else:
                 rospy.loginfo("END!!")
-                self._send_mail()
-                self.smach_state_list = None
+                rospy.loginfo("Following SMACH is reported")
+                for x in self.smach_state_list[caller_id]:
+                    rospy.loginfo(" - At {}, Active state is {}{}".format(x['TIME'], x['STATE'],
+                                  "({})".format(x['INFO']) if x['INFO'] else ''))
+                self._send_mail(self.smach_state_subject[caller_id], self.smach_state_list[caller_id])
+                self.smach_state_list[caller_id] = None
 
-    def _send_mail(self):
+    def _send_mail(self, subject, state_list):
         email_msg = Email()
         email_msg.body = []
         changeline = EmailBody()
         changeline.type = 'html'
         changeline.message = "<br>"
-        for x in self.smach_state_list:
+        for x in state_list:
             if x.has_key('DESCRIPTION'):
                 description = EmailBody()
                 description.type = 'text'
@@ -114,8 +130,8 @@ class SmachToMail():
                 email_msg.body.append(changeline)
         # rospy.loginfo("body:{}".format(email_msg.body))
 
-        if self.smach_state_subject:
-            email_msg.subject = self.smach_state_subject
+        if subject:
+            email_msg.subject = subject
         else:
             email_msg.subject = 'Message from {}'.format(rospy.get_param('/robot/name', 'robot'))
 


### PR DESCRIPTION
add `jsk_robot_startup/scripts/smach_to_mail.py` which  sends smach message to `/email`, `/tweet`, etc...

based on @tkmtnt7000 's code https://github.com/k-okada/jsk_robot/pull/60#issuecomment-1194891312
This PR depends on https://github.com/jsk-ros-pkg/jsk_3rdparty/pull/371

example SMACH examples can be found at  https://github.com/jsk-ros-pkg/jsk_robot/pull/1528
- https://github.com/k-okada/jsk_robot/blob/pepper_cross/jsk_naoqi_robot/jsk_pepper_startup/apps/meeting/scripts/meeting.l
- https://github.com/k-okada/jsk_robot/blob/pepper_cross/jsk_robot_common/jsk_robot_startup/lifelog/speaking-program-is-started-or-terminated.l

@mqcmd196 Can you add `_send_google_chat` function to this program ?
