### PR TITLE
[jsk_fetch_startup] Enable shutdown_unchecked topic to prevent shutdown when battery is charging

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -121,7 +121,7 @@ plugins:
     type: app_publisher/rostopic_publisher_plugin
     plugin_args:
       stop_topics:
-        - name: "/shutdown"
+        - name: "/shutdown_unchecked"
           pkg: std_msgs
           type: Empty
           cond:

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -31,6 +31,9 @@
     </rosparam>
   </node>
 
+  <include file="$(find jsk_fetch_startup)/launch/fetch_shutdown.launch" >
+  </include>
+
   <node pkg="jsk_robot_startup" name="nav_speak" type="nav_speak.py" respawn="true" >
     <rosparam>
       lang: japanese

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_shutdown.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_shutdown.launch
@@ -1,0 +1,24 @@
+<launch>
+
+  <arg name="shutdown_topic" default="/shutdown" />
+  <arg name="shutdown_unchecked_topic" default="/shutdown_unchecked" />
+  <arg name="shutdown_dummy_topic" default="/shutdown_dummy" doc="Dummy input (no signal)." />
+  <arg name="battery_state_topic" default="/battery_state" />
+
+  <node name="input_shutdown_mux"
+        pkg="topic_tools" type="mux"
+        respawn="true" clear_params="true"
+	      args="$(arg shutdown_topic) $(arg shutdown_unchecked_topic) $(arg shutdown_dummy_topic)" >
+    <remap from="mux" to="input_shutdown_mux" />
+  </node>
+
+  <node name="input_shutdown_selector"
+        pkg="jsk_robot_startup" type="mux_selector.py"
+	      respawn="true"
+	      args="$(arg battery_state_topic) 'm.is_charging is True' $(arg shutdown_dummy_topic)
+              $(arg battery_state_topic) 'm.is_charging is False' $(arg shutdown_unchecked_topic)" >
+    <remap from="mux" to="input_shutdown_mux" />
+    <param name="wait" value="true" />
+  </node>
+
+</launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_shutdown.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_shutdown.launch
@@ -1,10 +1,17 @@
 <launch>
 
-  <arg name="shutdown_topic" default="/shutdown" />
-  <arg name="shutdown_unchecked_topic" default="/shutdown_unchecked" />
+  <arg name="shutdown_topic" default="/shutdown" doc="Original shutdown topic. When this topic is published, it do shutdown." />
+  <arg name="shutdown_unchecked_topic" default="/shutdown_unchecked" doc="Unchecked shutdown topic. When battery_state.is_charging is False and this topic is published, shutdown_topic is published and shutdown is executed." />
   <arg name="shutdown_dummy_topic" default="/shutdown_dummy" doc="Dummy input (no signal)." />
-  <arg name="battery_state_topic" default="/battery_state" />
+  <arg name="battery_state_topic" default="/battery_state" doc="battery_state_topic. If is_charging is True, the battery is charging." />
 
+  <!--
+    input: $(arg shutdown_unchecked_topic) ___
+                                              |
+                                              |___ output: $(arg shutdown_topic)
+                                              |
+    input: $(arg shutdown_dummy_topic) _______|
+  -->
   <node name="input_shutdown_mux"
         pkg="topic_tools" type="mux"
         respawn="true" clear_params="true"
@@ -12,6 +19,21 @@
     <remap from="mux" to="input_shutdown_mux" />
   </node>
 
+  <!--
+    When /battery_state/is_charging is True
+    input: $(arg shutdown_unchecked_topic)_  _
+                                              |
+                                              |___ output: $(arg shutdown_topic)
+                                              |
+    input: $(arg shutdown_dummy_topic) _______|
+
+    When /battery_state/is_charging is False
+    input: $(arg shutdown_unchecked_topic) ___
+                                              |
+                                              |___ output: $(arg shutdown_topic)
+                                              |
+    input: $(arg shutdown_dummy_topic) _     _|
+  -->
   <node name="input_shutdown_selector"
         pkg="jsk_robot_startup" type="mux_selector.py"
 	      respawn="true"


### PR DESCRIPTION
# What is this?

This PR prevents shutdown if the robot is manually docked after kitchen demo has failed.

cc: @708yamaguchi @nakane11 