### PR TITLE
add allow-other-keys in baxter-init

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-interface.l
@@ -383,7 +383,7 @@
    ))
 
 
-(defun baxter-init (&key (safe t) (type :default-controller) (moveit t))
+(defun baxter-init (&key (safe t) (type :default-controller) (moveit t) &allow-other-keys)
   (let (mvit-env mvit-rb)
     (when moveit
       (setq mvit-env (instance baxter-moveit-environment))

--- a/jsk_baxter_robot/baxtereus/baxter-softhand-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-softhand-interface.l
@@ -178,7 +178,7 @@
 
 (defun baxter-init
   (&key (safe t) (type :default-controller) (moveit t)
-        (lgripper :softhand) (rgripper :softhand))
+        (lgripper :softhand) (rgripper :softhand) &allow-other-keys)
   (let (mvit-env mvit-rb)
     (if moveit
       (progn


### PR DESCRIPTION
I add `allow-other-keys` for `baxter-init`.
this is useful to pass all args with `&rest args` from your custom `baxter-init` function.