### PR TITLE
[jsk_baxter_startup] update baxter.launch to support current baxter-jsk-softhand

### DIFF
--- a/jsk_baxter_robot/jsk_baxter_startup/README.md
+++ b/jsk_baxter_robot/jsk_baxter_startup/README.md
@@ -2,12 +2,37 @@
 
 The `jsk_baxter_startup` package.
 
-## ROS launch
+## ROS launch and euslisp
+
+### Default gripper
+
+Launch and euslisp program for Baxter + default gripper
 
 ```bash
-roslaunch jsk_baxter_startup baxter.launch load_robot_description:=true launch_robot_state_publisher:=true
+roslaunch jsk_baxter_startup baxter_default.launch
 ```
 
+```bash
+roscd baxtereus
+roseus baxter-interface.l
+;; euslisp interpreter
+(baxter-init)
+```
+
+### Softhand gripper
+
+Launch and euslisp program for Baxter + [Softhand](https://ieeexplore.ieee.org/document/8968011)
+
+```bash
+roslaunch jsk_baxter_startup baxter_softhand.launch
+```
+
+```bash
+roscd baxtereus
+roseus baxter-softhand-interface.l
+;; euslisp interpreter
+(baxter-init)
+```
 
 ## ROS nodes
 

--- a/jsk_baxter_robot/jsk_baxter_startup/README.md
+++ b/jsk_baxter_robot/jsk_baxter_startup/README.md
@@ -2,6 +2,25 @@
 
 The `jsk_baxter_startup` package.
 
+## Installation
+
+### Copy `env.sh` to home dir for `baxter-c1`
+
+Copy `env.sh` to home directory for machine tag in baxter-c1
+
+```bash
+ssh baxter-c1
+roscd jsk_baxter_startup/jsk_baxter_machine
+cp env.sh ~/
+```
+
+### Copy udev to `/etc/udev/rules.d`
+
+```bash
+roscd jsk_baxter_startup/jsk_baxter_udev
+sudo cp * /etc/udev/rules.d
+```
+
 ## ROS launch and euslisp
 
 ### Default gripper

--- a/jsk_baxter_robot/jsk_baxter_startup/baxter.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/baxter.launch
@@ -60,6 +60,9 @@
   <arg name="launch_time_signal" default="true"/>
   <arg name="launch_app_manager" default="true"/>
 
+  <!-- gui -->
+  <arg name="launch_rviz" default="false"/>
+
   <!-- baxter default params -->
   <param name="/robot/name" value="baxter" />
   <param name="/robot/type" value="baxter" />
@@ -216,5 +219,9 @@
       max_height: $(arg xdisplay_max_height)
     </rosparam>
   </node>
+
+  <!-- launch rviz -->
+  <node name="$(anon rviz)" pkg="rviz" type="rviz" if="$(arg launch_rviz)"
+        args="-d $(find jsk_baxter_startup)/config/baxter_default.rviz"/>
 
 </launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/baxter.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/baxter.launch
@@ -1,11 +1,53 @@
 <launch>
   <arg name="launch_servo" default="true"/>
   <arg name="launch_joint_trajectory" default="true"/>
-  <arg name="launch_gripper_action" default="false"/>
+  <arg name="launch_moveit" default="true"/>
+  <arg name="launch_robot_state_publisher" default="false"/>
+  <arg name="launch_wrench" default="true"/>
+  <arg name="load_robot_description" default="false"/>
+  <arg name="sanity_check_joint_trajectory" default="true" />
+
+  <!-- camera-->
   <arg name="launch_openni" default="false"/>
   <arg name="launch_kinect2" default="false"/>
-  <arg name="launch_voice_echo" default="true"/>
-  <arg name="launch_moveit" default="true"/>
+  <arg name="launch_realsense_torso" default="false"/>
+  <arg name="launch_spherical_kodak" default="false" />
+  <arg name="launch_spherical_stereo" default="false" />
+  <arg name="start_openni" default="false"/>
+
+  <!-- xdisplay -->
+  <arg name="custom_xdisplay" default="true" />
+  <arg name="launch_xdisplay" default="false" />
+  <arg name="xdisplay_max_width" default="1024" unless="$(arg custom_xdisplay)" />
+  <arg name="xdisplay_max_width" default="1920" if="$(arg custom_xdisplay)" />
+  <arg name="xdisplay_max_height" default="600" unless="$(arg custom_xdisplay)" />
+  <arg name="xdisplay_max_height" default="1200" if="$(arg custom_xdisplay)" />
+
+  <!-- gripper -->
+  <arg name="launch_gripper_action" default="false"/>
+  <arg name="left_gripper_type" default="parallel" />
+  <arg name="right_gripper_type" default="parallel" />
+  <arg name="finger" default="standard_narrow" />
+  <arg name="finger_tip" default="paddle_tip" />
+  <arg name="left_electric_gripper" default="true"
+       if="$(eval arg('left_gripper_type') == 'parallel')" />
+  <arg name="left_electric_gripper" default="false"
+       if="$(eval arg('left_gripper_type') in ['softhand', 'softhand-v2'])" />
+  <arg name="right_electric_gripper" default="true"
+       if="$(eval arg('right_gripper_type') == 'parallel')" />
+  <arg name="right_electric_gripper" default="false"
+       if="$(eval arg('right_gripper_type') in ['softhand', 'softhand-v2'])" />
+
+  <!-- arm -->
+  <arg name="arm_interpolation" default="minjerk"
+       doc="Baxter arm trajectory interpolation method: minjerk or bezier (default: minjerk)"/>
+  <arg name="arm_control_mode" default="position_w_id"
+       doc="Baxter arm controller mode: positon_w_id, position or velocity (default: position_w_id)" />
+  <arg name="USER_NAME" default="false"/>
+
+  <!-- jsk lifelog -->
+  <arg name="launch_voice_echo" default="false"/>
+  <arg name="launch_respeaker" default="false"/>
   <arg name="launch_teleop" default="false"/>
   <arg name="launch_mongodb" default="false"
        doc="Deprecated. Please use launch_db instead."/>
@@ -15,29 +57,21 @@
        doc="Deprecated. Please use launch_twitter instead." />
   <arg name="launch_twitter" default="$(arg launch_tweet)"
        doc="launch twitter" />
-  <arg name="launch_wrench" default="true"/>
   <arg name="launch_time_signal" default="true"/>
   <arg name="launch_app_manager" default="true"/>
-  <arg name="sanity_check_joint_trajectory" default="true" />
-  <arg name="start_openni" default="false"/>
-  <arg name="load_robot_description" default="false"/>
-  <arg name="launch_robot_state_publisher" default="false"/>
-  <arg name="left_electric_gripper" default="false"/>
-  <arg name="right_electric_gripper" default="false"/>
-  <arg name="arm_interpolation" default="minjerk"
-       doc="Baxter arm trajectory interpolation method: minjerk or bezier (default: minjerk)"/>
-  <arg name="arm_control_mode" default="position_w_id"
-       doc="Baxter arm controller mode: positon_w_id, position or velocity (default: position_w_id)" />
-  <arg name="USER_NAME" default="false"/>
 
+  <!-- baxter default params -->
   <param name="/robot/name" value="baxter" />
   <param name="/robot/type" value="baxter" />
   <param name="/active_user/launch_user_name" value="$(arg USER_NAME)"/>
 
   <!-- custom baxter params -->
   <param if="$(arg load_robot_description)" name="/robot_description"
-         command="$(find xacro)/xacro --inorder $(find baxter_description)/urdf/baxter.urdf.xacro gazebo:=false
-         left_electric_gripper:=$(arg left_electric_gripper) right_electric_gripper:=$(arg right_electric_gripper)"/>
+         command="$(find xacro)/xacro --inorder $(find jsk_baxter_startup)/jsk_baxter_description/baxter.urdf.xacro
+                  gazebo:=false finger:=$(arg finger) finger_tip:=$(arg finger_tip)
+                  left_electric_gripper:=$(arg left_electric_gripper)
+                  right_electric_gripper:=$(arg right_electric_gripper)" />
+
   <!-- 
     NOTE: When baxter is booted up, baxter launches robot_state_publisher inside robot.
     However, that node is killed by roslaunch jsk_arc2017_baxter baxter.launch
@@ -70,7 +104,22 @@
     </group>
   </group>
 
+  <!-- launch defaulut gripper -->
   <node if="$(arg launch_gripper_action)" pkg="baxter_interface" name="baxter_gripper_action_server" type="gripper_action_server.py" args="" output="screen"/>
+
+  <!-- launch softhands -->
+  <group ns="lgripper" if="$(eval arg('left_gripper_type') in ['softhand', 'softhand-v2'])">
+    <include file="$(find softhand_ros)/launch/softhand_left.launch"
+             if="$(eval arg('left_gripper_type') == 'softhand')"/>
+    <include file="$(find softhand_ros)/launch/softhand_v2_left.launch"
+             if="$(eval arg('left_gripper_type') == 'softhand-v2')"/>
+  </group>
+  <group ns="rgripper" if="$(eval arg('right_gripper_type') in ['softhand', 'softhand-v2'])">
+    <include file="$(find softhand_ros)/launch/softhand_right.launch"
+             if="$(eval arg('right_gripper_type') == 'softhand')"/>
+    <include file="$(find softhand_ros)/launch/softhand_v2_right.launch"
+             if="$(eval arg('right_gripper_type') == 'softhand-v2')"/>
+  </group>
 
   <!-- Use Custom OpenNI-->
   <include if="$(arg launch_openni)"
@@ -84,6 +133,25 @@
     <arg name="launch_openni" value="$(arg start_openni)" />
   </include>
 
+  <!-- Use realsense L515 on torso -->
+  <include if="$(arg launch_realsense_torso)"
+           file="$(find jsk_baxter_startup)/jsk_baxter_sensors/baxter_realsense_torso.launch">
+    <arg name="realsense_camera_ns" value="realsense_torso" />
+  </include>
+
+  <!-- Use spherical kodak on head -->
+  <include if="$(arg launch_spherical_kodak)"
+           file="$(find jsk_baxter_startup)/jsk_baxter_sensors/baxter_spherical_kodak.launch">
+    <arg name="spherical_camera_ns" value="kodak_head" />
+  </include>
+
+  <!-- Use spherical stereo on head -->
+  <include if="$(arg launch_spherical_stereo)"
+           file="$(find jsk_baxter_startup)/jsk_baxter_sensors/baxter_spherical_stereo.launch">
+    <arg name="spherical_left_camera_ns" value="elp_head_left" />
+    <arg name="spherical_right_camera_ns" value="elp_head_right" />
+  </include>
+
   <!-- Fix camera info -->
   <include file="$(find jsk_baxter_startup)/jsk_baxter_sensors/camera_info_fixer.launch" />
 
@@ -91,6 +159,10 @@
   <include if="$(arg launch_voice_echo)"
            file="$(find jsk_baxter_startup)/jsk_baxter_sensors/voice.launch" >
   </include>
+
+  <!-- launch respeaker on torso -->
+  <include if="$(arg launch_respeaker)"
+           file="$(find jsk_baxter_startup)/jsk_baxter_sensors/respeaker.launch" />
 
   <include if="$(arg launch_moveit)"
            file="$(find jsk_baxter_startup)/jsk_baxter_moveit/moveit.launch" >
@@ -133,5 +205,16 @@
     <arg name="respawn" value="false" />
     <arg name="basic" value="false" />
   </include>
+
+  <!-- xdisplay for baxter head -->
+  <node name="xdisplay_image_topic" if="$(arg launch_xdisplay)"
+        pkg="jsk_baxter_startup" type="xdisplay_image_topic.py"
+        args="/xdisplay_image_topic/input/image"
+        output="screen" >
+    <rosparam subst_value="true">
+      max_width: $(arg xdisplay_max_width)
+      max_height: $(arg xdisplay_max_height)
+    </rosparam>
+  </node>
 
 </launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/baxter_default.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/baxter_default.launch
@@ -1,19 +1,38 @@
 <launch>
+  <arg name="moveit" default="true" />
+  <arg name="launch_realsense_torso" default="true"/>
+  <arg name="launch_spherical_kodak" default="false" />
+  <arg name="launch_spherical_stereo" default="false" />
+  <arg name="arm_interpolation" default="minjerk" />
+  <arg name="arm_control_mode" default="position_w_id" />
+
   <include file="$(find jsk_baxter_startup)/baxter.launch">
     <arg name="launch_servo" value="true"/>
     <arg name="launch_joint_trajectory" value="true"/>
-    <arg name="launch_gripper_action" value="true"/>
+    <arg name="launch_moveit" value="$(arg moveit)" />
+    <arg name="launch_robot_state_publisher" value="true" />
+    <arg name="launch_wrench" value="true" />
+    <arg name="load_robot_description" value="true" />
+    <arg name="sanity_check_joint_trajectory" value="false" />
     <arg name="launch_openni" value="false"/>
     <arg name="launch_kinect2" value="false"/>
-    <arg name="launch_voice_echo" value="false"/>
-    <arg name="launch_moveit" value="true"/>
-    <arg name="launch_teleop" value="false"/>
-    <arg name="launch_tweet" value="false"/>
-    <arg name="launch_mongodb" value="false"/>
-    <arg name="launch_wrench" value="false"/>
-    <arg name="launch_time_signal" value="false"/>
-    <arg name="sanity_check_joint_trajectory" value="false" />
+    <arg name="launch_realsense_torso" value="$(arg launch_realsense_torso)"/>
+    <arg name="launch_spherical_kodak" value="$(arg launch_spherical_kodak)" />
+    <arg name="launch_spherical_stereo" value="$(arg launch_spherical_stereo)" />
     <arg name="start_openni" value="false"/>
-    <arg name="USER_NAME" value="false"/>
+    <arg name="custom_xdisplay" value="true" />
+    <arg name="launch_xdisplay" value="true" />
+    <arg name="launch_gripper_action" value="true"/>
+    <arg name="left_gripper_type" value="parallel" />
+    <arg name="right_gripper_type" value="parallel" />
+    <arg name="arm_interpolation" value="$(arg arm_interpolation)" />
+    <arg name="arm_control_mode" value="$(arg arm_control_mode)" />
+    <arg name="launch_voice_echo" default="false"/>
+    <arg name="launch_respeaker" default="true"/>
+    <arg name="launch_teleop" default="false"/>
+    <arg name="launch_db" default="false" />
+    <arg name="launch_twitter" default="false" />
+    <arg name="launch_time_signal" default="false"/>
+    <arg name="launch_app_manager" default="true"/>
   </include>
 </launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/baxter_default.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/baxter_default.launch
@@ -5,6 +5,7 @@
   <arg name="launch_spherical_stereo" default="false" />
   <arg name="arm_interpolation" default="minjerk" />
   <arg name="arm_control_mode" default="position_w_id" />
+  <arg name="launch_rviz" default="true" />
 
   <include file="$(find jsk_baxter_startup)/baxter.launch">
     <arg name="launch_servo" value="true"/>
@@ -34,5 +35,6 @@
     <arg name="launch_twitter" default="false" />
     <arg name="launch_time_signal" default="false"/>
     <arg name="launch_app_manager" default="true"/>
+    <arg name="launch_rviz" default="$(arg launch_rviz)"/>
   </include>
 </launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/baxter_softhand.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/baxter_softhand.launch
@@ -1,0 +1,40 @@
+<launch>
+  <arg name="moveit" default="true" />
+  <arg name="launch_realsense_torso" default="true"/>
+  <arg name="launch_spherical_kodak" default="false" />
+  <arg name="launch_spherical_stereo" default="false" />
+  <arg name="left_gripper_type" default="softhand" />
+  <arg name="right_gripper_type" default="softhand" />
+  <arg name="arm_interpolation" default="minjerk" />
+  <arg name="arm_control_mode" default="position_w_id" />
+
+  <include file="$(find jsk_baxter_startup)/baxter.launch">
+    <arg name="launch_servo" value="true"/>
+    <arg name="launch_joint_trajectory" value="true"/>
+    <arg name="launch_moveit" value="$(arg moveit)" />
+    <arg name="launch_robot_state_publisher" value="true" />
+    <arg name="launch_wrench" value="true" />
+    <arg name="load_robot_description" value="true" />
+    <arg name="sanity_check_joint_trajectory" value="false" />
+    <arg name="launch_openni" value="false"/>
+    <arg name="launch_kinect2" value="false"/>
+    <arg name="launch_realsense_torso" value="$(arg launch_realsense_torso)"/>
+    <arg name="launch_spherical_kodak" value="$(arg launch_spherical_kodak)" />
+    <arg name="launch_spherical_stereo" value="$(arg launch_spherical_stereo)" />
+    <arg name="start_openni" value="false"/>
+    <arg name="custom_xdisplay" value="true" />
+    <arg name="launch_xdisplay" value="true" />
+    <arg name="launch_gripper_action" value="false"/>
+    <arg name="left_gripper_type" value="$(arg left_gripper_type)" />
+    <arg name="right_gripper_type" value="$(arg right_gripper_type)" />
+    <arg name="arm_interpolation" value="$(arg arm_interpolation)" />
+    <arg name="arm_control_mode" value="$(arg arm_control_mode)" />
+    <arg name="launch_voice_echo" default="false"/>
+    <arg name="launch_respeaker" default="true"/>
+    <arg name="launch_teleop" default="false"/>
+    <arg name="launch_db" default="false" />
+    <arg name="launch_twitter" default="false" />
+    <arg name="launch_time_signal" default="false"/>
+    <arg name="launch_app_manager" default="true"/>
+  </include>
+</launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/baxter_softhand.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/baxter_softhand.launch
@@ -7,6 +7,7 @@
   <arg name="right_gripper_type" default="softhand" />
   <arg name="arm_interpolation" default="minjerk" />
   <arg name="arm_control_mode" default="position_w_id" />
+  <arg name="launch_rviz" default="true" />
 
   <include file="$(find jsk_baxter_startup)/baxter.launch">
     <arg name="launch_servo" value="true"/>
@@ -36,5 +37,6 @@
     <arg name="launch_twitter" default="false" />
     <arg name="launch_time_signal" default="false"/>
     <arg name="launch_app_manager" default="true"/>
+    <arg name="launch_rviz" default="$(arg launch_rviz)"/>
   </include>
 </launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/config/baxter_default.rviz
+++ b/jsk_baxter_robot/jsk_baxter_startup/config/baxter_default.rviz
@@ -4,11 +4,9 @@ Panels:
     Name: Displays
     Property Tree Widget:
       Expanded:
-        - /Global Options1
-        - /Status1
-        - /Kinect2 PointCloud1
+        - /RobotModel1/Links1
       Splitter Ratio: 0.5
-    Tree Height: 681
+    Tree Height: 728
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -17,7 +15,7 @@ Panels:
       - /2D Nav Goal1
       - /Publish Point1
     Name: Tool Properties
-    Splitter Ratio: 0.588679
+    Splitter Ratio: 0.5886790156364441
   - Class: rviz/Views
     Expanded:
       - /Current View1
@@ -27,7 +25,11 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: Left Camera
+    SyncSource: RealsenseTorsoImage
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
 Visualization Manager:
   Class: ""
   Displays:
@@ -37,7 +39,7 @@ Visualization Manager:
       Color: 160; 160; 164
       Enabled: true
       Line Style:
-        Line Width: 0.03
+        Line Width: 0.029999999329447746
         Value: Lines
       Name: Grid
       Normal Cell Count: 0
@@ -49,6 +51,20 @@ Visualization Manager:
       Plane Cell Count: 10
       Reference Frame: <Fixed Frame>
       Value: true
+    - Class: rviz/TF
+      Enabled: false
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
     - Alpha: 1
       Class: rviz/RobotModel
       Collision Enabled: false
@@ -103,12 +119,10 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-          Value: true
         left_gripper_base:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-          Value: true
         left_hand:
           Alpha: 1
           Show Axes: false
@@ -199,12 +213,10 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-          Value: true
         right_gripper_base:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-          Value: true
         right_hand:
           Alpha: 1
           Show Axes: false
@@ -299,171 +311,89 @@ Visualization Manager:
       Update Interval: 0
       Value: true
       Visual Enabled: true
-    - Class: rviz/Camera
-      Enabled: true
-      Image Rendering: background and overlay
-      Image Topic: /cameras/left_hand_camera/image
-      Name: Left Camera
-      Overlay Alpha: 0.5
-      Queue Size: 2
-      Transport Hint: raw
-      Value: true
-      Visibility:
-        Effort: true
-        Grid: true
-        Head Sonar State: true
-        Kinect2 PointCloud: true
-        Left Hand Range: true
-        LeftWrench: true
-        MarkerArray: true
-        Right Camera: true
-        Right Hand Range: true
-        RightWrench: true
-        RobotModel: true
-        Value: true
-      Zoom Factor: 1
-    - Class: rviz/Camera
-      Enabled: true
-      Image Rendering: background and overlay
-      Image Topic: /cameras/right_hand_camera/image
-      Name: Right Camera
-      Overlay Alpha: 0.5
-      Queue Size: 2
-      Transport Hint: raw
-      Value: true
-      Visibility:
-        Effort: true
-        Grid: true
-        Head Sonar State: true
-        Kinect2 PointCloud: true
-        Left Camera: true
-        Left Hand Range: true
-        LeftWrench: true
-        MarkerArray: true
-        Right Hand Range: true
-        RightWrench: true
-        RobotModel: true
-        Value: true
-      Zoom Factor: 1
-    - Class: rviz/MarkerArray
-      Enabled: true
-      Marker Topic: /robot_interface_marker_array
-      Name: MarkerArray
-      Namespaces:
-        {}
-      Queue Size: 100
-      Value: true
-    - Alpha: 1
-      Autocompute Intensity Bounds: true
-      Autocompute Value Bounds:
-        Max Value: 0.817
-        Min Value: 0.817
-        Value: true
-      Axis: Z
-      Channel Name: SensorId
-      Class: rviz/PointCloud
-      Color: 255; 255; 255
-      Color Transformer: Intensity
-      Decay Time: 1
-      Enabled: true
-      Invert Rainbow: false
-      Max Color: 255; 255; 255
-      Max Intensity: 11
-      Min Color: 0; 0; 0
-      Min Intensity: 9
-      Name: Head Sonar State
-      Position Transformer: XYZ
-      Queue Size: 100
-      Selectable: true
-      Size (Pixels): 3
-      Size (m): 0.03
-      Style: Spheres
-      Topic: /robot/sonar/head_sonar/state
-      Use Fixed Frame: true
-      Use rainbow: true
-      Value: true
-    - Alpha: 0.5
-      Buffer Length: 1
-      Class: rviz/Range
-      Color: 90; 255; 19
-      Enabled: true
-      Name: Left Hand Range
-      Queue Size: 100
-      Topic: /robot/range/left_hand_range/state
-      Value: true
-    - Alpha: 0.5
-      Buffer Length: 1
-      Class: rviz/Range
-      Color: 12; 255; 0
-      Enabled: true
-      Name: Right Hand Range
-      Queue Size: 100
-      Topic: /robot/range/right_hand_range/state
-      Value: true
-    - Alpha: 1
-      Class: rviz/Effort
-      Enabled: true
-      History Length: 1
-      Joints:
-        {}
-      Name: Effort
+    - Acceleration_Scaling_Factor: 1
+      Class: moveit_rviz_plugin/MotionPlanning
+      Enabled: false
+      Move Group Namespace: ""
+      MoveIt_Allow_Approximate_IK: false
+      MoveIt_Allow_External_Program: false
+      MoveIt_Allow_Replanning: false
+      MoveIt_Allow_Sensor_Positioning: false
+      MoveIt_Planning_Attempts: 10
+      MoveIt_Planning_Time: 5
+      MoveIt_Use_Cartesian_Path: false
+      MoveIt_Use_Constraint_Aware_IK: true
+      MoveIt_Warehouse_Host: 127.0.0.1
+      MoveIt_Warehouse_Port: 33829
+      MoveIt_Workspace:
+        Center:
+          X: 0
+          Y: 0
+          Z: 0
+        Size:
+          X: 2
+          Y: 2
+          Z: 2
+      Name: MotionPlanning
+      Planned Path:
+        Color Enabled: false
+        Interrupt Display: false
+        Links:
+          All Links Enabled: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Link Tree Style: Links in Alphabetic Order
+        Loop Animation: true
+        Robot Alpha: 0.5
+        Robot Color: 150; 50; 150
+        Show Robot Collision: false
+        Show Robot Visual: true
+        Show Trail: false
+        State Display Time: 0.05 s
+        Trail Step Size: 1
+        Trajectory Topic: /move_group/display_planned_path
+      Planning Metrics:
+        Payload: 1
+        Show Joint Torques: false
+        Show Manipulability: false
+        Show Manipulability Index: false
+        Show Weight Limit: false
+        TextHeight: 0.07999999821186066
+      Planning Request:
+        Colliding Link Color: 255; 0; 0
+        Goal State Alpha: 1
+        Goal State Color: 250; 128; 0
+        Interactive Marker Size: 0
+        Joint Violation Color: 255; 0; 255
+        Planning Group: both_arms
+        Query Goal State: false
+        Query Start State: false
+        Show Workspace: false
+        Start State Alpha: 1
+        Start State Color: 0; 255; 0
+      Planning Scene Topic: move_group/monitored_planning_scene
       Robot Description: robot_description
-      Scale: 1
-      Topic: /robot/joint_states
-      Value: true
-      Width: 0.02
-      head_pan:
-        Value: true
-      left_e0:
-        Value: true
-      left_e1:
-        Value: true
-      left_s0:
-        Value: true
-      left_s1:
-        Value: true
-      left_w0:
-        Value: true
-      left_w1:
-        Value: true
-      left_w2:
-        Value: true
-      right_e0:
-        Value: true
-      right_e1:
-        Value: true
-      right_s0:
-        Value: true
-      right_s1:
-        Value: true
-      right_w0:
-        Value: true
-      right_w1:
-        Value: true
-      right_w2:
-        Value: true
-    - Alpha: 1
-      Arrow Scale: 0.05
-      Arrow Width: 0.5
-      Class: rviz/WrenchStamped
-      Enabled: true
-      Force Color: 204; 51; 51
-      History Length: 1
-      Name: LeftWrench
-      Topic: /robot/end_effector/left/wrench
-      Torque Color: 204; 204; 51
-      Value: true
-    - Alpha: 1
-      Arrow Scale: 0.05
-      Arrow Width: 0.5
-      Class: rviz/WrenchStamped
-      Enabled: true
-      Force Color: 204; 51; 51
-      History Length: 1
-      Name: RightWrench
-      Topic: /robot/end_effector/right/wrench
-      Torque Color: 204; 204; 51
-      Value: true
+      Scene Geometry:
+        Scene Alpha: 0.8999999761581421
+        Scene Color: 50; 230; 50
+        Scene Display Time: 0.20000000298023224
+        Show Scene Geometry: true
+        Voxel Coloring: Z-Axis
+        Voxel Rendering: Occupied Voxels
+      Scene Robot:
+        Attached Body Color: 150; 50; 150
+        Links:
+          All Links Enabled: true
+          Expand Joint Details: false
+          Expand Link Details: false
+          Expand Tree: false
+          Link Tree Style: Links in Alphabetic Order
+        Robot Alpha: 1
+        Show Robot Collision: false
+        Show Robot Visual: true
+      Value: false
+      Velocity_Scaling_Factor: 1
     - Alpha: 1
       Autocompute Intensity Bounds: true
       Autocompute Value Bounds:
@@ -474,29 +404,74 @@ Visualization Manager:
       Channel Name: intensity
       Class: rviz/PointCloud2
       Color: 255; 255; 255
-      Color Transformer: ""
+      Color Transformer: RGB8
       Decay Time: 0
       Enabled: true
       Invert Rainbow: false
       Max Color: 255; 255; 255
-      Max Intensity: 4096
       Min Color: 0; 0; 0
-      Min Intensity: 0
-      Name: Kinect2 PointCloud
-      Position Transformer: ""
+      Name: RealsenseTorsoCloud
+      Position Transformer: XYZ
       Queue Size: 10
       Selectable: true
-      Size (Pixels): 3
-      Size (m): 0.01
-      Style: Flat Squares
-      Topic: /kinect2/depth_lowres/points
+      Size (Pixels): 2
+      Size (m): 0.009999999776482582
+      Style: Points
+      Topic: /realsense_torso/depth_registered/quarter/points
+      Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /realsense_torso/color/image_rect_color
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: RealsenseTorsoImage
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /elp_head_left/image_raw
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: ELPLeftHeadImage
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /elp_head_right/image_raw
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: ELPRightHeadImage
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+    - Class: rviz/InteractiveMarkers
+      Enable Transparency: true
+      Enabled: false
+      Name: CameraMarker
+      Show Axes: false
+      Show Descriptions: true
+      Show Visual Aids: false
+      Update Topic: /marker_6dof_tf_base_to_color/update
+      Value: false
   Enabled: true
   Global Options:
-    Background Color: 48; 48; 48
-    Fixed Frame: world
+    Background Color: 255; 255; 255
+    Default Light: true
+    Fixed Frame: base
     Frame Rate: 30
   Name: root
   Tools:
@@ -507,7 +482,10 @@ Visualization Manager:
     - Class: rviz/FocusCamera
     - Class: rviz/Measure
     - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
       Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
     - Class: rviz/SetGoal
       Topic: /move_base_simple/goal
     - Class: rviz/PublishPoint
@@ -517,33 +495,42 @@ Visualization Manager:
   Views:
     Current:
       Class: rviz/Orbit
-      Distance: 3.61473
+      Distance: 2.613826274871826
       Enable Stereo Rendering:
-        Stereo Eye Separation: 0.06
+        Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 0.54962
-        Y: 0.544029
-        Z: 0.465737
+        X: 0.5460793972015381
+        Y: -0.008951941505074501
+        Z: 0.11801144480705261
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
       Name: Current View
-      Near Clip Distance: 0.01
-      Pitch: 0.460398
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 1.5697963237762451
       Target Frame: <Fixed Frame>
       Value: Orbit (rviz)
-      Yaw: 1.7954
+      Yaw: 3.135403871536255
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 1176
+  ELPLeftHeadImage:
+    collapsed: false
+  ELPRightHeadImage:
+    collapsed: false
+  Height: 1025
   Hide Left Dock: false
   Hide Right Dock: false
-  Left Camera:
+  MotionPlanning:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000017e0000040efc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002800000338000000dd00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb00000016004c006500660074002000430061006d0065007200610100000366000000d00000001600ffffff000000010000010f0000040efc0200000004fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000002800000347000000b000fffffffb0000001800520069006700680074002000430061006d0065007200610100000375000000c10000001600fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000005ff0000003efc0100000002fb0000000800540069006d00650100000000000005ff000002f600fffffffb0000000800540069006d00650100000000000004500000000000000000000003660000040e00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
-  Right Camera:
+  MotionPlanning - Trajectory Slider:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000029500000363fc020000000bfb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d00000363000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000280020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000000000000000fb0000001c004d006f00740069006f006e0050006c0061006e006e0069006e006700000001fa000001a60000017d00fffffffb00000044004d006f00740069006f006e0050006c0061006e006e0069006e00670020002d0020005400720061006a006500630074006f0072007900200053006c00690064006500720000000000ffffffff0000001600000016000000010000023700000363fc0200000007fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb00000026005200650061006c00730065006e007300650054006f00720073006f0049006d006100670065010000003d0000014b0000001600fffffffb000000200045004c0050004c00650066007400480065006100640049006d006100670065010000018e0000010f0000001600fffffffb0000002000470072006100730070004d00610073006b00520043004e004e0056006900730100000133000000fe0000000000000000fb000000220045004c00500052006900670068007400480065006100640049006d00610067006501000002a3000000fd0000001600fffffffb0000000a00560069006500770073000000028900000117000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000009bd0000003efc0100000002fb0000000800540069006d00650100000000000009bd000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000004e50000036300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  RealsenseTorsoImage:
     collapsed: false
   Selection:
     collapsed: false
@@ -553,6 +540,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 1535
-  X: 65
-  Y: 24
+  Width: 2493
+  X: 67
+  Y: 27

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_description/baxter.urdf.xacro
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_description/baxter.urdf.xacro
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<robot name="baxter" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:arg name="gazebo" default="false"/>
+  <xacro:arg name="pedestal" default="true"/>
+  <xacro:arg name="right_electric_gripper" default="true"/>
+  <xacro:arg name="left_electric_gripper" default="true"/>
+  <xacro:arg name="finger" default="standard_narrow"/>
+  <xacro:arg name="finger_tip" default="paddle_tip"/>
+  <xacro:arg name="" default="true"/>
+  <!-- Baxter Base URDF -->
+  <xacro:include filename="$(find baxter_description)/urdf/baxter_base/baxter_base.urdf.xacro">
+    <xacro:arg name="gazebo" value="${gazebo}"/>
+  </xacro:include>
+
+  <!-- Baxter Pedestal -->
+  <xacro:if value="$(arg pedestal)">
+    <xacro:include filename="$(find baxter_description)/urdf/pedestal/pedestal.xacro">
+      <xacro:arg name="gazebo" value="${gazebo}"/>
+    </xacro:include>
+  </xacro:if>
+
+  <!-- Left End Effector -->
+  <xacro:include filename="$(find jsk_baxter_startup)/jsk_baxter_description/left_end_effector.urdf.xacro">
+    <xacro:arg name="left_electric_gripper" value="${left_electric_gripper}"/>
+    <xacro:arg name="finger" value="${finger}"/>
+    <xacro:arg name="finger_tip" value="${finger_tip}"/>
+  </xacro:include>
+
+  <!-- Right End Effector -->
+  <xacro:include filename="$(find jsk_baxter_startup)/jsk_baxter_description/right_end_effector.urdf.xacro">
+    <xacro:arg name="right_electric_gripper" value="${right_electric_gripper}"/>
+    <xacro:arg name="finger" value="${finger}"/>
+    <xacro:arg name="finger_tip" value="${finger_tip}"/>
+  </xacro:include>
+
+</robot>

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_description/left_end_effector.urdf.xacro
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_description/left_end_effector.urdf.xacro
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<robot name="left_end_effector" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:arg name="left_electric_gripper" default="true"/>
+  <xacro:arg name="finger" default="standard_narrow"/>
+  <xacro:arg name="finger_tip" default="paddle_tip"/>
+  <xacro:if value="$(arg left_electric_gripper)">
+    <xacro:include filename="$(find rethink_ee_description)/urdf/electric_gripper/rethink_electric_gripper.xacro" />
+    <xacro:rethink_electric_gripper side="left"
+                                    l_finger="$(arg finger)"
+                                    l_finger_slot="2"
+                                    l_finger_tip="$(arg finger_tip)"
+                                    l_finger_grasp="inner"
+                                    r_finger="$(arg finger)"
+                                    r_finger_slot="2"
+                                    r_finger_tip="$(arg finger_tip)"
+                                    r_finger_grasp="inner"/>
+  </xacro:if>
+  <xacro:unless value="$(arg left_electric_gripper)">
+    <xacro:include filename="$(find rethink_ee_description)/urdf/null_gripper/null_gripper.xacro" />
+    <xacro:null_gripper side="left"/>
+  </xacro:unless>
+
+</robot>

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_description/right_end_effector.urdf.xacro
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_description/right_end_effector.urdf.xacro
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<robot name="right_end_effector" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:arg name="right_electric_gripper" default="true"/>
+  <xacro:arg name="finger" default="standard_narrow"/>
+  <xacro:arg name="finger_tip" default="paddle_tip"/>
+  <xacro:if value="$(arg right_electric_gripper)">
+    <xacro:include filename="$(find rethink_ee_description)/urdf/electric_gripper/rethink_electric_gripper.xacro" />
+    <xacro:rethink_electric_gripper side="right"
+                                    l_finger="$(arg finger)"
+                                    l_finger_slot="2"
+                                    l_finger_tip="$(arg finger_tip)"
+                                    l_finger_grasp="inner"
+                                    r_finger="$(arg finger)"
+                                    r_finger_slot="2"
+                                    r_finger_tip="$(arg finger_tip)"
+                                    r_finger_grasp="inner"/>
+  </xacro:if>
+  <xacro:unless value="$(arg right_electric_gripper)">
+  <xacro:include filename="$(find rethink_ee_description)/urdf/null_gripper/null_gripper.xacro" />
+    <xacro:null_gripper side="right"/>
+  </xacro:unless>
+</robot>

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_machine/baxter.machine
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_machine/baxter.machine
@@ -1,0 +1,4 @@
+<launch>
+  <machine name="baxter-c1" address="baxter-c1" env-loader="$(env HOME)/env.sh" />
+  <machine name="baxter-c4" address="baxter-c4" env-loader="$(env HOME)/env.sh" />
+</launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_machine/env.sh
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_machine/env.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# shellcheck source=/dev/null
+if [ -e "$HOME/ros/melodic/" ]; then
+  source "$HOME/ros/melodic/devel/setup.bash"
+fi
+if [ -e "$HOME/ros/noetic/" ]; then
+  source "$HOME/ros/noetic/devel/setup.bash"
+fi
+exec "$@"

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/baxter_realsense_torso.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/baxter_realsense_torso.launch
@@ -1,0 +1,61 @@
+<launch>
+  <arg name="launch_transformable_server" default="true" />
+  <arg name="realsense_camera_ns" default="realsense_torso" />
+  <arg name="publish_tf" default="false" />
+  <!-- in order to get higher resolution, we need USB3.2 -->
+  <arg name="color_width" default="960" />
+  <arg name="color_height" default="540" />
+  <arg name="depth_width" default="640" />
+  <arg name="depth_height" default="480" />
+
+  <arg name="camera_frame_id" default="$(arg realsense_camera_ns)_color_optical_frame" />
+  <arg name="manager" default="$(arg realsense_camera_ns)_camera_manager" />
+  <arg name="input_cloud" default="/$(arg realsense_camera_ns)/depth_registered/quarter/points" />
+  <arg name="input_image" default="/$(arg realsense_camera_ns)/depth_registered/quarter/image" />
+
+  <!-- interactive marker -->
+  <node name="transformable_interactive_server"
+        pkg="jsk_interactive_marker" type="transformable_server_sample"
+        if="$(arg launch_transformable_server)" >
+    <rosparam subst_value="true">
+      display_interactive_manipulator: true
+      display_interactive_manipulator_only_selected: true
+    </rosparam>
+  </node>
+
+  <!-- tf for realsense at baxter's torso -->
+  <node name="marker_6dof_tf_base_to_color"
+        pkg="jsk_interactive_marker" type="marker_6dof">
+    <rosparam command="load" file="$(find jsk_baxter_startup)/jsk_baxter_sensors/l515_torso_pose.yaml" />
+    <rosparam subst_value="true" >
+      object_type: cube
+      publish_tf: true
+      tf_frame: $(arg camera_frame_id)
+      object_x: 0.1
+      object_y: 0.1
+      object_z: 0.1
+    </rosparam>
+  </node>
+
+  <include file="$(find jsk_baxter_startup)/jsk_baxter_sensors/realsense.launch">
+    <arg name="realsense_camera_ns" value="$(arg realsense_camera_ns)" />
+    <arg name="manager" value="$(arg manager)" />
+    <arg name="publish_tf" value="$(arg publish_tf)" />
+    <arg name="color_width"  value="$(arg color_width)" />
+    <arg name="color_height" value="$(arg color_height)" />
+    <arg name="depth_width"  value="$(arg depth_width)" />
+    <arg name="depth_height" value="$(arg depth_height)" />
+  </include>
+
+  <node name="realsense_resize_points_publisher"
+        pkg="nodelet" type="nodelet"
+        args="load jsk_pcl/ResizePointsPublisher $(arg realsense_camera_ns)/$(arg manager)">
+    <remap from="~input" to="/$(arg realsense_camera_ns)/depth_registered/points" />
+    <remap from="~output" to="$(arg input_cloud)" />
+    <rosparam>
+      step_x: 2
+      step_y: 2
+    </rosparam>
+  </node>
+
+</launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/baxter_spherical_kodak.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/baxter_spherical_kodak.launch
@@ -1,0 +1,13 @@
+<launch>
+  <arg name="spherical_camera_ns" default="kodak_head" />
+
+  <node name="kodak_transform_publisher" pkg="tf" type="static_transform_publisher"
+        args="0.05 0.05 0.1 -1.5 -0.6 0.0 head_camera $(arg spherical_camera_ns)_link 100" />
+  <node name="kodak_optical_frame_transform_publisher" pkg="tf" type="static_transform_publisher"
+        args="0 0 0 0 0 1.57 $(arg spherical_camera_ns)_link $(arg spherical_camera_ns)_optical_frame 100" />
+  <node name="kodak_rviz_frame_transform_publisher" pkg="tf" type="static_transform_publisher"
+        args="0 0 0 3.14 0 0 $(arg spherical_camera_ns)_link $(arg spherical_camera_ns)_rviz_frame 100" />
+  <include file="$(find jsk_baxter_startup)/jsk_baxter_sensors/kodak_pixpro.launch">
+    <arg name="camera_name" value="$(arg spherical_camera_ns)" />
+  </include>
+</launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/baxter_spherical_stereo.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/baxter_spherical_stereo.launch
@@ -1,0 +1,32 @@
+<launch>
+  <arg name="spherical_left_camera_ns" default="elp_head_left" />
+  <arg name="spherical_right_camera_ns" default="elp_head_right" />
+
+  <!-- launch elp left camera on c1 -->
+  <node name="elp_left_transform_publisher" pkg="tf" type="static_transform_publisher"
+        args="0.032 0.05 0.1 -1.5 -0.6 0.0 head_camera $(arg spherical_left_camera_ns)_link 100" />
+  <node name="elp_left_optical_frame_transform_publisher" pkg="tf" type="static_transform_publisher"
+        args="0 0 0 -1.57 0 -1.57 $(arg spherical_left_camera_ns)_link $(arg spherical_left_camera_ns)_optical_frame 100" />
+  <node name="elp_left_rviz_frame_transform_publisher" pkg="tf" type="static_transform_publisher"
+        args="0 0 0 3.14 0 0 $(arg spherical_left_camera_ns)_link $(arg spherical_left_camera_ns)_rviz_frame 100" />
+  <include file="$(find jsk_baxter_startup)/jsk_baxter_sensors/elp_usb.launch">
+    <arg name="camera_name" value="$(arg spherical_left_camera_ns)" />
+    <arg name="machine" value="baxter-c1" />
+    <arg name="load_machinepath" value="true" />
+    <arg name="machinepath" value="$(find jsk_baxter_startup)/jsk_baxter_machine/baxter.machine" />
+  </include>
+
+  <!-- launch elp right camera on c4 -->
+  <node name="elp_right_transform_publisher" pkg="tf" type="static_transform_publisher"
+        args="-0.032 0.05 0.1 -1.5 -0.6 0.0 head_camera $(arg spherical_right_camera_ns)_link 100" />
+  <node name="elp_right_optical_frame_transform_publisher" pkg="tf" type="static_transform_publisher"
+        args="0 0 0 -1.57 0 -1.57 $(arg spherical_right_camera_ns)_link $(arg spherical_right_camera_ns)_optical_frame 100" />
+  <node name="elp_right_rviz_frame_transform_publisher" pkg="tf" type="static_transform_publisher"
+        args="0 0 0 3.14 0 0 $(arg spherical_right_camera_ns)_link $(arg spherical_right_camera_ns)_rviz_frame 100" />
+  <include file="$(find jsk_baxter_startup)/jsk_baxter_sensors/elp_usb.launch">
+    <arg name="camera_name" value="$(arg spherical_right_camera_ns)" />
+    <arg name="machine" value="localhost" />
+    <arg name="load_machinepath" value="true" />
+    <arg name="machinepath" value="$(find jsk_baxter_startup)/jsk_baxter_machine/baxter.machine" />
+  </include>
+</launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/elp_usb.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/elp_usb.launch
@@ -1,0 +1,27 @@
+<launch>
+  <arg name="camera_name" default="elp_head" />
+  <arg name="index" default="0" />
+
+  <!-- machine -->
+  <arg name="machine" default="localhost" />
+  <machine name="localhost" address="localhost" default="true" />
+  <arg name="load_machinepath" default="false" />
+  <arg name="machinepath" default="false" />
+  <include file="$(arg machinepath)" if="$(arg load_machinepath)" />
+
+  <group ns="$(arg camera_name)">
+    <node name="elp_camera_node" pkg="libuvc_camera" type="camera_node"
+          output="screen" respawn="true" machine="$(arg machine)">
+      <param name="vendor" value="0x32e4"/>
+      <param name="product" value="0x0317"/>
+      <param name="index" value="$(arg index)"/>
+      <param name="width" value="3840"/>
+      <param name="height" value="2160"/>
+      <param name="video_mode" value="mjpeg"/>
+      <param name="frame_rate" value="30"/>
+      <param name="time_method" value="start" />
+      <param name="auto_exposure" value="1" />
+      <param name="auto_white_balance" value="true" />
+    </node>
+  </group>
+</launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/kodak_pixpro.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/kodak_pixpro.launch
@@ -1,0 +1,16 @@
+<launch>
+  <arg name="camera_name" default="kodak_head" />
+  <include file="$(find video_stream_opencv)/launch/camera.launch" >
+    <arg name="camera_name" value="$(arg camera_name)" />
+    <arg name="video_stream_provider" value="/dev/kodak-head" />
+    <arg name="fps" value="5" />
+    <arg name="frame_id" value="$(arg camera_name)_optical_frame" />
+    <arg name="camera_info_url" value="" />
+    <arg name="flip_horizontal" value="false" />
+    <arg name="flip_vertical" value="false" />
+    <arg name="width" value="2880"/>
+    <arg name="height" value="2880" />
+    <arg name="visualize" value="false" />
+    <arg name="buffer_queue_size" value="1" />
+  </include>
+</launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/l515_torso_pose.yaml
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/l515_torso_pose.yaml
@@ -1,0 +1,9 @@
+frame_id: base
+initial_x: 0.253
+initial_y: -0.004
+initial_z: 0.563
+initial_orientation: [-0.679, 0.685, -0.153, 0.213]
+# - Translation: [0.253, -0.004, 0.563]
+# - Rotation: in Quaternion [-0.679, 0.685, -0.153, 0.213]
+#             in RPY (radian) [-2.616, 0.085, -1.557]
+#             in RPY (degree) [-149.881, 4.843, -89.196]

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/realsense.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/realsense.launch
@@ -1,0 +1,39 @@
+<launch>
+  <arg name="realsense_camera_ns" />
+  <arg name="manager" />
+  <arg name="publish_tf" />
+  <arg name="color_width" />
+  <arg name="color_height" />
+  <arg name="depth_width" />
+  <arg name="depth_height" />
+
+  <group ns="$(arg realsense_camera_ns)">
+    <param name="rgb_camera/global_time_enabled" value="true"/>
+    <param name="l500_depth_sensor/global_time_enabled" value="true"/>
+  </group>
+
+  <include file="$(find realsense2_camera)/launch/rs_rgbd.launch">
+    <arg name="camera" value="$(arg realsense_camera_ns)" />
+    <arg name="manager" value="$(arg manager)" />
+    <arg name="publish_tf" value="$(arg publish_tf)" />
+    <arg name="color_width"  value="$(arg color_width)" />
+    <arg name="color_height" value="$(arg color_height)" />
+    <arg name="depth_width"  value="$(arg depth_width)" />
+    <arg name="depth_height" value="$(arg depth_height)" />
+  </include>
+
+  <!-- subscribing /$(arg realsense_camera_ns)/depth/image_rect_raw/compressedDepth causes serious frequency drop. -->
+  <node name="depth_compress_republish" pkg="image_transport"
+        type="republish" args="raw in:=$(arg realsense_camera_ns)/depth/image_rect_raw
+                               compressedDepth out:=$(arg realsense_camera_ns)/depth/compressed/image_rect_raw" />
+  <node name="depth_camera_info_relay" pkg="topic_tools"
+        type="relay" args="$(arg realsense_camera_ns)/depth/camera_info
+                           $(arg realsense_camera_ns)/depth/compressed/camera_info" />
+  <!-- subscribing /$(arg realsense_camera_ns)/aligned_depth_to_color/image_rect_raw/compressedDepth causes serious frequency drop. -->
+  <node name="aligned_depth_to_color_compress_republish" pkg="image_transport"
+        type="republish" args="raw in:=$(arg realsense_camera_ns)/aligned_depth_to_color/image_raw
+                               compressedDepth out:=$(arg realsense_camera_ns)/aligned_depth_to_color/compressed/image_raw" />
+  <node name="aligned_depth_to_color_camera_info_relay" pkg="topic_tools"
+        type="relay" args="$(arg realsense_camera_ns)/aligned_depth_to_color/camera_info
+                           $(arg realsense_camera_ns)/aligned_depth_to_color/compressed/camera_info" />
+</launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/respeaker.launch
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_sensors/respeaker.launch
@@ -1,0 +1,3 @@
+<launch>
+  <node name="respeaker_node" pkg="respeaker_ros" type="respeaker_node.py" respawn="true"/>
+</launch>

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_udev/99-elp.rules
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_udev/99-elp.rules
@@ -1,0 +1,3 @@
+#elp video
+KERNEL=="video[02468]", SUBSYSTEM=="video4linux", SUBSYSTEMS=="usb", ATTRS{idVendor}=="32e4", ATTRS{idProduct}=="0317", MODE="0666", GROUP="video", SYMLINK+="elp-head"
+SUBSYSTEMS=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="32e4", ATTRS{idProduct}=="0317", MODE="0666"

--- a/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_udev/99-kodak.rules
+++ b/jsk_baxter_robot/jsk_baxter_startup/jsk_baxter_udev/99-kodak.rules
@@ -1,0 +1,2 @@
+# kodak video
+KERNEL=="video[02468]", SUBSYSTEM=="video4linux", SUBSYSTEMS=="usb", ATTRS{idVendor}=="040a", ATTRS{idProduct}=="0426", MODE="0666", GROUP="video", SYMLINK+="kodak-head"

--- a/jsk_baxter_robot/jsk_baxter_startup/package.xml
+++ b/jsk_baxter_robot/jsk_baxter_startup/package.xml
@@ -7,35 +7,44 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>baxter_interface</build_depend>
-  <build_depend>baxter_description</build_depend>
-  <build_depend>baxter_tools</build_depend>
-  <build_depend>baxter_examples</build_depend>
-  <build_depend>openni_launch</build_depend>
-  <build_depend>joy</build_depend>
-  <build_depend>checkerboard_detector</build_depend>
-  <build_depend>topic_tools</build_depend>
-  <build_depend>sound_play</build_depend>
   <build_depend>baxter_core_msgs</build_depend>
+  <build_depend>baxter_examples</build_depend>
+  <build_depend>baxter_description</build_depend>
+  <build_depend>baxter_interface</build_depend>
+  <build_depend>baxter_tools</build_depend>
+  <build_depend>checkerboard_detector</build_depend>
   <build_depend>dynamic_tf_publisher</build_depend>
-  <build_depend>rostwitter</build_depend>
   <build_depend>image_view</build_depend>
+  <build_depend>joy</build_depend>
+  <build_depend>openni_launch</build_depend>
   <build_depend>roseus</build_depend>
+  <build_depend>rostwitter</build_depend>
+  <build_depend>sound_play</build_depend>
+  <build_depend>topic_tools</build_depend>
 
-  <run_depend>baxter_interface</run_depend>
-  <run_depend>baxter_description</run_depend>
-  <run_depend>baxter_tools</run_depend>
-  <run_depend>baxter_examples</run_depend>
-  <run_depend>openni_launch</run_depend>
-  <run_depend>joy</run_depend>
-  <run_depend>checkerboard_detector</run_depend>
-  <run_depend>topic_tools</run_depend>
-  <run_depend>sound_play</run_depend>
   <run_depend>baxter_core_msgs</run_depend>
+  <run_depend>baxter_description</run_depend>
+  <run_depend>baxter_examples</run_depend>
+  <run_depend>baxter_interface</run_depend>
+  <run_depend>baxter_tools</run_depend>
+  <run_depend>checkerboard_detector</run_depend>
   <run_depend>dynamic_tf_publisher</run_depend>
-  <run_depend>rostwitter</run_depend>
+  <run_depend>image_transport</run_depend>
   <run_depend>image_view</run_depend>
+  <run_depend>joy</run_depend>
+  <run_depend>jsk_interactive_marker</run_depend>
+  <run_depend>jsk_pcl_ros</run_depend>
+  <run_depend>libuvc_camera</run_depend>
+  <run_depend>openni_launch</run_depend>
+  <run_depend>realsense2_camera</run_depend>
+  <run_depend>respeaker_ros</run_depend>
   <run_depend>roseus</run_depend>
+  <run_depend>rostwitter</run_depend>
+  <run_depend>softhand_ros</run_depend>
+  <run_depend>sound_play</run_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>topic_tools</run_depend>
+  <run_depend>video_stream_opencv</run_depend>
 
   <export>
   </export>


### PR DESCRIPTION
this PR is originally from [knorth55/eus_vive](https://github.com/knorth55/eus_vive/blob/master/launch/baxter/baxter.launch)
I'm moving the code from `eus_vive` to `jsk_robot`.

this PR updated `baxter.launch` to support current baxter-jsk-softhand.

this PR supports:
- New grippers 
  - softhand
  - softhand-v2
- New cameras
  - Torso realsense
  - Kodak Spherical camera
  - Spherical stereo camera
- New microphone
  - Torso respeaker
- Launch xdisplay

You can run this launch with following commands.

### For Baxter + Default gripper

```bash
roslaunch jsk_baxter_startup baxter_default.launch
```

### For Baxter + Softhand gripper

```bash
roslaunch jsk_baxter_startup baxter_softhand.launch
```