### PR TITLE
[baxtereus] move end-coords for new softhand mount

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-softhand-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-softhand-interface.l
@@ -196,6 +196,11 @@
         (if safe
           (setq *baxter* (instance baxter-robot-safe :init))
           (setq *baxter* (instance baxter-robot :init)))
+        ;; move end-coords for softhand
+        (if (equal lgripper :softhand)
+          (send (send *baxter* :larm :end-coords) :translate #f(20 10 0)))
+        (if (equal rgripper :softhand)
+          (send (send *baxter* :rarm :end-coords) :translate #f(20 -10 0)))
         (send *baxter* :angle-vector (send *ri* :state :potentio-vector))))
     (if (equal lgripper :parallel) (send *ri* :calib-grasp :larm))
     (if (equal rgripper :parallel) (send *ri* :calib-grasp :rarm))))


### PR DESCRIPTION
I change softhand mount, so I move the end-coords for softhand a little forward.
this mount is for softhand and softhand V2, so we can easily change the both two grippers.

![IMG_2507](https://user-images.githubusercontent.com/9300063/185777850-98391259-79ba-4ba0-96c4-f106234cb6d5.JPG)