### PR TITLE
[jsk_robot_startup] Update Readme; configuring a smtp server

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -10,7 +10,7 @@ see [lifelog/README.md](lifelog/README.md)
 This node sends email based on received rostopic (jsk_robot_startup/Email).
 Default values can be set by using `~email_info`
 There is [a client library](./euslisp/email-topic-client.l) and [sample program](./euslisp/sample-email-topic-client.l).
-If you want to see a demo. Please configure a smtp server and setup your email_info yaml at /var/lib/robot/email_info.yaml and run.
+If you want to see a demo. Please [configure a smtp server](https://github.com/tkmtnt7000/jsk_robot/blob/PR-update-switchbot-device-name/jsk_robot_common/jsk_robot_startup/README.md#configuring-a-smtp-server-with-gmail) and setup your email_info yaml at /var/lib/robot/email_info.yaml and run.
 
 ```bash
 roslaunch jsk_robot_startup sample_email_topic.launch receiver_address:=<a mail address to send a mail to>
@@ -293,3 +293,35 @@ To check how many devices are bound to rfcomm, use rfcomm command.
 ```
 rfcomm
 ```
+
+## Tips
+### Configuring a smtp server with Gmail
+1. Setting postfix
+
+Add following codes to `/etc/postfix/main.cf`
+```
+relayhost = smtp.gmail.com:587
+smtp_sasl_auth_enable = yes
+smtp_sasl_password_maps = hash:/etc/postfix/gmail_passwd
+smtp_sasl_security_options = noanonymous
+smtp_sasl_mechanism_filter = plain
+smtp_use_tls = yes
+```
+2. Create and register a password file
+
+Create `/etc/postfix/gmail_passwd`
+```
+# /etc/postfix/gmail_passwd
+smtp.gmail.com:587 <example>@gmail.com:<login password or application password>
+```
+Register `/etc/postfix/gmail_passwd`
+```bash
+$ sudo postmap /etc/postfix/gmail_passwd
+```
+If you find `/etc/postfix/gmail_passwd.db`, it works well.
+
+3. Reload postfix
+```bash
+$ sudo postfix reload
+```
+

--- a/jsk_robot_common/jsk_robot_startup/README.md
+++ b/jsk_robot_common/jsk_robot_startup/README.md
@@ -10,7 +10,7 @@ see [lifelog/README.md](lifelog/README.md)
 This node sends email based on received rostopic (jsk_robot_startup/Email).
 Default values can be set by using `~email_info`
 There is [a client library](./euslisp/email-topic-client.l) and [sample program](./euslisp/sample-email-topic-client.l).
-If you want to see a demo. Please [configure a smtp server](https://github.com/tkmtnt7000/jsk_robot/blob/PR-update-switchbot-device-name/jsk_robot_common/jsk_robot_startup/README.md#configuring-a-smtp-server-with-gmail) and setup your email_info yaml at /var/lib/robot/email_info.yaml and run.
+If you want to see a demo. Please [configure a smtp server](https://github.com/jsk-ros-pkg/jsk_robot/tree/master/jsk_robot_common/jsk_robot_startup#configuring-a-smtp-server-with-gmail) and setup your email_info yaml at /var/lib/robot/email_info.yaml and run.
 
 ```bash
 roslaunch jsk_robot_startup sample_email_topic.launch receiver_address:=<a mail address to send a mail to>


### PR DESCRIPTION
I have written a readme about the work that needs to be done before using `email_topic.py`.
We have to configure a smtp server to use `email_topic.py`

If there is a better position to put this, please tell me.