### PR TITLE
[jsk_robot_startup] Not using yaml file to set email config like receiver mail address

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/email_topic.py
@@ -21,7 +21,8 @@ import base64
 class EmailTopic(object):
     """
     This node sends email based on received rostopic (jsk_robot_startup/Email).
-    Default values can be set by using `~email_info`
+    Default ~sender_address and ~receiver_address can be set from rosparam
+    Default values can be set by using `~email_info`(DEPRECATED)
 
     The yaml file is like the following:
     subject: hello
@@ -38,11 +39,18 @@ class EmailTopic(object):
         yaml_path = rospy.get_param(
             '~email_info', "/var/lib/robot/email_info.yaml")
         if os.path.exists(yaml_path):
+            rospy.logwarn("Using ~email_info as email config is deprecated.")
+            rospy.logwarn("Set ~sender_address and ~receiver_address directory as rosparam")
             with open(yaml_path) as yaml_f:
                 self.email_info = yaml.load(yaml_f)
             rospy.loginfo(
                 "{} is loaded as email config file.".format(yaml_path))
-            rospy.loginfo(self.email_info)
+        else:
+            self.email_info['sender_address'] = rospy.get_param(
+                "~sender_address", "jsk_robot@example.com")
+            self.email_info['receiver_address'] = rospy.get_param(
+                "~receiver_address", "jsk_robot@example.com")
+        rospy.loginfo(self.email_info)
         self.subscriber = rospy.Subscriber(
             'email', Email, self._cb, queue_size=1)
 

--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -3,11 +3,9 @@
 import base64
 import cv2
 import datetime
-import os
 import pickle
 import rospy
 import sys
-import yaml
 
 from cv_bridge import CvBridge
 from jsk_robot_startup.msg import Email
@@ -30,27 +28,16 @@ class SmachToMail():
         self.bridge = CvBridge()
         self.smach_state_list = {}  # for status list
         self.smach_state_subject = {}  # for status subject
-        yaml_path = rospy.get_param(
-            '~email_info', "/var/lib/robot/email_info.yaml")
-        if os.path.exists(yaml_path):
-            with open(yaml_path) as yaml_f:
-                self.email_info = yaml.load(yaml_f)
-            rospy.loginfo(
-                "{} is loaded as email config file.".format(yaml_path))
-            rospy.loginfo(self.email_info)
-            self.sender_address = self.email_info['sender_address']
-            self.receiver_address = self.email_info['receiver_address']
+        if rospy.has_param("~sender_address"):
+            self.sender_address = rospy.get_param("~sender_address")
         else:
-            if rospy.has_param("~sender_address"):
-                self.sender_address = rospy.get_param("~sender_address")
-            else:
-                rospy.logerr("Please set rosparam {}/sender_address".format(
+            rospy.logerr("Please set rosparam {}/sender_address".format(
+                rospy.get_name()))
+        if rospy.has_param("~receiver_address"):
+            self.receiver_address = rospy.get_param("~receiver_address")
+        else:
+            rospy.logerr("Please set rosparam {}/receiver_address".format(
                     rospy.get_name()))
-            if rospy.has_param("~receiver_address"):
-                self.receiver_address = rospy.get_param("~receiver_address")
-            else:
-                rospy.logerr("Please set rosparam {}/receiver_address".format(
-                        rospy.get_name()))
 
 
     def _status_cb(self, msg):


### PR DESCRIPTION
In this PR, both `smach_to_mail.py` and `email_topic.py` stop using yaml file to set email config.

`email_topic.py` has been used for some months, so it is deprecated rather than completely dropping yaml config.