### PR TITLE
[develop/fetch] add jsk-switch-wifi supervisor conf

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-switch-wifi-73b2.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-switch-wifi-73b2.conf
@@ -1,0 +1,8 @@
+[program:jsk-switch-wifi-73b2]
+command=nmcli c up sanshiro-73B2
+stopsignal=TERM
+autostart=false
+autorestart=false
+stdout_logfile=/var/log/ros/jsk-switch-wifi.log
+stderr_logfile=/var/log/ros/jsk-switch-wifi.log
+user=root

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-switch-wifi-outside.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-switch-wifi-outside.conf
@@ -1,0 +1,8 @@
+[program:jsk-switch-wifi-outside]
+command=nmcli c up sanshiro-outside
+stopsignal=TERM
+autostart=false
+autorestart=false
+stdout_logfile=/var/log/ros/jsk-switch-wifi.log
+stderr_logfile=/var/log/ros/jsk-switch-wifi.log
+user=root


### PR DESCRIPTION
this PR adds `jsk-switch-wifi-outside` and `jsk-switch-wifi-73B2` supervisor conf.
you can press the button on supervisor GUI, and you can change the network configuration.
In the conf, the follwing command runs.

```bash
nmcli c up sanshiro-73B2
# or 
nmcli c up sanshiro-outside
```

cc. @nakane11 