### PR TITLE
[jsk_pr2_startup/cable_warning.l] No warning for zero velocity

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/cable_warning.l
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_warning/cable_warning.l
@@ -19,6 +19,13 @@
 
 (defun move-base-command-cb (msg)
   (cond
+   ((and (= (send msg :linear :x) 0)
+         (= (send msg :linear :y) 0)
+         (= (send msg :linear :z) 0)
+         (= (send msg :angular :x) 0)
+         (= (send msg :angular :y) 0)
+         (= (send msg :angular :z) 0))
+    (ros::publish "/base_controller/command" msg))
    ((and *check-power-p* *ac*)
     (when (< *ac-warning-sec* (send (ros::time- (ros::time-now) *ac-warning-time*) :to-sec))
       (setq *ac-warning-time* (ros::time-now))


### PR DESCRIPTION
If L1 is pressed, `/joy_vel` is selected and cable_warning node speaks "電源ケーブルを抜いてください。".
It is undesirable when we want to command torso up (L1+△)/torso down (L1+×) with PR2 connected to the cable. 
- [PR2 teleoperation](https://github.com/jsk-ros-pkg/jsk_robot/tree/master/jsk_pr2_robot#teleoperation)
- [JSK safe teleop system](https://github.com/jsk-ros-pkg/jsk_robot/tree/master/jsk_robot_common/jsk_robot_startup#launchsafe_teleoplaunch)
- [pr2_teleop_general_joystick.cpp](https://github.com/PR2/pr2_apps/blob/melodic-devel/pr2_teleop_general/src/pr2_teleop_general_joystick.cpp)