### PR TITLE
[jsk_fetch_startup] Set AUDIO_DEVICE environment variable to select peaker

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/config/config.bash
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/config.bash
@@ -22,6 +22,8 @@ if [ $(hostname) = 'fetch15' ]; then
   export NETWORK_DEFAULT_WIFI_INTERFACE="wlan0";
   export NETWORK_DEFAULT_ROS_INTERFACE="fetch15";
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-73B2";
+
+  export AUDIO_DEVICE="alsa_output.usb-1130_USB_AUDIO-00.analog-stereo"
 elif [ $(hostname) = 'fetch1075' ]; then
   export DEFAULT_SPEAKER=2;
   export DEFAULT_ENGLISH_SPEAKER=cmu_us_slt.flitevox;
@@ -43,4 +45,6 @@ elif [ $(hostname) = 'fetch1075' ]; then
   export NETWORK_DEFAULT_WIFI_INTERFACE="wlan0";
   export NETWORK_DEFAULT_ROS_INTERFACE="fetch1075";
   export NETWORK_DEFAULT_PROFILE_ID="sanshiro-73B2";
+
+  export AUDIO_DEVICE="alsa_output.usb-SEEED_ReSpeaker_4_Mic_Array__UAC1.0_-00.analog-stereo"
 fi

--- a/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-fetch-startup.conf
+++ b/jsk_fetch_robot/jsk_fetch_startup/supervisor_scripts/jsk-fetch-startup.conf
@@ -7,5 +7,5 @@ autorestart=false
 stdout_logfile=/var/log/ros/jsk-fetch-startup.log
 stderr_logfile=/var/log/ros/jsk-fetch-startup.log
 user=fetch
-environment=ROSCONSOLE_FORMAT="[${severity}] [${time}] [${node}:${logger}]: ${message}",AUDIO_DEVICE="alsa_output.usb-1130_USB_AUDIO-00.analog-stereo",PYTHONUNBUFFERED=1
+environment=ROSCONSOLE_FORMAT="[${severity}] [${time}] [${node}:${logger}]: ${message}",PYTHONUNBUFFERED=1
 priority=100


### PR DESCRIPTION
Related to #1551 
We replaced the fetch1075 speakers as a trial.
To automatically select a speaker, we need to set the `AUDIO_DEVICE` environment variable.
So, this PR set the variable in config.bash
