### PR TITLE
Fixed typo of Software License Agreement. and/o2r to and/or

### DIFF
--- a/jsk_pr2_robot/pr2_base_trajectory_action/include/pr2_base_trajectory_action/math_spline.h
+++ b/jsk_pr2_robot/pr2_base_trajectory_action/include/pr2_base_trajectory_action/math_spline.h
@@ -13,7 +13,7 @@
  *     notice, this list of conditions and the following disclaimer.
  *   * Redistributions in binary form must reproduce the above
  *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/o2r other materials provided
+ *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
  *   * Neither the name of the JSK Lab nor the names of its
  *     contributors may be used to endorse or promote products derived

--- a/jsk_pr2_robot/pr2_base_trajectory_action/include/pr2_base_trajectory_action/pr2_base_trajectory_action_controller.h
+++ b/jsk_pr2_robot/pr2_base_trajectory_action/include/pr2_base_trajectory_action/pr2_base_trajectory_action_controller.h
@@ -13,7 +13,7 @@
  *     notice, this list of conditions and the following disclaimer.
  *   * Redistributions in binary form must reproduce the above
  *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/o2r other materials provided
+ *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
  *   * Neither the name of the JSK Lab nor the names of its
  *     contributors may be used to endorse or promote products derived

--- a/jsk_pr2_robot/pr2_base_trajectory_action/src/pr2_base_trajectory_action_controller.cpp
+++ b/jsk_pr2_robot/pr2_base_trajectory_action/src/pr2_base_trajectory_action_controller.cpp
@@ -13,7 +13,7 @@
  *     notice, this list of conditions and the following disclaimer.
  *   * Redistributions in binary form must reproduce the above
  *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/o2r other materials provided
+ *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
  *   * Neither the name of the JSK Lab nor the names of its
  *     contributors may be used to endorse or promote products derived

--- a/jsk_pr2_robot/pr2_base_trajectory_action/src/pr2_base_trajectory_action_controller_node.cpp
+++ b/jsk_pr2_robot/pr2_base_trajectory_action/src/pr2_base_trajectory_action_controller_node.cpp
@@ -13,7 +13,7 @@
  *     notice, this list of conditions and the following disclaimer.
  *   * Redistributions in binary form must reproduce the above
  *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/o2r other materials provided
+ *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
  *   * Neither the name of the JSK Lab nor the names of its
  *     contributors may be used to endorse or promote products derived

--- a/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h
+++ b/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h
@@ -13,7 +13,7 @@
  *     notice, this list of conditions and the following disclaimer.
  *   * Redistributions in binary form must reproduce the above
  *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/o2r other materials provided
+ *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
  *   * Neither the name of the JSK Lab nor the names of its
  *     contributors may be used to endorse or promote products derived

--- a/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/message_store_singleton.h
+++ b/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/message_store_singleton.h
@@ -13,7 +13,7 @@
  *     notice, this list of conditions and the following disclaimer.
  *   * Redistributions in binary form must reproduce the above
  *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/o2r other materials provided
+ *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
  *   * Neither the name of the JSK Lab nor the names of its
  *     contributors may be used to endorse or promote products derived

--- a/jsk_robot_common/jsk_robot_startup/src/joint_states_throttle_node.cpp
+++ b/jsk_robot_common/jsk_robot_startup/src/joint_states_throttle_node.cpp
@@ -13,7 +13,7 @@
  *     notice, this list of conditions and the following disclaimer.
  *   * Redistributions in binary form must reproduce the above
  *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/o2r other materials provided
+ *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
  *   * Neither the name of the JSK Lab nor the names of its
  *     contributors may be used to endorse or promote products derived

--- a/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp
+++ b/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp
@@ -13,7 +13,7 @@
  *     notice, this list of conditions and the following disclaimer.
  *   * Redistributions in binary form must reproduce the above
  *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/o2r other materials provided
+ *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
  *   * Neither the name of the JSK Lab nor the names of its
  *     contributors may be used to endorse or promote products derived

--- a/jsk_robot_common/jsk_robot_startup/src/message_store_singleton.cpp
+++ b/jsk_robot_common/jsk_robot_startup/src/message_store_singleton.cpp
@@ -13,7 +13,7 @@
  *     notice, this list of conditions and the following disclaimer.
  *   * Redistributions in binary form must reproduce the above
  *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/o2r other materials provided
+ *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
  *   * Neither the name of the JSK Lab nor the names of its
  *     contributors may be used to endorse or promote products derived


### PR DESCRIPTION
# What is this?

There has always been a TYPO in the SOFTWARE LICENSE AGREEMENT.
This is not good because the users copy here and make a node.