### PR TITLE
[develop/fetch][jsk_fetch_startup] record smach transition in go_to_kitchen app

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -148,6 +148,12 @@
     local-name: jsk-ros-pkg/coral_usb_ros
     uri: https://github.com/jsk-ros-pkg/coral_usb_ros.git
     version: master
+# headless smach_viewer
+# https://github.com/ros-visualization/executive_smach_visualization/pull/46
+- git:
+    local-name: ros-visualization/executive_smach_visualization
+    uri: https://github.com/knorth55/executive_smach_visualization.git
+    version: develop/fetch
 # eus10 and roseus_resume
 - git:
     local-name: euslisp/Euslisp

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -47,6 +47,7 @@ plugins:
         - /server_name/smach/container_structure
         - /audio
         - /rviz/throttled/image/compressed
+        - /smach_image_publisher/image/compressed
   - name: head_camera_converter_plugin
     type: app_recorder/rosbag_video_converter_plugin
     plugin_args:
@@ -85,6 +86,14 @@ plugins:
       image_topic_name: /rviz/throttled/image/compressed
       image_fps: 5
       video_path: /tmp/go_to_kitchen_rviz.mp4
+  - name: smach_converter_plugin
+    type: app_recorder/rosbag_video_converter_plugin
+    plugin_args:
+      rosbag_path: /tmp
+      rosbag_title: go_to_kitchen_rosbag.bag
+      image_topic_name: /smach_image_publisher/image/compressed
+      image_fps: 2
+      video_path: /tmp/go_to_kitchen_smach.mp4
   - name: respeaker_audio_converter_plugin
     type: app_recorder/rosbag_audio_converter_plugin
     plugin_args:
@@ -108,6 +117,7 @@ plugins:
         - /tmp/go_to_kitchen_object_detection.mp4
         - /tmp/go_to_kitchen_panorama.mp4
         - /tmp/go_to_kitchen_rviz.mp4
+        - /tmp/go_to_kitchen_smach.mp4
         - /tmp/go_to_kitchen_audio.wav
         - /tmp/go_to_kitchen_rosbag.bag
         - /tmp/trashcan_inside.jpg
@@ -117,6 +127,7 @@ plugins:
         - go_to_kitchen_object_detection.mp4
         - go_to_kitchen_panorama.mp4
         - go_to_kitchen_rviz.mp4
+        - go_to_kitchen_smach.mp4
         - go_to_kitchen_audio.wav
         - go_to_kitchen_rosbag.bag
         - trashcan_inside.jpg
@@ -166,6 +177,7 @@ plugin_order:
     - object_detection_converter_plugin
     - panorama_converter_plugin
     - rviz_converter_plugin
+    - smach_converter_plugin
     - respeaker_audio_converter_plugin
     - result_recorder_plugin
     - gdrive_uploader_plugin
@@ -182,6 +194,7 @@ plugin_order:
     - object_detection_converter_plugin
     - panorama_converter_plugin
     - rviz_converter_plugin
+    - smach_converter_plugin
     - respeaker_audio_converter_plugin
     - result_recorder_plugin
     - gdrive_uploader_plugin

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -342,6 +342,14 @@
     </rosparam>
   </node>
 
+  <!-- publish smach image -->
+  <node name="smach_image_publisher" pkg="smach_viewer" type="smach_image_publisher.py"
+	output="screen">
+    <rosparam>
+      duration: 0.5
+    </rosparam>
+  </node>
+
   <!-- Two robots cannot use one rosserial device at the same time -->
   <group if="$(eval hostname == 'fetch1075')">
     <include file="$(find jsk_fetch_startup)/launch/fetch_rosserial.launch" />


### PR DESCRIPTION
This PR needs https://github.com/ros-visualization/executive_smach_visualization/pull/46

I add `smach_image_publisher` and record `smach` transition video.

You can find video in the following e-mail
`Fetch kitchen patrol demo: 2022/09/30 (23:30:36)`

https://user-images.githubusercontent.com/9300063/193293228-af16723b-0947-407b-a310-5987cf7fb149.mp4

