### PR TITLE
[jsk_fetch_startup] Use email address instead of yaml for smach_to_mail

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/CMakeLists.txt
+++ b/jsk_fetch_robot/jsk_fetch_startup/CMakeLists.txt
@@ -90,10 +90,24 @@ macro(configure_dialogflow_hotword_yaml dname)
   endif()
 endmacro(configure_dialogflow_hotword_yaml)
 
+macro(configure_email_topic_yaml rname)
+  cmake_host_system_information(RESULT FETCH_NAME QUERY HOSTNAME)
+  if (${FETCH_NAME} MATCHES ^${rname})
+    set(RECEIVER_MAIL ${rname})
+    set(EMAIL_SENDER_ADDRESS ${FETCH_NAME}@jsk.imi.i.u-tokyo.ac.jp)
+    set(EMAIL_RECEIVER_ADDRESS ${RECEIVER_MAIL}@jsk.imi.i.u-tokyo.ac.jp)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config/email_topic.yaml.in
+                   ${CMAKE_CURRENT_SOURCE_DIR}/config/${FETCH_NAME}_email_topic.yaml)
+  endif()
+endmacro(configure_email_topic_yaml)
+
+
 configure_icon_files(blue fetch15)
 configure_icon_files(red fetch1075)
 configure_dialogflow_hotword_yaml(fetch15)
 configure_dialogflow_hotword_yaml(fetch1075)
+configure_email_topic_yaml(fetch)
+
 
 #############
 ## Testing ##

--- a/jsk_fetch_robot/jsk_fetch_startup/config/.gitignore
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/.gitignore
@@ -1,1 +1,2 @@
 fetch*_dialogflow_hotword.yaml
+fetch*_email_topic.yaml

--- a/jsk_fetch_robot/jsk_fetch_startup/config/email_topic.yaml.in
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/email_topic.yaml.in
@@ -1,0 +1,2 @@
+sender_address: @EMAIL_SENDER_ADDRESS@
+receiver_address: @EMAIL_RECEIVER_ADDRESS@

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -337,9 +337,8 @@
 
   <!-- send email, twitter with smach -->
   <node name="server_name" pkg="jsk_robot_startup" type="smach_to_mail.py" output="screen">
-    <rosparam>
-      email_info: /var/lib/robot/email_topic.yaml
-    </rosparam>
+    <rosparam command="load"
+              file="$(find jsk_fetch_startup)/config/$(arg hostname)_email_topic.yaml" />
   </node>
 
   <!-- publish smach image -->


### PR DESCRIPTION
This change depends on https://github.com/jsk-ros-pkg/jsk_robot/pull/1588 .
We use rosparam instead of yaml file to set email information.