### PR TITLE
[jsk_fetch_startup] Generate fetch_email_topic.yaml when building wor…

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/CMakeLists.txt
+++ b/jsk_fetch_robot/jsk_fetch_startup/CMakeLists.txt
@@ -51,8 +51,22 @@ macro(configure_icon_files icol iname)
   endif()
 endmacro(configure_icon_files)
 
+macro(configure_email_topic_yaml rname)
+  cmake_host_system_information(RESULT FETCH_NAME QUERY HOSTNAME)
+  if (${FETCH_NAME} MATCHES ^${rname})
+    set(RECEIVER_MAIL ${rname})
+    set(EMAIL_SENDER_ADDRESS ${FETCH_NAME}@jsk.imi.i.u-tokyo.ac.jp)
+    set(EMAIL_RECEIVER_ADDRESS ${RECEIVER_MAIL}@jsk.imi.i.u-tokyo.ac.jp)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config/email_topic.yaml.in
+                   ${CMAKE_CURRENT_SOURCE_DIR}/config/${FETCH_NAME}_email_topic.yaml)
+  endif()
+endmacro(configure_email_topic_yaml)
+
+
 configure_icon_files(blue fetch15)
 configure_icon_files(red fetch1075)
+configure_email_topic_yaml(fetch)
+
 
 
 #############

--- a/jsk_fetch_robot/jsk_fetch_startup/CMakeLists.txt
+++ b/jsk_fetch_robot/jsk_fetch_startup/CMakeLists.txt
@@ -51,8 +51,10 @@ macro(configure_icon_files icol iname)
   endif()
 endmacro(configure_icon_files)
 
+# Create email config for fetch
 macro(configure_email_topic_yaml rname)
   cmake_host_system_information(RESULT FETCH_NAME QUERY HOSTNAME)
+  # If HOSTNAME is "fetchxxx", create email config
   if (${FETCH_NAME} MATCHES ^${rname})
     set(RECEIVER_MAIL ${rname})
     set(EMAIL_SENDER_ADDRESS ${FETCH_NAME}@jsk.imi.i.u-tokyo.ac.jp)

--- a/jsk_fetch_robot/jsk_fetch_startup/config/.gitignore
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/.gitignore
@@ -1,0 +1,1 @@
+fetch*_email_topic.yaml

--- a/jsk_fetch_robot/jsk_fetch_startup/config/email_topic.yaml.in
+++ b/jsk_fetch_robot/jsk_fetch_startup/config/email_topic.yaml.in
@@ -1,0 +1,2 @@
+sender_address: @EMAIL_SENDER_ADDRESS@
+receiver_address: @EMAIL_RECEIVER_ADDRESS@

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -267,9 +267,8 @@
 
   <!-- send email, twitter with smach -->
   <node name="server_name" pkg="jsk_robot_startup" type="smach_to_mail.py" output="screen">
-    <rosparam>
-      email_info: /var/lib/robot/email_topic.yaml
-    </rosparam>
+    <rosparam command="load"
+              file="$(find jsk_fetch_startup)/config/$(arg hostname)_email_topic.yaml" />
   </node>
 
   <!-- Two robots cannot use one rosserial device at the same time -->

--- a/jsk_pr2_robot/jsk_pr2_startup/.gitignore
+++ b/jsk_pr2_robot/jsk_pr2_startup/.gitignore
@@ -1,0 +1,1 @@
+pr*_email_topic.yaml

--- a/jsk_pr2_robot/jsk_pr2_startup/CMakeLists.txt
+++ b/jsk_pr2_robot/jsk_pr2_startup/CMakeLists.txt
@@ -20,3 +20,17 @@ endforeach()
 
 install(FILES install_pr1040_description.sh jsk_pr2.machine plugin.xml startup.app
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+# Create email config for PR2
+macro(configure_email_topic_yaml rname)
+  cmake_host_system_information(RESULT PR2_NAME QUERY HOSTNAME)
+  if (${PR2_NAME} MATCHES ^${rname})
+    set(RECEIVER_MAIL ${rname})
+    set(EMAIL_SENDER_ADDRESS ${PR2_NAME}@jsk.imi.i.u-tokyo.ac.jp)
+    set(EMAIL_RECEIVER_ADDRESS ${RECEIVER_MAIL}@jsk.imi.i.u-tokyo.ac.jp)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config/email_topic.yaml.in
+                   ${CMAKE_CURRENT_SOURCE_DIR}/config/${PR2_NAME}_email_topic.yaml)
+  endif()
+endmacro(configure_email_topic_yaml)
+
+configure_email_topic_yaml(pr)

--- a/jsk_pr2_robot/jsk_pr2_startup/config/email_topic.yaml.in
+++ b/jsk_pr2_robot/jsk_pr2_startup/config/email_topic.yaml.in
@@ -1,0 +1,2 @@
+sender_address: @EMAIL_SENDER_ADDRESS@
+receiver_address: @EMAIL_SENDER_ADDRESS@

--- a/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
@@ -203,7 +203,7 @@
   </node>
 
   <!-- send email, twitter with smach -->
-  <node name="server_name" pkg="jsk_robot_startup" type="smach_to_mail.py" output="screen">
+  <node name="smach_to_mail_server" pkg="jsk_robot_startup" type="smach_to_mail.py" output="screen">
     <rosparam>
       email_info: /var/lib/robot/email_topic.yaml
     </rosparam>

--- a/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
@@ -1,6 +1,7 @@
 <launch>
   <node pkg="jsk_robot_startup" type="start_launch_sound.py"
         name="start_launch_sound" />
+  <arg name="hostname" default="pr1040" />
   <arg name="map_frame" default="eng2" />
   <arg name="launch_map" default="true" />
   <arg name="launch_kinect" default="true" />
@@ -204,9 +205,8 @@
 
   <!-- send email, twitter with smach -->
   <node name="smach_to_mail_server" pkg="jsk_robot_startup" type="smach_to_mail.py" output="screen">
-    <rosparam>
-      email_info: /var/lib/robot/email_topic.yaml
-    </rosparam>
+    <rosparam command="load"
+              file="$(find jsk_pr2_startup)/config/$(arg hostname)_email_topic.yaml" />
   </node>
 
 </launch>

--- a/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
@@ -195,4 +195,18 @@
     <remap from="~input" to="/kinect_head/rgb/image_raw" />
   </node>
 
+  <!-- send email by rostopic -->
+  <node name="email_topic" pkg="jsk_robot_startup" type="email_topic.py" output="screen">
+    <rosparam>
+      email_info: /var/lib/robot/email_topic.yaml
+    </rosparam>
+  </node>
+
+  <!-- send email, twitter with smach -->
+  <node name="server_name" pkg="jsk_robot_startup" type="smach_to_mail.py" output="screen">
+    <rosparam>
+      email_info: /var/lib/robot/email_topic.yaml
+    </rosparam>
+  </node>
+
 </launch>


### PR DESCRIPTION
Almost same as #1634. Reflect #1588 .

In this PR, an email config file is auto-generated when we build workspace.
`(robot_name)_email_topic.yaml` is loaded when robot starts.