### PR TITLE
[jsk_robot_startup] Use /email_topic/mail_title for email title in kitchen-demo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.app
@@ -113,6 +113,7 @@ plugins:
     plugin_args:
       mail_title: Fetch kitchen patrol demo
       use_timestamp_title: true
+      use_app_start_time: true
     plugin_arg_yaml: /var/lib/robot/fetch_mail_notifier_plugin.yaml
   - name: move_base_cancel_plugin
     type: app_publisher/rostopic_publisher_plugin

--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -167,6 +167,8 @@ class SmachToMail():
 
         if subject:
             email_msg.subject = subject
+        elif rospy.has_param("/email_topic/mail_title"):
+            email_msg.subject = rospy.get_param("/email_topic/mail_title")
         else:
             email_msg.subject = 'Message from {}'.format(rospy.get_param('/robot/name', 'robot'))
 


### PR DESCRIPTION
Duplicates #1649.

This PR enables us to set the same email title between smach_to_mail.py and app_manager_utile/mail_notifier_plugin.
We can receive the same demo emails as one thread.

app_managerで管理されているデモのうち，プラグインからメール通知が行くものに関して，smach_to_mail側が同じタイトルに合わせられるようにした変更です．
キッチンデモ関連のメールが行われた時間ごとに一つのスレッドにまとまるので，ユーザー通知+開発者向け通知のような形として見られるようになります．