### PR TITLE
[develop/fetch] [fetcheus] do not load roseus_resume when roseus_resume is not found

### DIFF
--- a/jsk_fetch_robot/README.md
+++ b/jsk_fetch_robot/README.md
@@ -44,15 +44,21 @@ cd  catkin_ws/src
 wstool init .
 wstool set --git jsk-ros-pkg/jsk_robot https://github.com/jsk-ros-pkg/jsk_robot.git -v develop/fetch -y
 wstool merge -t . https://raw.githubusercontent.com/jsk-ros-pkg/jsk_robot/master/jsk_fetch_robot/jsk_fetch_user.rosinstall.$ROS_DISTRO
+
+# (optional): the two lines below are necessary when you want to use roseus_resume
 wstool merge -t . https://gist.githubusercontent.com/Affonso-Gui/25518fef9dc7af0051147bdd2a94b116/raw/e3fcbf4027c876329801a25e32f4a4746200ddae/guiga_system.rosinstall
 wstool update -t .
-# To use eus10, furuschev script is required.
+
+# (optional): the two lines below are necessary when you want to use eus10
 wget https://raw.githubusercontent.com/jsk-ros-pkg/jsk_roseus/master/setup_upstream.sh -O /tmp/setup_upstream.sh
 bash /tmp/setup_upstream.sh -w ../ -p jsk-ros-pkg/geneus -p euslisp/jskeus
+
 source /opt/ros/$ROS_DISTRO/setup.bash
 rosdep install -y -r --from-paths . --ignore-src
 cd ../
-catkin build fetcheus jsk_fetch_startup roseus_resume
+# (optional): if you want to use roseus_resume, build roseus_resume, too.
+catkin build fetcheus jsk_fetch_startup
+
 source devel/setup.bash
 ```
 

--- a/jsk_fetch_robot/fetcheus/fetch-interface.l
+++ b/jsk_fetch_robot/fetcheus/fetch-interface.l
@@ -1,7 +1,15 @@
 (require "package://fetcheus/fetch-utils.l")
 (require "package://pr2eus/robot-interface.l")
 (require "package://pr2eus_moveit/euslisp/robot-moveit.l")
-(require "package://roseus_resume/euslisp/interruption-handler.l")
+(defvar *enable-roseus-resume* (ros::rospack-find "roseus_resume"))
+(if *enable-roseus-resume*
+  (progn
+    (require :roseus_resume "package://roseus_resume/euslisp/interruption-handler.l")
+    (warning-message 2 "roseus_resume is enabled.~%"))
+  (progn
+    ;; make dummy package to avoid symbol search error
+    (unless (find-package "ROSEUS_RESUME") (make-package "ROSEUS_RESUME"))
+    (warning-message 3 "roseus_resume is disabled.~%")))
 
 (ros::load-ros-package "fetcheus")
 (ros::load-ros-package "fetch_driver_msgs")
@@ -43,11 +51,16 @@
                      "/head_controller/point_head"
                      control_msgs::PointHeadAction))
 
-     (roseus_resume:install-interruption-handler self
-         gripper-action
-         move-base-action
-         move-base-trajectory-action)
-     (roseus_resume:install-default-intervention self)))
+     (if *enable-roseus-resume*
+       (progn
+         (warning-message 3 "Installing interruption handler...~%")
+         (roseus_resume::install-interruption-handler self
+             gripper-action
+             move-base-action
+             move-base-trajectory-action)
+         (roseus_resume::install-default-intervention self)
+         (warning-message 3 "...done.~%")))
+     ))
   (:state (&rest args)
    "We do not have :wait-until-update option for :state :worldcoords.
 In other cases, :state calls with :wait-until-update by default, since Fetch publishes /joint_states from body and gripper at almost same frequency.


### PR DESCRIPTION
this PR allow not to use `eus10` or `roseus_resume`.
We can load `fetch-interface` in `eus9` and not `roseus_resume` installed workspace.
I also updated the readme for installation.