### PR TITLE
[jsk_robot_startup] Add timeout for smach notification and refactor error handling

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -34,14 +34,12 @@ class SmachToMail():
         self.timeout = rospy.get_param("~timeout", 1200)
         try:
             self.sender_address = rospy.get_param("~sender_address")
-        else:
-            rospy.logerr("Please set rosparam {}/sender_address".format(
-                rospy.get_name()))
-        if rospy.has_param("~receiver_address"):
             self.receiver_address = rospy.get_param("~receiver_address")
-        else:
-            rospy.logerr("Please set rosparam {}/receiver_address".format(
-                    rospy.get_name()))
+        except KeyError as e:
+            rospy.logerr(e)
+            rospy.logerr(
+                "Please set rosparam ~sender_address or ~receiver_address")
+            sys.exit()
 
     def _stop_timer_cb(self, event):
         now = rospy.Time.now()

--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -25,10 +25,14 @@ class SmachToMail():
         self.pub_twitter = rospy.Publisher("tweet", String, queue_size=10)
         rospy.Subscriber(
             "~smach/container_status", SmachContainerStatus, self._status_cb)
+        rospy.Timer(rospy.Duration(
+            rospy.get_param("~stop_duration", 3600)), self._stop_timer_cb)
         self.bridge = CvBridge()
         self.smach_state_list = {}  # for status list
         self.smach_state_subject = {}  # for status subject
-        if rospy.has_param("~sender_address"):
+        self.smach_start_time = {}
+        self.timeout = rospy.get_param("~timeout", 1200)
+        try:
             self.sender_address = rospy.get_param("~sender_address")
         else:
             rospy.logerr("Please set rosparam {}/sender_address".format(
@@ -39,6 +43,21 @@ class SmachToMail():
             rospy.logerr("Please set rosparam {}/receiver_address".format(
                     rospy.get_name()))
 
+    def _stop_timer_cb(self, event):
+        now = rospy.Time.now()
+        rospy.loginfo("stop timer")
+        if (self.smach_state_list and
+            self.smach_state_subject and
+            self.timeout is not None and
+            self.smach_start_time is not None):
+            for key in self.smach_state_list.keys():
+                if (now - self.smach_start_time[key]).to_sec() > self.timeout:
+                    self._send_mail(
+                        self.smach_state_subject[key], self.smach_state_list[key])
+                    self._send_twitter(
+                        self.smach_state_subject[key], self.smach_state_list[key])
+                rospy.logwarn(
+                    "SmachToMail timer publishes stop signal. Send Notification.")
 
     def _status_cb(self, msg):
         '''
@@ -80,6 +99,7 @@ class SmachToMail():
 
         # If we received START/INIT status, restart storing smach_state_list
         if status_str in ["START", "INIT"]:
+            self.smach_start_time[caller_id] = rospy.Time.now()
             self.smach_state_list[caller_id] = []
             # DESCRIPTION of START is MAIL SUBJECT
             if 'DESCRIPTION' in local_data_str:


### PR DESCRIPTION
This PR adds timeout section for smach notification.
If demo fails, smach notification is not sent. (Ideally, failure or timeout should be detected on the demo side and brought to the finish state as a state transition, but I think it's also good to support on the `smach_to_notification` side.)

And I also refactor getting rosparam.