### PR TITLE
[jsk_robot_startup] Fix sending notification every times if demo stuck and refactor _stop_timer_cb

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -42,6 +42,10 @@ class SmachToMail():
             sys.exit()
 
     def _stop_timer_cb(self, event):
+        '''
+        If smach does not go to finish/end state,
+        this is forced to send notification.
+        '''
         now = rospy.Time.now()
         rospy.logdebug("SmachToMail stop timer called")
         if (self.smach_state_list and


### PR DESCRIPTION
This PR fixes a bug that caused emails to continue to be sent at certain intervals when the demo failed and the state transition stopped.

And I refactored `_stop_timer_cb` function (e.g. Log level, code indent).