### PR TITLE
[cobottaeus][OSS] Change queue size of joint_states

### DIFF
--- a/jsk_denso_robot/cobottaeus/cobotta-oss-interface.l
+++ b/jsk_denso_robot/cobottaeus/cobotta-oss-interface.l
@@ -13,7 +13,9 @@
   (:init
     (&rest args)
     (prog1
-      (send-super* :init :robot cobotta-robot :joint-states-topic "/cobotta/joint_states"
+      (send-super* :init :robot cobotta-robot
+                   :joint-states-topic "/cobotta/joint_states"
+                   :joint-states-queue-size 2  ;; joint_states of arm and gripper are separated
                    :groupname "cobotta_oss_interface" args)
       (send self :add-controller :rarm-controller)
       (ros::subscribe "/cobotta/gripper_state" std_msgs::Bool


### PR DESCRIPTION
COBOTTA OSS publishes two types of joint_states (arm and gripper) to one topic:
```
$ rostopic echo /cobotta/joint_states 
header: 
  seq: 140336
  stamp: 
    secs: 1665713626
    nsecs: 996598999
  frame_id: ''
name: [joint_gripper]
position: [0.011664775546719816]
velocity: []
effort: []
---
header: 
  seq: 140113
  stamp: 
    secs: 1665713626
    nsecs: 997815384
  frame_id: ''
name: [joint_1, joint_2, joint_3, joint_4, joint_5, joint_6]
position: [-0.1776660274798269, -0.2001291276808761, 1.4076959332091423, 0.11033073128926771, -0.6619518902611218, -0.016595376969955465]
velocity: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
effort: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
---
header: 
  seq: 140337
  stamp: 
    secs: 1665713627
    nsecs:    668648
  frame_id: ''
name: [joint_gripper]
position: [0.011664775546719816]
velocity: []
effort: []
---
header: 
  seq: 140114
  stamp: 
    secs: 1665713627
    nsecs:   1882105
  frame_id: ''
name: [joint_1, joint_2, joint_3, joint_4, joint_5, joint_6]
position: [-0.1776660274798269, -0.2001291276808761, 1.4076959332091423, 0.11033073128926771, -0.6619518902611218, -0.016595376969955465]
velocity: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
effort: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
```

To manage this well on `*ri*`, this PR fixes queue size of joint_states following the documentation: https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/0.3.14/pr2eus/robot-interface.l#L130

Without this PR, update of `:potentio-vector` is rarely slow:
```
1.irteusgl$ (progn (cobotta-oss-init) (send *ri* :state :potentio-vector :wait-until-update t))
PQP Error! EndModel() called on model with no triangles
PQP Error! EndModel() called on model with no triangles
#f(0.0 20.0 79.0 0.0 20.0 0.0)
2.irteusgl$ (send *ri* :state :potentio-vector :wait-until-update t)
#f(0.0 20.0 79.0 0.0 20.0 0.0)
3.irteusgl$ (send *ri* :state :potentio-vector :wait-until-update t)
#f(-10.1795 -11.4666 80.655 6.32149 -37.927 -0.950845)
```
(I know something is wrong around `:wait-until-update t` because this should force to update all joints, but fixing queue size is enough for current COBOTTA OSS.)