### PR TITLE
[jsk_pr2_startup] add smach_image_publisher in pr2.launch

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
@@ -195,4 +195,12 @@
     <remap from="~input" to="/kinect_head/rgb/image_raw" />
   </node>
 
+  <!-- publish smach image -->
+  <node name="smach_image_publisher" pkg="smach_viewer" type="smach_image_publisher.py"
+        output="screen">
+    <rosparam>
+      duration: 0.5
+    </rosparam>
+  </node>
+
 </launch>


### PR DESCRIPTION
this PR adds `smach_image_publisher` in `pr2.launch`.
we can get `smach_viewer` image as image topic.