### PR TITLE
[pr2_base_trajectory_action] Fix parameter names in pr2_base_link.yaml

### DIFF
--- a/jsk_pr2_robot/pr2_base_trajectory_action/config/pr2_base_link.yaml
+++ b/jsk_pr2_robot/pr2_base_trajectory_action/config/pr2_base_link.yaml
@@ -1,6 +1,6 @@
-x_joint_name: base_link_x
-y_joint_name: base_link_y
-rotational_joint_name: base_link_pan
+linear_x_joint_name: base_link_x
+linear_y_joint_name: base_link_y
+rotational_z_joint_name: base_link_pan
 base_link_x:
     max_velocity: 0.305
 base_link_y:


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_robot/pull/623 refactored `pr2_base_trajectory_action.cpp` and used `pr2_base_trajectory_action_controller.cpp` instead. Parameter names were changed at this time. 
The problem is that `pr2_base_link.yaml` still sets previous parameters, so I fixed it.
