### PR TITLE
[jsk_pepper_startup/apps/meeting] add end function into roseus-sigint-handler and delete joy subscriber

### DIFF
--- a/jsk_naoqi_robot/jsk_pepper_startup/apps/meeting/scripts/meeting.l
+++ b/jsk_naoqi_robot/jsk_pepper_startup/apps/meeting/scripts/meeting.l
@@ -209,8 +209,21 @@
 ;; https://github.com/jsk-ros-pkg/jsk_roseus/pull/717
 ;; did not work, when we subscribe image data ???
 
+(defun end ()
+  (let ()
+    (send *ri* :angle-vector-sequence (list #f(2.0 -2.0 -5.0 85.0 20.0 -70.0 -20.0 -40.0 85.0 -20.0 70.0 20.0 40.0 30.0 -10.0) #f(2.0 -2.0 -5.0 85.0 10.0 -70.0 -20.0 -40.0 85.0 -10.0 70.0 20.0 40.0 0.0 0.0) #f(2.0 -2.0 -5.0 85.0 20.0 -70.0 -20.0 -40.0 85.0 -20.0 70.0 20.0 40.0 -30.0 -10.0) #f(2.0 -2.0 -5.0 85.0 10.0 -70.0 -20.0 -40.0 85.0 -10.0 70.0 20.0 40.0 0.0 0.0)) (list 1000 1000 1000 1000))
+    (send *ri* :speak "\\vct=120\\\\rspd=80\\みなさん")
+    (send *ri* :wait-interpolation)
+    (send *ri* :angle-vector-sequence (list *a* *d* *a* *d* *a* *d* *a* *d* *a* *e* *reset*) (list 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 3000))
+    (send *ri* :speak "\\vct=120\\\\rspd=80\\おつかれさまでしたッ！\\rspd=100\\")
+    (send *ri* :wait-interpolation)
+    (send *ri* :hide-image)
+    (send *ri* :set-language "English")
+    ))
+
 (defun ros::roseus-sigint-handler (sig code)
   (ros::ros-warn (format nil "ros::roseus-sigint-handler ~A" sig))
+  (end)
   (setq *continue* nil))
 (unix:signal unix::sigint 'ros::roseus-sigint-handler)
 

--- a/jsk_naoqi_robot/jsk_pepper_startup/apps/meeting/scripts/meeting.l
+++ b/jsk_naoqi_robot/jsk_pepper_startup/apps/meeting/scripts/meeting.l
@@ -86,14 +86,6 @@
 
 (ros::roseus "online-meeting-enhancement-main")
 
-(ros::subscribe "joy" sensor_msgs::Joy
-                #'(lambda (msg)
-                    (let ((button (send msg :buttons)))
-                      (ros::ros-info "received joy button ~A" button)
-                      (when (eq (elt button 3) 1)
-                        (send *ri* :speak "はい")
-                        (setq *continue* nil)))))
-
 (defun start-func (args)
   (let ()
     (setq *last-tm* (ros::time-now))


### PR DESCRIPTION
### 変更内容
`ros::roseus-sigint-handler`関数が呼ばれた時に，`end`状態で実行される関数 (https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_naoqi_robot/jsk_pepper_startup/apps/meeting/scripts/meeting.l#L117) の中身を実行するようにしました (`end`関数としました) 。

### 理由
現状のプログラムでは，meetingアプリを実行後，stop_app サービスを呼ぶとプログラムが終了し，
`ros::roseus-sigint-handler`関数が呼ばれて`*continue*`がnilになる。
その後に`comment`状態から抜けて`end`状態に遷移する。
この時点でプログラムは終了しているので，`end`状態で実行される関数は実行されないが，本当は実行してほしいため。

### そのほかの変更
- `end`関数では，以下のように，タブレットに写真を表示するのに必要な`naoqi_tablet`ノードは，
stop_app サービスを呼ぶと落ちてしまうので，
`end-func`関数では実行している` (send *ri* :show-image "golden-saying-by-pepper-7.png")`は削除してあります。
```
[INFO] [1665994300.560000]: start_app: jsk_pepper_startup/meeting
[INFO] [1665994308.053461]: handle stop app: jsk_pepper_startup/meeting
[INFO] [1665994308.055742]: handle stop app: stopping app [jsk_pepper_startup/meeting]
[meeting-20] killing on exit
[naoqi_background_movement-19] killing on exit
[naoqi_basic_awareness-18] killing on exit
[naoqi_tablet-17] killing on exit
[INFO] [1665994308.154899]: Stopping naoqi_tablet
[INFO] [1665994308.159175]: naoqi_tablet stopped
[ WARN] [1665994308.490994316]: ros::roseus-sigint-handler 2
[INFO] [1665994308.546117]: JointTrajectory action executing
[INFO] [1665994312.574133]: JointTrajectory action done
[meeting-20] escalating to SIGTERM
[INFO] [1665994324.349246]: handle stop app: app [jsk_pepper_startup/meeting] stopped
```
- joy_nodeのsubscriberは使われていないので削除しました。