### PR TITLE
[jsk_naoqi_robot/cross/repos] update app_manager version in pepper.repos

### DIFF
--- a/jsk_naoqi_robot/cross/repos/pepper.repos
+++ b/jsk_naoqi_robot/cross/repos/pepper.repos
@@ -1,8 +1,8 @@
 repositories:
   app_manager:
     type: git
-    url: https://github.com/Affonso-Gui/app_manager
-    version: enable-parallel-run-apps
+    url: https://github.com/PR2/app_manager
+    version: kinetic-devel
   #
   # fix qt> 5 (https://github.com/ros-naoqi/naoqi_dashboard/pull/3)
   naoqi_dashboard:


### PR DESCRIPTION
https://github.com/PR2/app_manager/pull/59
がマージされたので，
`repos/pepper.repos`に書かれた`app_manager`のバージョンを変更しました。


### 変更前

以下のように`make user`が失敗します。
```
kochigami@kochigami-desktop:~/catkin_ws/src/jsk_robot/jsk_naoqi_robot/cross$ make user
./build_user.sh
+ mkdir -p i386_User/src/jsk_robot
+ rsync -avzh --delete --exclude 'jsk_naoqi_robot/cross*' --exclude nao.l --exclude pepper.l --exclude nao-simple.l --exclude pepper-simple.l ../../../jsk_robot i386_User/src/
sending incremental file list
jsk_robot/
jsk_robot/.gitignore
jsk_robot/.gitmodules
jsk_robot/.travis.rosinstall
jsk_robot/.travis.rosinstall.hydro
jsk_robot/.travis.rosinstall.indigo
jsk_robot/.travis.rosinstall.kinetic
jsk_robot/.travis.rosinstall.melodic
jsk_robot/.travis.rosinstall.noetic
jsk_robot/.travis.yml
jsk_robot/README.md

…（省略）...

+ '[' -e i386_User/src/jsk_robot/doc/CATKIN_IGNORE ']'
+ touch i386_User/src/jsk_robot/doc/CATKIN_IGNORE
+ for dir in $(find ${SOURCE_ROOT}/src/jsk_robot -maxdepth 1 -mindepth 1 -type d)
+ [[ ! i386_User/src/jsk_robot/jsk_aero_robot =~ jsk_naoqi_robot|jsk_robot_common ]]
+ '[' -e i386_User/src/jsk_robot/jsk_aero_robot/CATKIN_IGNORE ']'
+ touch i386_User/src/jsk_robot/jsk_aero_robot/CATKIN_IGNORE
+ '[' 1 -eq 0 ']'
+ vcs import i386_User/src
......E..
=== i386_User/src/app_manager (git) ===
Could not checkout ref 'enable-parallel-run-apps': fatal: invalid reference: enable-parallel-run-apps
=== i386_User/src/nao_interaction (git) ===
Cloning into '.'...
=== i386_User/src/nao_robot (git) ===
Cloning into '.'...
=== i386_User/src/naoqi_bridge (git) ===
Cloning into '.'...
=== i386_User/src/naoqi_bridge_msgs (git) ===
Cloning into '.'...
=== i386_User/src/naoqi_dashboard (git) ===
Cloning into '.'...
=== i386_User/src/naoqi_driver (git) ===
Cloning into '.'...
=== i386_User/src/pepper_meshes (git) ===
Cloning into '.'...
=== i386_User/src/pepper_robot (git) ===
Cloning into '.'...
Makefile:18: recipe for target 'user' failed
make: *** [user] Error 1
```
