### PR TITLE
[jsk_naoqi_robot/README] update troubleshooting about set audio false in boot_config.json: add notes that this is Pepper-only

### DIFF
--- a/jsk_naoqi_robot/README.md
+++ b/jsk_naoqi_robot/README.md
@@ -178,7 +178,7 @@ To control NAO and Pepper via gazebo simulator and roseus, please refer to [here
 
 ## Troubleshooting
 
-* If you use Ubuntu18.04, you need to set audio `false` in `~/catkin_ws/src/naoqi_driver/share/boot_config.json`
+* [Pepper Only] If you use Ubuntu 18.04, it is possible that you can't run `jsk_pepper_startup.launch` as reported in [this issue](https://github.com/jsk-ros-pkg/jsk_robot/issues/1474#issuecomment-1110768907). In that case, you may need to set audio `false` in `~/catkin_ws/src/naoqi_driver/share/boot_config.json`. Note that this means you can't subscribe audio topic.
 
   ```
   "audio":


### PR DESCRIPTION
I updated README based on https://github.com/jsk-ros-pkg/jsk_robot/issues/1682.
Thank you very much.

In troubleshooting about set audio false in boot_config.json, I added notes that this is Pepper-only and side-effect of this change.