### PR TITLE
[develop/fetch] diable google chat when google_chat_space is not set

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -49,9 +49,14 @@ class SmachToMail():
             rospy.logerr(
                 "Please set rosparam ~sender_address or ~receiver_address")
             sys.exit()
+
+        self.chat_space = rospy.get_param("~google_chat_space", None)
+        if self.use_google_chat and self.chat_space is None:
+            rospy.logerr("Please set rosparam ~google_chat_space")
+            self.use_google_chat = False
+
         if self.use_google_chat:
             self.gchat_ac = actionlib.SimpleActionClient("/google_chat_ros/send", SendMessageAction)
-            self.chat_space = rospy.get_param("~google_chat_space")
             self.gchat_image_dir = rospy.get_param("~google_chat_tmp_image_dir", "/tmp")
             self._gchat_thread = None
 


### PR DESCRIPTION
this PR diable `google_chat_ros` when `google_chat_space` param is not set.
currently, `fetch1075` does not send e-mail because of this.