### PR TITLE
[jsk_robot_startup] disable google chat when google_chat_space is not set

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -47,9 +47,14 @@ class SmachToMail():
         else:
             rospy.logerr("Please set rosparam {}/receiver_address".format(
                     rospy.get_name()))
+
+        self.chat_space = rospy.get_param("~google_chat_space", None)
+        if self.use_google_chat and self.chat_space is None:
+            rospy.logerr("Please set rosparam ~google_chat_space")
+            self.use_google_chat = False
+
         if self.use_google_chat:
             self.gchat_ac = actionlib.SimpleActionClient("/google_chat_ros/send", SendMessageAction)
-            self.chat_space = rospy.get_param("~google_chat_space")
             self.gchat_image_dir = rospy.get_param("~google_chat_tmp_image_dir", "/tmp")
             self._gchat_thread = None
 


### PR DESCRIPTION
`~google_chat_space` is necessary field for `smach_to_mail.py` if you want to use `Google Chat`
this PR check if `~google_chat_space` is set, and if not disable `Google Chat`.