### PR TITLE
[jsk_robot_startup] add missing import in smach_to_mail

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -6,6 +6,7 @@ import actionlib
 import base64
 import cv2
 import datetime
+import os
 import pickle
 import rospy
 import sys


### PR DESCRIPTION
this PR add missing import `os` in `smach_to_mail`