### PR TITLE
[jsk_pr2_startup] add respawn to respeaker node

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/pr2_microphone.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/pr2_microphone.launch
@@ -1,6 +1,7 @@
 <launch>
   <arg name="use_microcone" default="false"/>
   <arg name="use_respeaker" default="true"/>
+  <arg name="respawn" default="false"/>
 
   <arg name="language" default="ja-JP"/>
 
@@ -20,7 +21,7 @@
   <!-- respeaker -->
   <group if="$(arg use_respeaker)">
     <node name="respeaker_node" pkg="respeaker_ros" type="respeaker_node.py"
-          machine="$(arg machine)" output="screen">
+          machine="$(arg machine)" output="screen" respawn="$(arg respawn)">
       <rosparam>
         sensor_frame_id: head_mount_link
       </rosparam>

--- a/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
@@ -136,7 +136,9 @@
 
   <!-- for microphone -->
   <include if="$(arg launch_microphone)"
-           file="$(find jsk_pr2_startup)/jsk_pr2_lifelog/pr2_microphone.launch"/>
+           file="$(find jsk_pr2_startup)/jsk_pr2_lifelog/pr2_microphone.launch">
+    <arg name="respawn" value="true" />
+  </include>
 
   <!-- joy mux -->
   <node machine="c2" pkg="topic_tools" type="mux" name="multiple_joystick_mux"


### PR DESCRIPTION
This PR adds `respawn` flag for `respeaker_node`.
Also, in `pr2.launch` we set `respawn` `true` for `respeaker_node`.