### PR TITLE
[jsk_fetch_startup] Add timeout for get-light-on

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -227,7 +227,9 @@ Args:
 
 (defun get-light-on ()
   (let* ((room-light-msg
-           (one-shot-subscribe "/check_room_light/output" jsk_robot_startup::RoomLight))
+          (one-shot-subscribe "/check_room_light/output"
+                              jsk_robot_startup::RoomLight
+                              :timeout 1000))
          (light-on (if room-light-msg (send room-light-msg :light_on))))
     light-on))
 


### PR DESCRIPTION
This is a master branch version of #1709.
Without this PR, `get-light-on` hangs when head camra image does not publish.