### PR TITLE
[TEST] add mongodb_store to .travis.install.ROS_DISTRO to pass test

### DIFF
--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -43,3 +43,11 @@
     local-name: DENSORobot/denso_cobotta_ros
     uri: https://github.com/DENSORobot/denso_cobotta_ros.git
     version: 1a4a74a92c763906c47eec574b5b3dbaa52f622e
+# Following error is output at about 25Hz for about 4 hours
+# [ERROR] [1653231340.987602] [/replicator_node:rosout]: [mongorestore] - E11000 duplicate key error collection: jsk_robot_lifelog.fetch1075 index: _id_ dup key: { : ObjectId('6243af9651998d10f0c7787c') }
+# Errors are now output once per hour
+# Wait for merging PR: https://github.com/strands-project/mongodb_store/pull/271
+- git:
+    local-name: strands-project/mongodb_store
+    uri: https://github.com/708yamaguchi/mongodb_store.git
+    version: fetch15

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -64,3 +64,11 @@
     local-name: jsk-ros-pkg/jsk_3rdparty 
     uri: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
     version: f0ab7bba54523b8f9945ed4a3e9c0efec0c8dde9 
+# Following error is output at about 25Hz for about 4 hours
+# [ERROR] [1653231340.987602] [/replicator_node:rosout]: [mongorestore] - E11000 duplicate key error collection: jsk_robot_lifelog.fetch1075 index: _id_ dup key: { : ObjectId('6243af9651998d10f0c7787c') }
+# Errors are now output once per hour
+# Wait for merging PR: https://github.com/strands-project/mongodb_store/pull/271
+- git:
+    local-name: strands-project/mongodb_store
+    uri: https://github.com/708yamaguchi/mongodb_store.git
+    version: fetch15


### PR DESCRIPTION
In develop branch, test fails with the following error etc......
```
2022-10-28T13:29:32.7271607Z FAILURE:
2022-10-28T13:29:32.7271735Z 
2022-10-28T13:29:32.7271877Z                                                                                 
2022-10-28T13:29:32.7272291Z [/github/home/ros/ws_jsk_robot/src/jsk_robot/jsk_aero_robot/jsk_aero_startup/test/aero.test.xml]:
2022-10-28T13:29:32.7272561Z 
2022-10-28T13:29:32.7272697Z                                                                                 
2022-10-28T13:29:32.7273151Z 	unused args [logerr_period] for include of [/opt/ros/melodic/share/mongodb_store/launch/mongodb_store_inc.launch]
2022-10-28T13:29:33.2522859Z checking /github/home/ros/ws_jsk_robot/src/jsk_robot/jsk_aero_robot/jsk_aero_startup/test/aero.test.xml
2022-10-28T13:29:33.2523294Z 
2022-10-28T13:29:33.2523352Z 
2022-10-28T13:29:33.2523548Z                                                                                 
2022-10-28T13:29:33.2524720Z ...writing test results to /github/home/ros/ws_jsk_robot/build/jsk_aero_startup/test_results/jsk_aero_startup/roslaunch-check_test_aero.test.xml.xml
```