### PR TITLE
[jsk_robot_startup/src/jsk_robot_startup/email_topic_client.py] update msg body format based on new Email.msg

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/email_topic_client.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/email_topic_client.py
@@ -1,6 +1,6 @@
 import rospy
 from jsk_robot_startup.msg import Email
-
+from jsk_robot_startup.msg import EmailBody
 
 class EmailTopicClient:
 
@@ -20,7 +20,10 @@ class EmailTopicClient:
         msg = Email()
         msg.header.stamp = rospy.Time.now()
         msg.subject = subject
-        msg.body = body
+        email_body = EmailBody()
+        email_body.type = "text"
+        email_body.message = body
+        msg.body.append(email_body)
         msg.receiver_address = receiver_address
         if sender_address is not None:
             msg.sender_address = sender_address


### PR DESCRIPTION
When I tried `roslaunch jsk_robot_startup sample_email_topic.launch receiver_address:="my email address" use_eus:=false`, 
I got the following error because `Email.msg` is updated in https://github.com/jsk-ros-pkg/jsk_robot/commit/1993399f50bd4569c51e7700d46e2a863a469d2f

```
kanae@kanae-ThinkPad-T480s:~/catkin_ws/devel$ roslaunch jsk_robot_startup sample_email_topic.launch receiver_address:="my email address" use_eus:=false
... logging to /home/kanae/.ros/log/d410d19c-5ff4-11ed-a4b2-e86a6433c67f/roslaunch-kanae-ThinkPad-T480s-9441.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://192.168.97.182:42673/

SUMMARY
========

PARAMETERS
 * /email_topic/email_info: /var/lib/robot/em...
 * /rosdistro: kinetic
 * /rosversion: 1.12.14
 * /sample_email_topic_client/attached_files: ['/home/kanae/cat...
 * /sample_email_topic_client/receiver_address: <my email address...>

NODES
  /
    email_topic (jsk_robot_startup/email_topic.py)
    sample_email_topic_client (jsk_robot_startup/sample_email_topic_client.py)

auto-starting new master
process[master]: started with pid [9451]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to d410d19c-5ff4-11ed-a4b2-e86a6433c67f
process[rosout-1]: started with pid [9464]
started core service [/rosout]
process[email_topic-2]: started with pid [9480]
process[sample_email_topic_client-3]: started with pid [9482]
[INFO] [1667974066.734499]: {'sender_address': 'jsk_robot@example.com', 'receiver_address': 'jsk_robot@example.com'}
Traceback (most recent call last):
  File "/home/kanae/catkin_ws/src/jsk_robot/jsk_robot_common/jsk_robot_startup/scripts/sample_email_topic_client.py", line 19, in <module>
    main()
  File "/home/kanae/catkin_ws/src/jsk_robot/jsk_robot_common/jsk_robot_startup/scripts/sample_email_topic_client.py", line 15, in main
    client.send_mail('test-mail',receiver_address,'test',attached_files=attached_files)
  File "/home/kanae/catkin_ws/src/jsk_robot/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/email_topic_client.py", line 33, in send_mail
    self.pub.publish(msg)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/topics.py", line 882, in publish
    self.impl.publish(data)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/topics.py", line 1066, in publish
    serialize_message(b, self.seq, message)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/msg.py", line 152, in serialize_message
    msg.serialize(b)
  File "/home/kanae/catkin_ws/devel/lib/python2.7/dist-packages/jsk_robot_startup/msg/_Email.py", line 125, in serialize
    _x = val1.type
AttributeError: 'str' object has no attribute 'type'
[sample_email_topic_client-3] process has died [pid 9482, exit code 1, cmd /home/kanae/catkin_ws/src/jsk_robot/jsk_robot_common/jsk_robot_startup/scripts/sample_email_topic_client.py __name:=sample_email_topic_client __log:=/home/kanae/.ros/log/d410d19c-5ff4-11ed-a4b2-e86a6433c67f/sample_email_topic_client-3.log].
log file: /home/kanae/.ros/log/d410d19c-5ff4-11ed-a4b2-e86a6433c67f/sample_email_topic_client-3*.log
^C[email_topic-2] killing on exit
[rosout-1] killing on exit
[master] killing on exit
shutting down processing monitor...
... shutting down processing monitor complete
```

After I updated `msg.body` format, I could send an e-mail using `email_topic_client.py` as follows.
If any comments, please let me know.

```
kanae@kanae-ThinkPad-T480s:~/catkin_ws/devel$ roslaunch jsk_robot_startup sample_email_topic.launch receiver_address:="my email address" use_eus:=false
... logging to /home/kanae/.ros/log/210f4540-5ff6-11ed-a4b2-e86a6433c67f/roslaunch-kanae-ThinkPad-T480s-9945.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://192.168.97.182:38231/

SUMMARY
========

PARAMETERS
 * /email_topic/email_info: /var/lib/robot/em...
 * /rosdistro: kinetic
 * /rosversion: 1.12.14
 * /sample_email_topic_client/attached_files: ['/home/kanae/cat...
 * /sample_email_topic_client/receiver_address: my email address...

NODES
  /
    email_topic (jsk_robot_startup/email_topic.py)
    sample_email_topic_client (jsk_robot_startup/sample_email_topic_client.py)

auto-starting new master
process[master]: started with pid [9955]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 210f4540-5ff6-11ed-a4b2-e86a6433c67f
process[rosout-1]: started with pid [9968]
started core service [/rosout]
process[email_topic-2]: started with pid [9984]
process[sample_email_topic_client-3]: started with pid [9986]
[INFO] [1667974625.438508]: {'sender_address': 'jsk_robot@example.com', 'receiver_address': 'jsk_robot@example.com'}
[INFO] [1667974630.443102]: Sent a mail
[INFO] [1667974630.448127]: Received an msg: header: 
  seq: 1
  stamp: 
    secs: 1667974630
    nsecs: 442497014
  frame_id: ''
subject: "test-mail"
body: 
  - 
    type: "text"
    message: "test"
    file_path: ''
    img_data: ''
    img_size: 0
sender_address: ''
receiver_address: "my email address"
smtp_server: ''
smtp_port: ''
attached_files: [/home/kanae/catkin_ws/src/jsk_robot/jsk_robot_common/jsk_robot_startup/images/jsk_safe_teleop_system.png]
[INFO] [1667974630.450850]: File /home/kanae/catkin_ws/src/jsk_robot/jsk_robot_common/jsk_robot_startup/images/jsk_safe_teleop_system.png is attached.
[INFO] [1667974630.495182]: Send mail from jsk_robot@example.com to my email address using localhost:25
[sample_email_topic_client-3] process has finished cleanly
log file: /home/kanae/.ros/log/210f4540-5ff6-11ed-a4b2-e86a6433c67f/sample_email_topic_client-3*.log
```