### PR TITLE
[jsk_robot/.travis.rosinstall] update .travis.rosinstall.kinetic/melodic/noetic to install naoqi_bridge source (kochigami-develop)

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -17,3 +17,10 @@
     local-name: jsk-ros-pkg/jsk_demos/jsk_maps
     uri: https://github.com/tork-a/jsk_demos-release/archive/release/melodic/jsk_maps/0.0.5-1.tar.gz
     version: jsk_demos-release-release-melodic-jsk_maps-0.0.5-1
+# use naoqi_pose, wait for melodic release https://github.com/ros-naoqi/naoqi_bridge/issues/94
+# use naoqi_apps, wait for merge https://github.com/ros-naoqi/naoqi_bridge/pull/95 & https://github.com/ros-naoqi/naoqi_bridge/pull/96
+# see https://github.com/jsk-ros-pkg/jsk_robot/pull/1718
+- git:
+   local-name: naoqi_bridge
+   uri: https://github.com/kochigami/naoqi_bridge.git
+   version: kochigami-develop

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -21,6 +21,9 @@
 - git:
    uri: https://github.com/ros-naoqi/nao_interaction.git
    local-name: ros-naoqi/nao_interaction
+- git: # use naoqi_apps launch files, which are only available in kochigami-develop.
+   uri: https://github.com/kochigami/naoqi_bridge.git
+   version: kochigami-develop
 # jsk_fetch_startup requires fetch_ros with following PRs.
 # https://github.com/fetchrobotics/fetch_ros/pull/144
 # https://github.com/fetchrobotics/fetch_ros/pull/146

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -21,9 +21,6 @@
 - git:
    uri: https://github.com/ros-naoqi/nao_interaction.git
    local-name: ros-naoqi/nao_interaction
-- git: # use naoqi_apps launch files, which are only available in kochigami-develop.
-   uri: https://github.com/kochigami/naoqi_bridge.git
-   version: kochigami-develop
 # jsk_fetch_startup requires fetch_ros with following PRs.
 # https://github.com/fetchrobotics/fetch_ros/pull/144
 # https://github.com/fetchrobotics/fetch_ros/pull/146

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -25,9 +25,6 @@
 - git: # https://github.com/ros-naoqi/nao_robot/issues/40
    uri: https://github.com/ros-naoqi/nao_robot.git
    local-name: nao_robot
-- git: # use naoqi_pose, wait for melodic release https://github.com/ros-naoqi/naoqi_bridge/issues/94, and use naoqi_apps launch files, which are only available in kochigami-develop.
-   uri: https://github.com/kochigami/naoqi_bridge.git
-   version: kochigami-develop
 # jsk_fetch_startup requires fetch_ros with following PRs.
 # https://github.com/fetchrobotics/fetch_ros/pull/144
 # https://github.com/fetchrobotics/fetch_ros/pull/146

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -25,10 +25,9 @@
 - git: # https://github.com/ros-naoqi/nao_robot/issues/40
    uri: https://github.com/ros-naoqi/nao_robot.git
    local-name: nao_robot
-- git: # use naoqi_pose, wait for melodic release https://github.com/ros-naoqi/naoqi_bridge/issues/94
-   uri: https://github.com/ros-naoqi/naoqi_bridge-release.git
-   local-name: naoqi_pose
-   version: release/kinetic/naoqi_pose
+- git: # use naoqi_pose, wait for melodic release https://github.com/ros-naoqi/naoqi_bridge/issues/94, and use naoqi_apps launch files, which are only available in kochigami-develop.
+   uri: https://github.com/kochigami/naoqi_bridge.git
+   version: kochigami-develop
 # jsk_fetch_startup requires fetch_ros with following PRs.
 # https://github.com/fetchrobotics/fetch_ros/pull/144
 # https://github.com/fetchrobotics/fetch_ros/pull/146

--- a/.travis.rosinstall.noetic
+++ b/.travis.rosinstall.noetic
@@ -41,10 +41,9 @@
 - git: # https://github.com/ros-naoqi/nao_robot/issues/40
    uri: https://github.com/ros-naoqi/nao_robot.git
    local-name: nao_robot
-- git: # use naoqi_pose, wait for melodic release https://github.com/ros-naoqi/naoqi_bridge/issues/94
-   uri: https://github.com/ros-naoqi/naoqi_bridge-release.git
-   local-name: naoqi_pose
-   version: release/kinetic/naoqi_pose
+- git: # use naoqi_pose, wait for melodic release https://github.com/ros-naoqi/naoqi_bridge/issues/94, and use naoqi_apps launch files, which are only available in kochigami-develop.
+   uri: https://github.com/kochigami/naoqi_bridge.git
+   version: kochigami-develop
 # for drc_task_common in jsk_demos
 # jsk_control is not released in noetic
 - git:

--- a/.travis.rosinstall.noetic
+++ b/.travis.rosinstall.noetic
@@ -41,9 +41,6 @@
 - git: # https://github.com/ros-naoqi/nao_robot/issues/40
    uri: https://github.com/ros-naoqi/nao_robot.git
    local-name: nao_robot
-- git: # use naoqi_pose, wait for melodic release https://github.com/ros-naoqi/naoqi_bridge/issues/94, and use naoqi_apps launch files, which are only available in kochigami-develop.
-   uri: https://github.com/kochigami/naoqi_bridge.git
-   version: kochigami-develop
 # for drc_task_common in jsk_demos
 # jsk_control is not released in noetic
 - git:


### PR DESCRIPTION
In https://github.com/jsk-ros-pkg/jsk_robot/pull/1674, I’d like to include naoqi_apps programs such as `/launch/tablet.launch, basic_awareness.launch, background_movement.launch` to `jsk_pepper_startup.launch`,
which belong to https://github.com/kochigami/naoqi_bridge/tree/kochigami-develop and are not merged to https://github.com/ros-naoqi/naoqi_bridge because merging process of the repository is suspended.

Because these packages are not cloned when running travis test, I got the following errors. 

In the case of kinetic:
```
 <testsuite errors="0" failures="1" name="roslaunch-check_jsk_pepper_startup__ROS_IP_10.68.0.2 NAO_IP_10.68.0.3 launch_dashboard_false.launch.xml" tests="1" time="1"><testcase classname="Results" name="test_ran" status="run" time="1"><failure message="roslaunch check [/github/home/ros/ws_jsk_robot/src/jsk_robot/jsk_naoqi_robot/jsk_pepper_startup/launch/jsk_pepper_startup.launch] failed" type="" /></testcase><system-out>&lt;![CDATA[
 
... 

[/github/home/ros/ws_jsk_robot/src/jsk_robot/jsk_naoqi_robot/jsk_pepper_startup/launch/jsk_pepper_startup.launch]:
  	while processing /opt/ros/kinetic/share/naoqi_apps/launch/tablet.launch:
  Invalid roslaunch XML syntax: [Errno 2] No such file or directory: u'/opt/ros/kinetic/share/naoqi_apps/launch/tablet.launch'
  ]]&gt;</system-out></testsuite>
```

I learned that naoqi_bridge release from https://github.com/ros-naoqi/naoqi_bridge-release stopped at kinetic.
However, in this case, I’d like to git clone https://github.com/kochigami/naoqi_bridge/tree/kochigami-develop, not https://github.com/ros-naoqi/naoqi_bridge.

I’m not familiar with travis, so if you have any comments, please let me know.
I apologize and thanks in advance.