### PR TITLE
[jsk_robot_startup] Support manual setting of the name of mongodb database and collection

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -1,4 +1,8 @@
 <launch>
+  <!-- mongo setting -->
+  <arg name="database" default="jsk_robot_lifelog" />
+  <arg name="collection" default="null" />
+
   <!-- options -->
   <arg name="save_rgb" default="true" />
   <arg name="save_depth" default="true" />
@@ -33,8 +37,9 @@
   <machine if="$(arg localhost)" name="localhost" address="localhost" />
 
   <!-- nodelet -->
+  <arg name="ns" default="lifelog" />
   <arg name="launch_manager" default="true" />
-  <arg     if="$(arg launch_manager)" name="manager" default="mongodb_record_nodelet_manager" />
+  <arg     if="$(arg launch_manager)" name="manager" default="mongodb_$(arg ns)_nodelet_manager" />
   <arg unless="$(arg launch_manager)" name="manager" />
 
   <!-- others -->
@@ -53,7 +58,7 @@
         pkg="nodelet" type="nodelet" args="manager" machine="$(arg machine)"
         output="screen" respawn="$(arg respawn)" launch-prefix="$(arg launch-prefix)"/>
 
-  <group ns="lifelog">
+  <group ns="$(arg ns)">
     <!-- image throttle -->
     <group if="$(arg save_rgb)">
       <group if="$(arg save_depth)">
@@ -132,6 +137,8 @@
             respawn="$(arg respawn)">
         <remap from="~input" to="rgb/$(arg rgb_topic)$(arg rgb_suffix)" />
         <rosparam subst_value="true">
+          database: $(arg database)
+          collection: $(arg collection)
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg camera_ns)/$(arg rgb_ns)/$(arg rgb_topic)
           vital_check: $(arg vital_check)
@@ -144,6 +151,8 @@
             respawn="$(arg respawn)">
         <remap from="~input" to="rgb/$(arg camera_info_topic)" />
         <rosparam subst_value="true">
+          database: $(arg database)
+          collection: $(arg collection)
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg camera_ns)/$(arg rgb_ns)/$(arg rgb_topic)
           vital_check: $(arg vital_check)
@@ -158,6 +167,8 @@
             respawn="$(arg respawn)">
         <remap from="~input" to="depth/$(arg depth_topic)$(arg depth_suffix)" />
         <rosparam subst_value="true">
+          database: $(arg database)
+          collection: $(arg collection)
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg camera_ns)/$(arg depth_ns)/$(arg depth_topic)
           vital_check: $(arg vital_check)
@@ -170,6 +181,8 @@
             respawn="$(arg respawn)">
         <remap from="~input" to="depth/$(arg camera_info_topic)" />
         <rosparam subst_value="true">
+          database: $(arg database)
+          collection: $(arg collection)
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg camera_ns)/$(arg depth_ns)/$(arg depth_topic)
           vital_check: $(arg vital_check)
@@ -184,6 +197,8 @@
           respawn="$(arg respawn)"
           if="$(arg save_tf)">
       <rosparam subst_value="true">
+        database: $(arg database)
+        collection: $(arg collection)
         update_rate: $(arg log_rate)
       </rosparam>
     </node>
@@ -205,6 +220,8 @@
             respawn="$(arg respawn)">
         <remap from="~input" to="joint_states_throttle/output" />
         <rosparam subst_value="true">
+          database: $(arg database)
+          collection: $(arg collection)
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg joint_states_topic)
           vital_check: $(arg vital_check)
@@ -243,6 +260,8 @@
           machine="$(arg machine)"
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
+        database: $(arg database)
+        collection: $(arg collection)
         update_rate: $(arg log_rate)
         map_frame: $(arg map_frame_id)
         robot_frame: $(arg base_frame_id)
@@ -256,6 +275,8 @@
           machine="$(arg machine)"
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
+        database: $(arg database)
+        collection: $(arg collection)
         map_frame: $(arg map_frame_id)
         robot_frame: $(arg base_frame_id)
       </rosparam>
@@ -266,7 +287,12 @@
           name="action_logger"
           pkg="jsk_robot_startup" type="action_logger.py"
           machine="$(arg machine)"
-          respawn="$(arg respawn)" />
+          respawn="$(arg respawn)">
+      <rosparam subst_value="true">
+        database: $(arg database)
+        collection: $(arg collection)
+      </rosparam>
+    </node>
 
     <!-- app manager -->
     <node if="$(arg save_app)"
@@ -275,6 +301,8 @@
           machine="$(arg machine)"
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
+        database: $(arg database)
+        collection: $(arg collection)
         subst_param: true
         topics:
         - /${param /robot/name}/app_list

--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- mongo setting -->
   <arg name="database" default="jsk_robot_lifelog" />
-  <arg name="collection" default="null" />
+  <arg name="collection" default="" />
 
   <!-- options -->
   <arg name="save_rgb" default="true" />
@@ -138,10 +138,12 @@
         <remap from="~input" to="rgb/$(arg rgb_topic)$(arg rgb_suffix)" />
         <rosparam subst_value="true">
           database: $(arg database)
-          collection: $(arg collection)
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg camera_ns)/$(arg rgb_ns)/$(arg rgb_topic)
           vital_check: $(arg vital_check)
+        </rosparam>
+        <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+          collection: $(arg collection)
         </rosparam>
       </node>
       <node name="rgb_camera_info_logger"
@@ -152,10 +154,12 @@
         <remap from="~input" to="rgb/$(arg camera_info_topic)" />
         <rosparam subst_value="true">
           database: $(arg database)
-          collection: $(arg collection)
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg camera_ns)/$(arg rgb_ns)/$(arg rgb_topic)
           vital_check: $(arg vital_check)
+        </rosparam>
+        <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+          collection: $(arg collection)
         </rosparam>
       </node>
     </group>
@@ -168,10 +172,12 @@
         <remap from="~input" to="depth/$(arg depth_topic)$(arg depth_suffix)" />
         <rosparam subst_value="true">
           database: $(arg database)
-          collection: $(arg collection)
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg camera_ns)/$(arg depth_ns)/$(arg depth_topic)
           vital_check: $(arg vital_check)
+        </rosparam>
+        <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+          collection: $(arg collection)
         </rosparam>
       </node>
       <node name="depth_camera_info_logger"
@@ -182,10 +188,12 @@
         <remap from="~input" to="depth/$(arg camera_info_topic)" />
         <rosparam subst_value="true">
           database: $(arg database)
-          collection: $(arg collection)
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg camera_ns)/$(arg depth_ns)/$(arg depth_topic)
           vital_check: $(arg vital_check)
+        </rosparam>
+        <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+          collection: $(arg collection)
         </rosparam>
       </node>
     </group>
@@ -198,8 +206,10 @@
           if="$(arg save_tf)">
       <rosparam subst_value="true">
         database: $(arg database)
-        collection: $(arg collection)
         update_rate: $(arg log_rate)
+      </rosparam>
+      <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+        collection: $(arg collection)
       </rosparam>
     </node>
 
@@ -212,8 +222,10 @@
         <remap from="~input" to="/$(arg joint_states_topic)" />
         <rosparam subst_value="true">
           database: $(arg database)
-          collection: $(arg collection)
           periodic_rate: $(arg log_rate)
+        </rosparam>
+        <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+          collection: $(arg collection)
         </rosparam>
       </node>
       <node name="joint_states_logger"
@@ -223,10 +235,12 @@
         <remap from="~input" to="joint_states_throttle/output" />
         <rosparam subst_value="true">
           database: $(arg database)
-          collection: $(arg collection)
           enable_monitor: $(arg enable_monitor)
           monitor_topic: /$(arg joint_states_topic)
           vital_check: $(arg vital_check)
+        </rosparam>
+        <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+          collection: $(arg collection)
         </rosparam>
       </node>
     </group>
@@ -238,11 +252,13 @@
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
         database: $(arg database)
-        collection: $(arg collection)
         topics:
         - /server_name/smach/container_init
         - /server_name/smach/container_status
         - /server_name/smach/container_structure
+      </rosparam>
+      <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+        collection: $(arg collection)
       </rosparam>
     </node>
 
@@ -253,9 +269,11 @@
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
         database: $(arg database)
-        collection: $(arg collection)
         topics:
         - /Tablet/voice
+      </rosparam>
+      <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+        collection: $(arg collection)
       </rosparam>
     </node>
 
@@ -267,10 +285,12 @@
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
         database: $(arg database)
-        collection: $(arg collection)
         update_rate: $(arg log_rate)
         map_frame: $(arg map_frame_id)
         robot_frame: $(arg base_frame_id)
+      </rosparam>
+      <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+        collection: $(arg collection)
       </rosparam>
     </node>
 
@@ -282,9 +302,11 @@
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
         database: $(arg database)
-        collection: $(arg collection)
         map_frame: $(arg map_frame_id)
         robot_frame: $(arg base_frame_id)
+      </rosparam>
+      <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+        collection: $(arg collection)
       </rosparam>
     </node>
 
@@ -296,6 +318,8 @@
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
         database: $(arg database)
+      </rosparam>
+      <rosparam subst_value="true" if="$(eval arg('collection') != '')">
         collection: $(arg collection)
       </rosparam>
     </node>
@@ -308,10 +332,12 @@
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
         database: $(arg database)
-        collection: $(arg collection)
         subst_param: true
         topics:
         - /${param /robot/name}/app_list
+      </rosparam>
+      <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+        collection: $(arg collection)
       </rosparam>
     </node>
 

--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -211,6 +211,8 @@
             respawn="$(arg respawn)">
         <remap from="~input" to="/$(arg joint_states_topic)" />
         <rosparam subst_value="true">
+          database: $(arg database)
+          collection: $(arg collection)
           periodic_rate: $(arg log_rate)
         </rosparam>
       </node>
@@ -235,6 +237,8 @@
           machine="$(arg machine)"
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
+        database: $(arg database)
+        collection: $(arg collection)
         topics:
         - /server_name/smach/container_init
         - /server_name/smach/container_status
@@ -248,6 +252,8 @@
           machine="$(arg machine)"
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
+        database: $(arg database)
+        collection: $(arg collection)
         topics:
         - /Tablet/voice
       </rosparam>

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/action_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/action_logger.py
@@ -22,7 +22,10 @@ class ActionLogger(LoggerBase):
     subscribers = {} # topicname:subscriber
 
     def __init__(self):
-        LoggerBase.__init__(self)
+        db_name = rospy.get_param('~database', 'jsk_robot_lifelog')
+        col_name = rospy.get_param('~collection', None)
+
+        super(ActionLogger, self).__init__(db_name=db_name, col_name=col_name)
 
         self.queue_size = rospy.get_param("~queue_size", 30)
         self.action_regex = re.compile(".*Action(Result|Goal|Feedback)$")

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/base_trajectory_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/base_trajectory_logger.py
@@ -31,7 +31,11 @@ def diff_pose(p1, p2):
 
 class BaseTrajectoryLogger(LoggerBase):
     def __init__(self):
-        LoggerBase.__init__(self)
+        db_name = rospy.get_param('~database', 'jsk_robot_lifelog')
+        col_name = rospy.get_param('~collection', None)
+
+        super(BaseTrajectoryLogger, self).__init__(db_name=db_name, col_name=col_name)
+
         self.update_rate = rospy.get_param("~update_rate", 1.0)
         self.use_amcl = rospy.get_param("~use_amcl", True)
         self.persistent = rospy.get_param("~persistent", True)

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/mongo_record.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/mongo_record.py
@@ -20,6 +20,7 @@ class MongoRecord(LoggerBase):
             self.queue_size = rospy.get_param("~queue_size", 1)
             self.update_rate = rospy.get_param("~update_rate", 1.0)
             subst_param = rospy.get_param("~subst_param", False)
+            database = rospy.get_param("~database", 'jsk_robot_lifelog')
             collection = rospy.get_param("~collection", None)
         else:
             args = self.parse_args(argv)
@@ -28,6 +29,7 @@ class MongoRecord(LoggerBase):
             self.queue_size = args.queue_size
             self.update_rate = args.update_rate
             subst_param = args.subst_param
+            database = args.database
             collection = args.collection
         self.subscribers = {}
 
@@ -42,7 +44,7 @@ class MongoRecord(LoggerBase):
                 topics.append(str().join(splitted))
             self.topics = topics
 
-        LoggerBase.__init__(self, col_name=collection)
+        LoggerBase.__init__(self, db_name=database, col_name=collection)
 
     def parse_args(self, argv):
         p = argparse.ArgumentParser()
@@ -57,6 +59,8 @@ class MongoRecord(LoggerBase):
                        help="Enable substring param (e,g, '$(param robot/name)/list')")
         p.add_argument("-r", "--update-rate", type=float, default=1.0,
                        help="Update rate for checking topics")
+        p.add_argument("-d", "--database", type=str, default=None,
+                       help="Database name to record data")
         p.add_argument("-c", "--collection", type=str, default=None,
                        help="Collection name to record data")
         return p.parse_args(argv)

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/object_detection_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/object_detection_logger.py
@@ -16,7 +16,11 @@ from .transformations import TransformListener
 
 class ObjectDetectionLogger(LoggerBase):
     def __init__(self):
-        LoggerBase.__init__(self)
+        db_name = rospy.get_param('~database', 'jsk_robot_lifelog')
+        col_name = rospy.get_param('~collection', None)
+
+        super(ObjectDetectionLogger, self).__init__(db_name=db_name, col_name=col_name)
+        
         self.update_rate = rospy.get_param("~update_rate", 1.0)
         self.map_frame = rospy.get_param('~map_frame', 'map')
         self.robot_frame = rospy.get_param('~robot_frame', 'base_footprint')

--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/tf_logger.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/tf_logger.py
@@ -13,7 +13,10 @@ from .logger_base import LoggerBase
 
 class TFLogger(LoggerBase):
     def __init__(self):
-        LoggerBase.__init__(self)
+        db_name = rospy.get_param('~database', 'jsk_robot_lifelog')
+        col_name = rospy.get_param('~collection', None)
+
+        super(TFLogger, self).__init__(db_name=db_name, col_name=col_name)
 
         self.tf_buffer = tf2_ros.Buffer()
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)

--- a/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp
+++ b/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp
@@ -51,7 +51,7 @@ namespace jsk_robot_startup
       // settings for database
       if (ros::param::has("~database"))
       {
-        pnh_->param<std::string>("~database", db_name_, "jsk_robot_lifelog");
+        pnh_->param<std::string>("database", db_name_, "jsk_robot_lifelog");
       }
       else
       {
@@ -59,7 +59,7 @@ namespace jsk_robot_startup
       }
       if (ros::param::has("~collection"))
       {
-        pnh_->param<std::string>("~collection", col_name_, std::string());
+        pnh_->param<std::string>("collection", col_name_, std::string());
       }
       else
       {

--- a/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp
+++ b/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp
@@ -49,8 +49,23 @@ namespace jsk_robot_startup
       jsk_topic_tools::StealthRelay::onInit();
 
       // settings for database
-      nh_->param<std::string>("/robot/database", db_name_, "jsk_robot_lifelog");
-      nh_->param<std::string>("/robot/name", col_name_, std::string());
+      if (ros::param::has("~database"))
+      {
+        pnh_->param<std::string>("~database", db_name_, "jsk_robot_lifelog");
+      }
+      else
+      {
+        pnh_->param<std::string>("/robot/database", db_name_, "jsk_robot_lifelog");
+      }
+      if (ros::param::has("~collection"))
+      {
+        pnh_->param<std::string>("~collection", col_name_, std::string());
+      }
+      else
+      {
+        pnh_->param<std::string>("/robot/name", col_name_, std::string());
+      }
+
       if (col_name_.empty())
       {
         NODELET_FATAL_STREAM("Please specify param 'robot/name' (e.g. pr1012, olive)");
@@ -123,7 +138,7 @@ namespace jsk_robot_startup
 
       // The message store object is initialized here, since the object waits for connection
       // until the connection to the server is established.
-      msg_store_.reset(new mongodb_store::MessageStoreProxy(*nh_, col_name_, db_name_));
+      msg_store_.reset(new mongodb_store::MessageStoreProxy(*pnh_, col_name_, db_name_));
       initialized_ = true;
 
       // After message store object is initialized, this thread is re-used for


### PR DESCRIPTION
This PR supports launching multiple `common_logger.launch` .
Related to #1706 #1714

Use case:
- Divide database dependent on each demonstration. (kitchen demo, PR2 fridge demo, etc)
- Able to change database name and collection name.

cc: @knorth55 