### PR TITLE
jsk_robot_startup: python3 support

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
+++ b/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
@@ -140,6 +140,14 @@ endif()
 install(DIRECTORY lifelog util launch images config cfg
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS)
+file(GLOB_RECURSE SCRIPT_PROGRAMS lifelog/*)
+foreach(SCRIPT_PROGRAM ${SCRIPT_PROGRAMS})
+  if("${SCRIPT_PROGRAM}" MATCHES ".*\\.py$")
+    catkin_install_python(PROGRAMS ${SCRIPT_PROGRAM} DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+  else()
+    install(PROGRAMS ${SCRIPT_PROGRAM} DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+  endif()
+endforeach()
 
 if(mongodb_store_FOUND)
 install(TARGETS jsk_robot_lifelog

--- a/jsk_robot_common/jsk_robot_startup/package.xml
+++ b/jsk_robot_common/jsk_robot_startup/package.xml
@@ -32,6 +32,12 @@
   <exec_depend>nodelet</exec_depend>
   <exec_depend>pointcloud_to_laserscan</exec_depend>
   <exec_depend>posedetection_msgs</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-bson</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-bson</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-pymongo</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pymongo</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-tz</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-tz</exec_depend>
   <exec_depend>rosbridge_server</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>roseus_mongo</exec_depend>

--- a/jsk_robot_common/jsk_robot_startup/package.xml
+++ b/jsk_robot_common/jsk_robot_startup/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
   <name>jsk_robot_startup</name>
   <version>1.1.0</version>
   <description>The jsk_robot_startup package</description>
@@ -19,33 +19,33 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>urdf</build_depend>
-  <run_depend>actionlib_msgs</run_depend>
-  <run_depend>app_manager</run_depend>
-  <run_depend>dynamic_reconfigure</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>gmapping</run_depend>
-  <run_depend>google_chat_ros</run_depend>
-  <run_depend>jsk_recognition_msgs</run_depend>
-  <run_depend version_gte="2.2.7">jsk_topic_tools</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>mongodb_store</run_depend>
-  <run_depend>nodelet</run_depend>
-  <run_depend>pointcloud_to_laserscan</run_depend>
-  <run_depend>posedetection_msgs</run_depend>
-  <run_depend>rosbridge_server</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>roseus_mongo</run_depend>
-  <run_depend>rosgraph</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>rostwitter</run_depend>
-  <run_depend>roswww</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>tf2_ros</run_depend>
-  <run_depend>tf2_py</run_depend>
-  <run_depend>tf2_geometry_msgs</run_depend>
-  <run_depend>urdf</run_depend>
-  <run_depend>jsk_tilt_laser</run_depend>
+  <exec_depend>actionlib_msgs</exec_depend>
+  <exec_depend>app_manager</exec_depend>
+  <exec_depend>dynamic_reconfigure</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>gmapping</exec_depend>
+  <exec_depend>google_chat_ros</exec_depend>
+  <exec_depend>jsk_recognition_msgs</exec_depend>
+  <exec_depend version_gte="2.2.7">jsk_topic_tools</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>mongodb_store</exec_depend>
+  <exec_depend>nodelet</exec_depend>
+  <exec_depend>pointcloud_to_laserscan</exec_depend>
+  <exec_depend>posedetection_msgs</exec_depend>
+  <exec_depend>rosbridge_server</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>roseus_mongo</exec_depend>
+  <exec_depend>rosgraph</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>rostwitter</exec_depend>
+  <exec_depend>roswww</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>tf</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>tf2_py</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
+  <exec_depend>urdf</exec_depend>
+  <exec_depend>jsk_tilt_laser</exec_depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>pr2_gazebo</test_depend>


### PR DESCRIPTION
-   jsk_robot_startup/CMakeLists.txt: install python code using catkin_install_python
-    jsk_robot_startup/package.xml: update to version 3, add python3-* packages to exec_depend

if you want to use jsk_robot_startup, specially `lifelog` with melodic environment compiled with `-DPYTHON_EXECUTABLE=/usr/bin/python3 `,  you need to instal following packages from source
```
#
# mongodb_store need to be built for python3
- git:
    local-name: mongodb_store
    uri: https://github.com/strands-project/mongodb_store.git
    version: noetic-devel
#
# to avtivate python_catkin_install, we need newer catkin
- git:
    local-name: catkin
    uri:     https://github.com/ros/catkin.git
    version: 0.8.10
```

part of https://github.com/jsk-ros-pkg/jsk_robot/pull/1701
