### PR TITLE
[wait for upstream] control tweet speak volume by dynamic reconfigure

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client.l
@@ -34,7 +34,8 @@
  (t
   (setq *waking-target-second* *waking-tweet-second*)))
 
-(defun tweet-string (twit-str &key (warning-time) (with-image) (image-wait 30) (speak t))
+(defun tweet-string (twit-str &key (warning-time) (with-image) (image-wait 30) (speak t)
+                              (volume 1.0))
   (let (prev-image-topic img)
   (when warning-time
     (unless (numberp warning-time)
@@ -53,7 +54,8 @@
                           (8 "はち")
                           (9 "きゅう")
                           (10 "じゅう")
-                          (t "じゅういじょう")))))
+                          (t "じゅういじょう")))
+                :volume volume))
     (unix::sleep warning-time))
 
   (cond
@@ -89,5 +91,5 @@
       (ros::service-call "/tweet_image_mux/select" (instance topic_tools::muxselectrequest :init :topic prev-image-topic)))
     (t
       (ros::publish "/tweet" (instance std_msgs::String :init :data twit-str))))
-  (when speak (speak-jp "ついーとしました" :wait t))))
+  (when speak (speak-jp "ついーとしました" :wait t :volume volume))))
 

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_tablet.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_tablet.l
@@ -3,13 +3,26 @@
 (ros::roseus "twitter_client_tablet")
 (ros::roseus-add-msgs "roseus")
 
+(load "package://roseus/euslisp/dynamic-reconfigure-server.l")
 (load "package://jsk_robot_startup/lifelog/tweet_client.l")
+
+(setq *volume* (ros::get-param "~volume" 1.0))
+(setq *reconfigure-server*
+      (def-dynamic-reconfigure-server
+        ;;; ((name type level description (default) (min) (max) (edit_method)) ... )
+        (("volume"  double_t  0  "tweet speak volume" 1.0  0.0 1.0))
+        ;; use lamda-closure to avoid memory error
+        '(lambda-closure nil 0 0 (cfg level)
+            (setq *volume* (cdr (assoc "volume" cfg :test #'equal)))
+            (ros::ros-warn "Volume changed to: ~A" *volume*)
+            cfg)))
 
 (defun twit-cb (msg)
   (let ((twit-str (send msg :data)))
     (tweet-string twit-str
                   :warning-time nil
-                  :with-image "/tablet/marked/image_rect_color")))
+                  :with-image "/tablet/marked/image_rect_color"
+                  :volume *volume*)))
 (ros::subscribe "/pr2twit_from_tablet" roseus::StringStamped #'twit-cb)
 
 (ros::spin)

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_uptime.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_uptime.l
@@ -2,6 +2,7 @@
 
 (ros::roseus "twitter_client_uptime")
 
+(load "package://roseus/euslisp/dynamic-reconfigure-server.l")
 (load "package://jsk_robot_startup/lifelog/tweet_client.l")
 
 (setq *src-lines* nil)
@@ -11,6 +12,17 @@
 (when (ros::has-param "/active_user/robot_name")
   (setq *robot-name* (ros::get-param "/active_user/robot_name"))
   )
+
+(setq *volume* (ros::get-param "~volume" 1.0))
+(setq *reconfigure-server*
+      (def-dynamic-reconfigure-server
+        ;;; ((name type level description (default) (min) (max) (edit_method)) ... )
+        (("volume"  double_t  0  "tweet speak volume" 1.0  0.0 1.0))
+        ;; use lamda-closure to avoid memory error
+        '(lambda-closure nil 0 0 (cfg level)
+            (setq *volume* (cdr (assoc "volume" cfg :test #'equal)))
+            (ros::ros-warn "Volume changed to: ~A" *volume*)
+            cfg)))
 
 (ros::rate 0.1)
 (do-until-key
@@ -55,8 +67,10 @@
                 (incf pos (length s))
                 (if (< pos (- ln 2)) (setf (elt dt pos) 10))
                 (incf pos))
-              (tweet-string dt :warning-time 1 :with-image t)
+              (tweet-string dt :warning-time 1 :with-image t
+                            :volume *volume*)
               ))
           ))))
+  (ros::spin-once)
   (ros::sleep)
   )

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_warning.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_warning.l
@@ -2,8 +2,20 @@
 
 (ros::roseus "twitter_client_warning")
 
+(load "package://roseus/euslisp/dynamic-reconfigure-server.l")
 (load "package://jsk_robot_startup/lifelog/tweet_client.l")
 (ros::load-ros-manifest "diagnostic_msgs")
+
+(setq *volume* (ros::get-param "~volume" 1.0))
+(setq *reconfigure-server*
+      (def-dynamic-reconfigure-server
+        ;;; ((name type level description (default) (min) (max) (edit_method)) ... )
+        (("volume"  double_t  0  "tweet speak volume" 1.0  0.0 1.0))
+        ;; use lamda-closure to avoid memory error
+        '(lambda-closure nil 0 0 (cfg level)
+            (setq *volume* (cdr (assoc "volume" cfg :test #'equal)))
+            (ros::ros-warn "Volume changed to: ~A" *volume*)
+            cfg)))
 
 (defun diagnostics-cb (msg)
   (let ((diagnostics (make-hash-table :test #'equal))
@@ -34,7 +46,7 @@
       (setq id (random (length status)))
       (when (= (mod (round (send tm :sec)) 1000) 0)
         (tweet-string (format nil "Warning!! ~A is ~A at ~0,3f" (car (elt status id)) (cdr (elt status id)) (send tm :to-sec))
-                      :warning-time 1 :with-image t)
+                      :warning-time 1 :with-image t :volume *volume*)
 	)) ;; when
     )) ;; let
 

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_worktime.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_worktime.l
@@ -2,12 +2,24 @@
 
 (ros::roseus "twitter_client_worktime")
 
+(load "package://roseus/euslisp/dynamic-reconfigure-server.l")
 (load "package://jsk_robot_startup/lifelog/tweet_client.l")
 
 (defvar *robot-name* "robot")
 (when (ros::has-param "/active_user/robot_name")
   (setq *robot-name* (ros::get-param "/active_user/robot_name"))
   )
+
+(setq *volume* (ros::get-param "~volume" 1.0))
+(setq *reconfigure-server*
+      (def-dynamic-reconfigure-server
+        ;;; ((name type level description (default) (min) (max) (edit_method)) ... )
+        (("volume"  double_t  0  "tweet speak volume" 1.0  0.0 1.0))
+        ;; use lamda-closure to avoid memory error
+        '(lambda-closure nil 0 0 (cfg level)
+            (setq *volume* (cdr (assoc "volume" cfg :test #'equal)))
+            (ros::ros-warn "Volume changed to: ~A" *volume*)
+            cfg)))
 
 (ros::rate 0.1)
 (do-until-key
@@ -49,8 +61,10 @@
               postsubstr ", Got some rest?")))
 
       (tweet-string (format nil "~A~A~A" presubstr mainstr postsubstr)
-                    :warning-time 1 :with-image t)
+                    :warning-time 1 :with-image t
+                    :volume *volume*)
 
       ))
+  (ros::spin-once)
   (ros::sleep)
   )


### PR DESCRIPTION
this PR needs https://github.com/jsk-ros-pkg/jsk_roseus/pull/729 .

this PR changes to control `volume` `tweet` nodes by `dynamic_reconfigure`.

related to #1724 