### PR TITLE
[jsk_fetch_startup] [jsk_robot_startup] Use demo-based mongodb logging in kitchen-demo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -43,7 +43,8 @@
     <arg name="save_tf" value="true" />
     <arg name="save_joint_states" value="true" />
     <arg name="save_base_trajectory" value="true" />
-    <arg name="save_object_detection" value="false" />
+    <arg name="save_object_detection" value="true" />
+    <arg name="save_edgetpu_object_detector" value="true" />
     <arg name="save_speech" value="true" />
     <arg name="save_action" value="true" />
     <arg name="save_smach" value="true" />

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -28,4 +28,31 @@
     <env name="HOME" value="/home/fetch" />
   </node>
 
+  <!-- logging database for go_to_kitchen -->
+  <arg name="map_frame" default="map" />
+  <include file="$(find jsk_robot_startup)/lifelog/common_logger.launch">
+    <arg name="ns" value="go_to_kitchen" />
+    <arg name="database" value="jsk_robot_lifelog" />
+    <arg name="collection" value="go_to_kitchen" />
+    <arg name="save_rgb" value="true" />
+    <arg name="camera_ns" default="head_camera" />
+    <arg name="rgb_ns" value="rgb/half" />
+    <arg name="rgb_topic" default="image_rect_color" />
+    <arg name="rgb_suffix" default="/compressed"/>
+    <arg name="save_depth" value="false" />
+    <arg name="save_tf" value="true" />
+    <arg name="save_joint_states" value="true" />
+    <arg name="save_base_trajectory" value="false" />
+    <arg name="save_object_detection" value="false" />
+    <arg name="save_action" value="true" />
+    <arg name="save_smach" value="true" />
+    <arg name="save_app" value="true" />
+    <arg name="enable_monitor" value="false" />
+    <arg name="log_rate" value="1.0" />
+    <arg name="launch_manager" value="true" />
+    <arg name="map_frame_id" value="$(arg map_frame)" />
+    <arg name="approximate_sync" value="true"/>
+    <arg name="base_frame_id" value="base_link" />
+  </include>
+
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -35,11 +35,13 @@
     <arg name="database" value="jsk_robot_lifelog" />
     <arg name="collection" value="go_to_kitchen" />
     <arg name="save_rgb" value="true" />
-    <arg name="camera_ns" default="head_camera" />
+    <arg name="camera_ns" value="head_camera" />
     <arg name="rgb_ns" value="rgb/half" />
-    <arg name="rgb_topic" default="image_rect_color" />
-    <arg name="rgb_suffix" default="/compressed"/>
+    <arg name="rgb_topic" value="image_rect_color" />
+    <arg name="rgb_suffix" value="/compressed"/>
     <arg name="save_depth" value="true" />
+    <arg name="depth_topic" value="image" />
+    <arg name="depth_suffix" value="/compressedDepth"/>
     <arg name="save_tf" value="true" />
     <arg name="save_joint_states" value="true" />
     <arg name="save_base_trajectory" value="true" />

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -42,17 +42,26 @@
     <arg name="save_depth" value="false" />
     <arg name="save_tf" value="true" />
     <arg name="save_joint_states" value="true" />
-    <arg name="save_base_trajectory" value="false" />
+    <arg name="save_base_trajectory" value="true" />
     <arg name="save_object_detection" value="false" />
+    <arg name="save_speech" value="true" />
     <arg name="save_action" value="true" />
     <arg name="save_smach" value="true" />
     <arg name="save_app" value="true" />
+    <arg name="save_human_pose" default="true" />
     <arg name="enable_monitor" value="false" />
     <arg name="log_rate" value="1.0" />
     <arg name="launch_manager" value="true" />
     <arg name="map_frame_id" value="$(arg map_frame)" />
     <arg name="approximate_sync" value="true"/>
     <arg name="base_frame_id" value="base_link" />
+    <arg name="vital_check" value="true" />
   </include>
+
+  <rosparam ns="go_to_kitchen/speech_logger">
+    topics:
+    - /sound_play/goal
+    - /speech_to_text
+  </rosparam>
 
 </launch>

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/go_to_kitchen/go_to_kitchen.xml
@@ -39,7 +39,7 @@
     <arg name="rgb_ns" value="rgb/half" />
     <arg name="rgb_topic" default="image_rect_color" />
     <arg name="rgb_suffix" default="/compressed"/>
-    <arg name="save_depth" value="false" />
+    <arg name="save_depth" value="true" />
     <arg name="save_tf" value="true" />
     <arg name="save_joint_states" value="true" />
     <arg name="save_base_trajectory" value="true" />

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -49,6 +49,7 @@
 
   <!-- lifelog -->
   <arg name="launch_fetch_lifelog" default="true" />
+  <arg name="extra_collections" default="[go_to_kitchen]" />
 
   <arg name="hostname" default="fetch15" />
   <arg name="use_voice_text" default="false" />
@@ -137,6 +138,7 @@
            if="$(arg launch_fetch_lifelog)">
     <arg name="map_frame" value="$(arg map_frame)" />
     <arg name="vital_check" value="false" />
+    <arg name="extra_collections" value="$(arg extra_collections)" />
   </include>
 
   <!-- diagnostic aggregator -->

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
@@ -31,6 +31,7 @@
     <arg name="save_object_detection" value="false" />
     <arg name="save_speech" value="true" />
     <arg name="save_action" value="true" />
+    <arg name="save_human_pose" default="true" />
     <arg name="camera_ns" value="head_camera" />
     <arg name="enable_monitor" value="false" />
     <arg name="log_rate" value="1.0" />

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
@@ -2,6 +2,7 @@
   <arg name="use_system_mongod" default="true" />
   <arg name="map_frame" default="map" />
   <arg name="vital_check" default="false" />
+  <arg name="extra_collections" default="[go_to_kitchen]" />
 
   <include file="$(find jsk_fetch_startup)/jsk_fetch.machine" />
 
@@ -11,11 +12,13 @@
     <arg name="use_daemon" value="true"/>
     <arg name="port" value="27017" />
     <arg name="repl_set_mode" value="false" />
+    <arg name="extra_collections" value="$(arg extra_collections)" />
   </include>
   <include file="$(find jsk_robot_startup)/lifelog/mongodb.launch"
            unless="$(arg use_system_mongod)">
     <arg name="use_daemon" value="false"/>
     <arg name="repl_set_mode" value="false" />
+    <arg name="extra_collections" value="$(arg extra_collections)" />
   </include>
 
   <include file="$(find jsk_robot_startup)/lifelog/common_logger.launch">

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
@@ -29,6 +29,7 @@
     <arg name="save_joint_states" value="true" />
     <arg name="save_base_trajectory" value="true" />
     <arg name="save_object_detection" value="false" />
+    <arg name="save_speech" value="true" />
     <arg name="save_action" value="true" />
     <arg name="camera_ns" value="head_camera" />
     <arg name="enable_monitor" value="false" />
@@ -39,6 +40,12 @@
     <arg name="base_frame_id" value="base_link" />
     <arg name="vital_check" value="$(arg vital_check)" />
   </include>
+
+  <rosparam ns="lifelog/speech_logger">
+    topics:
+    - /sound_play/goal
+    - /speech_to_text
+  </rosparam>
 
   <rosparam ns="lifelog/joint_states_throttle">
     periodic: false

--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -14,6 +14,7 @@
   <arg name="save_smach" default="true" />
   <arg name="save_base_trajectory" default="false" />
   <arg name="save_object_detection" default="false" />
+  <arg name="save_edgetpu_object_detector" default="false" />
   <arg name="save_human_pose" default="false" />
   <arg name="save_action" default="false" />
   <arg name="save_app" default="true" />
@@ -332,20 +333,36 @@
     </node>
 
     <!-- object detection logger -->
-    <node if="$(arg save_object_detection)"
-          name="object_detection_logger"
-          pkg="jsk_robot_startup" type="object_detection_logger.py"
-          machine="$(arg machine)"
-          respawn="$(arg respawn)">
-      <rosparam subst_value="true">
-        database: $(arg database)
-        map_frame: $(arg map_frame_id)
-        robot_frame: $(arg base_frame_id)
-      </rosparam>
-      <rosparam subst_value="true" if="$(eval arg('collection') != '')">
-        collection: $(arg collection)
-      </rosparam>
-    </node>
+    <group if="$(arg save_object_detection)">
+      <node if="$(arg save_edgetpu_object_detector)"
+            name="object_detection_logger"
+            pkg="jsk_robot_startup" type="mongo_record.py"
+            machine="$(arg machine)"
+            respawn="$(arg respawn)">
+        <rosparam subst_value="true">
+          database: $(arg database)
+          topics:
+          - /edgetpu_human_pose_estimator/output/class
+        </rosparam>
+        <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+          collection: $(arg collection)
+        </rosparam>
+      </node>
+      <node unless="$(arg save_edgetpu_object_detector)"
+            name="object_detection_logger"
+            pkg="jsk_robot_startup" type="object_detection_logger.py"
+            machine="$(arg machine)"
+            respawn="$(arg respawn)">
+        <rosparam subst_value="true">
+          database: $(arg database)
+          map_frame: $(arg map_frame_id)
+          robot_frame: $(arg base_frame_id)
+        </rosparam>
+        <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+          collection: $(arg collection)
+        </rosparam>
+      </node>
+    </group>
 
     <!-- human pose logger -->
     <node if="$(arg save_human_pose)"

--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -356,6 +356,7 @@
       <rosparam subst_value="true">
         database: $(arg database)
         topics:
+        - /edgetpu_human_pose_estimator/output/class
         - /edgetpu_human_pose_estimator/output/poses
       </rosparam>
       <rosparam subst_value="true" if="$(eval arg('collection') != '')">

--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -342,7 +342,7 @@
         <rosparam subst_value="true">
           database: $(arg database)
           topics:
-          - /edgetpu_human_pose_estimator/output/class
+          - /edgetpu_object_detector/output/class
         </rosparam>
         <rosparam subst_value="true" if="$(eval arg('collection') != '')">
           collection: $(arg collection)

--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -343,6 +343,7 @@
           database: $(arg database)
           topics:
           - /edgetpu_object_detector/output/class
+          - /edgetpu_object_detector/output/rects
         </rosparam>
         <rosparam subst_value="true" if="$(eval arg('collection') != '')">
           collection: $(arg collection)
@@ -375,6 +376,7 @@
         topics:
         - /edgetpu_human_pose_estimator/output/class
         - /edgetpu_human_pose_estimator/output/poses
+        - /edgetpu_human_pose_estimator/output/rects
       </rosparam>
       <rosparam subst_value="true" if="$(eval arg('collection') != '')">
         collection: $(arg collection)

--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -9,6 +9,8 @@
   <arg name="save_tf" default="true" />
   <arg name="save_joint_states" default="true" />
   <arg name="save_speech" default="true" />
+  <arg name="save_faces" default="true" />
+  <arg name="save_dialogflow" default="true" />
   <arg name="save_smach" default="true" />
   <arg name="save_base_trajectory" default="false" />
   <arg name="save_object_detection" default="false" />
@@ -275,6 +277,32 @@
       </rosparam>
       <rosparam subst_value="true" if="$(eval arg('collection') != '')">
         collection: $(arg collection)
+      </rosparam>
+    </node>
+
+    <!-- face save aws face data -->
+    <node if="$(arg save_faces)"
+          name="face_logger"
+          pkg="jsk_robot_startup" type="mongo_record.py"
+          machine="$(arg machine)"
+          respawn="$(arg respawn)">
+      <rosparam subst_value="true">
+        topics:
+        - /aws_auto_checkin_app/class
+        - /aws_detect_faces/attributes
+      </rosparam>
+    </node>
+
+    <!-- face dialogflow I/O -->
+    <node if="$(arg save_dialogflow)"
+          name="dialogflow_logger"
+          pkg="jsk_robot_startup" type="mongo_record.py"
+          machine="$(arg machine)"
+          respawn="$(arg respawn)">
+      <rosparam subst_value="true">
+        topics:
+        - /dialogflow_client/text_action/goal
+        - /dialogflow_client/text_action/result
       </rosparam>
     </node>
 

--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -12,6 +12,7 @@
   <arg name="save_smach" default="true" />
   <arg name="save_base_trajectory" default="false" />
   <arg name="save_object_detection" default="false" />
+  <arg name="save_human_pose" default="false" />
   <arg name="save_action" default="false" />
   <arg name="save_app" default="true" />
 
@@ -304,6 +305,22 @@
         database: $(arg database)
         map_frame: $(arg map_frame_id)
         robot_frame: $(arg base_frame_id)
+      </rosparam>
+      <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+        collection: $(arg collection)
+      </rosparam>
+    </node>
+
+    <!-- human pose logger -->
+    <node if="$(arg save_human_pose)"
+          name="human_pose_logger"
+          pkg="jsk_robot_startup" type="mongo_record.py"
+          machine="$(arg machine)"
+          respawn="$(arg respawn)">
+      <rosparam subst_value="true">
+        database: $(arg database)
+        topics:
+        - /edgetpu_human_pose_estimator/output/poses
       </rosparam>
       <rosparam subst_value="true" if="$(eval arg('collection') != '')">
         collection: $(arg collection)

--- a/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/common_logger.launch
@@ -287,9 +287,13 @@
           machine="$(arg machine)"
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
+        database: $(arg database)
         topics:
         - /aws_auto_checkin_app/class
         - /aws_detect_faces/attributes
+      </rosparam>
+      <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+        collection: $(arg collection)
       </rosparam>
     </node>
 
@@ -300,9 +304,13 @@
           machine="$(arg machine)"
           respawn="$(arg respawn)">
       <rosparam subst_value="true">
+        database: $(arg database)
         topics:
         - /dialogflow_client/text_action/goal
         - /dialogflow_client/text_action/result
+      </rosparam>
+      <rosparam subst_value="true" if="$(eval arg('collection') != '')">
+        collection: $(arg collection)
       </rosparam>
     </node>
 

--- a/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
@@ -19,12 +19,14 @@
   <!-- Replication -->
   <group if="$(arg replicate)">
     <rosparam command="load" file="$(arg replicator_param_path)" />
-    <rosparam subst_value="true" if="$(eval arg('extra_collections') != '')">
-      extra_collections: $(arg extra_collections)
-    </rosparam>
+
     <node name="replication_client"
           pkg="jsk_robot_startup" type="periodic_replicator_client.py"
-          output="screen" machine="$(arg machine)"/>
+          output="screen" machine="$(arg machine)">
+      <rosparam subst_value="true" if="$(eval arg('extra_collections') != '')">
+        extra_collections: $(arg extra_collections)
+      </rosparam>
+    </node>
   </group>
 
   <!-- MongoDB -->

--- a/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
@@ -10,6 +10,7 @@
   <arg name="replicator_dump_path" default="/tmp/replicator_dumps" />
   <arg name="replicator_param_path"
        default="$(find jsk_robot_startup)/lifelog/mongodb_replication_params.yaml" />
+  <arg name="extra_collections" default="" />
 
   <arg name="test_mode" default="false" />
 
@@ -18,6 +19,9 @@
   <!-- Replication -->
   <group if="$(arg replicate)">
     <rosparam command="load" file="$(arg replicator_param_path)" />
+    <rosparam subst_value="true" if="$(eval arg('extra_collections') != '')">
+      extra_collections: $(arg extra_collections)
+    </rosparam>
     <node name="replication_client"
           pkg="jsk_robot_startup" type="periodic_replicator_client.py"
           output="screen" machine="$(arg machine)"/>

--- a/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp
+++ b/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp
@@ -49,7 +49,7 @@ namespace jsk_robot_startup
       jsk_topic_tools::StealthRelay::onInit();
 
       // settings for database
-      if (ros::param::has("~database"))
+      if (ros::param::has(pnh_->resolveName("database")))
       {
         pnh_->param<std::string>("database", db_name_, "jsk_robot_lifelog");
       }
@@ -57,7 +57,7 @@ namespace jsk_robot_startup
       {
         pnh_->param<std::string>("/robot/database", db_name_, "jsk_robot_lifelog");
       }
-      if (ros::param::has("~collection"))
+      if (ros::param::has(pnh_->resolveName("collection")))
       {
         pnh_->param<std::string>("collection", col_name_, std::string());
       }

--- a/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp
+++ b/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp
@@ -198,7 +198,9 @@ namespace jsk_robot_startup
       const boost::shared_ptr<topic_tools::ShapeShifter const>& msg = event.getConstMessage();
       jsk_topic_tools::StealthRelay::inputCallback(msg);
 
-      vital_checker_->poke();
+      if (vital_checker_ != nullptr) {
+        vital_checker_->poke();
+      }
 
       bool on_the_fly = initialized_ && buffer_.empty();
       if (!wait_for_insert_ && msg_store_->getNumInsertSubscribers() == 0) {
@@ -246,7 +248,7 @@ namespace jsk_robot_startup
       } else if (!initialized_) {
         stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR,
                      getName() + " is taking too long to be initialized");
-      } else if (vital_check_ && !vital_checker_->isAlive()) {
+      } else if (vital_checker_ != nullptr && vital_check_ && !vital_checker_->isAlive()) {
         jsk_topic_tools::addDiagnosticErrorSummary(getName(), vital_checker_, stat);
       } else if (insert_error_count_ != prev_insert_error_count_) {
         stat.summary(diagnostic_msgs::DiagnosticStatus::ERROR,
@@ -259,7 +261,9 @@ namespace jsk_robot_startup
 
       stat.add("Inserted", inserted_count_);
       stat.add("Insert Failure", insert_error_count_);
-      vital_checker_->registerStatInfo(stat, "Last Insert");
+      if (vital_checker_ != nullptr) {
+        vital_checker_->registerStatInfo(stat, "Last Insert");
+      }
     }
   } // lifelog
 } // jsk_robot_startup


### PR DESCRIPTION
With this PR, we can store `images`, `speech_to_text`, `sound_play/goal` in kitchen-demo.
We can get these data from `jsk_robot_lifelog/go_to_kitchen` data collection