### PR TITLE
[jsk_robot_startup] Fix unintended smach notification when demo fails

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -89,6 +89,7 @@ class SmachToMail():
                     self._send_twitter(
                         self.smach_state_subject[key], self.smach_state_list[key])
                     self.smach_state_subject[key] = None
+                    self.smach_state_list[key] = None
                     rospy.logwarn(
                         "SmachToMail timer publishes stop signal. Send Notification.")
 

--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -186,6 +186,7 @@ class SmachToMail():
                 if self.use_google_chat:
                     self._send_google_chat(self.smach_state_subject[caller_id], self.smach_state_list[caller_id])
                 self.smach_state_list[caller_id] = None
+                self.smach_state_subject[caller_id] = None
 
     def _send_mail(self, subject, state_list):
         email_msg = Email()


### PR DESCRIPTION
Currently, this node notifiacate every one hour when demonstration with smach fails and `finish` state is not called.
This PR fixes this unintended smach notification.

I am sorry, I mistakenly thought I have already send PR about this bug...