### PR TITLE
[jsk_robot_startup] make tweet_client.l loadable  in simulation

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client.l
@@ -6,34 +6,6 @@
 
 (load "package://pr2eus/speak.l")
 
-(ros::roseus "tweet_client")
-(ros::advertise "/tweet" std_msgs::String 1)
-
-;; next tweet timing ( x(i+1) = x(i) * 2, 5 * 60 = 300 sec)
-(while (not (ros::has-param "/active_user/elapsed_time"))
-  (unix::sleep 3)
-  (ros::ros-info "Wait for /active_user/elapsed_time parameter ..."))
-
-(cond
- ((ros::has-param "/active_user/tweet_second")
-  (setq *tweet-second* (ros::get-param "/active_user/tweet_second")))
- (t
-  (setq *tweet-second* 300)
-  ))
-
-(setq *target-second* (+ (ros::get-param "/active_user/elapsed_time")
-                         *tweet-second*))
-
-(setq *waking-tweet-second* 3600.0)
-(cond
- ((ros::has-param "/active_user/start_time")
-  (let ((st (ros::get-param "/active_user/start_time")))
-    (setq *waking-target-second*
-          (+ (- (send (ros::time-now) :to-sec) st)
-             *waking-tweet-second*))))
- (t
-  (setq *waking-target-second* *waking-tweet-second*)))
-
 (defun tweet-string (twit-str &key (warning-time) (with-image) (image-wait 30) (speak t))
   (let (prev-image-topic img)
   (when warning-time

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_tablet.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_tablet.l
@@ -10,6 +10,8 @@
     (tweet-string twit-str
                   :warning-time nil
                   :with-image "/tablet/marked/image_rect_color")))
+
+(ros::advertise "/tweet" std_msgs::String 1)
 (ros::subscribe "/pr2twit_from_tablet" roseus::StringStamped #'twit-cb)
 
 (ros::spin)

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_uptime.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_uptime.l
@@ -12,6 +12,32 @@
   (setq *robot-name* (ros::get-param "/active_user/robot_name"))
   )
 
+;; next tweet timing ( x(i+1) = x(i) * 2, 5 * 60 = 300 sec)
+(while (not (ros::has-param "/active_user/elapsed_time"))
+  (unix::sleep 3)
+  (ros::ros-info "Wait for /active_user/elapsed_time parameter ..."))
+
+(cond
+ ((ros::has-param "/active_user/tweet_second")
+  (setq *tweet-second* (ros::get-param "/active_user/tweet_second")))
+ (t
+  (setq *tweet-second* 300)
+  ))
+
+(setq *target-second* (+ (ros::get-param "/active_user/elapsed_time")
+                         *tweet-second*))
+
+(setq *waking-tweet-second* 3600.0)
+(cond
+ ((ros::has-param "/active_user/start_time")
+  (let ((st (ros::get-param "/active_user/start_time")))
+    (setq *waking-target-second*
+          (+ (- (send (ros::time-now) :to-sec) st)
+             *waking-tweet-second*))))
+ (t
+  (setq *waking-target-second* *waking-tweet-second*)))
+
+(ros::advertise "/tweet" std_msgs::String 1)
 (ros::rate 0.1)
 (do-until-key
   (setq *user-name* (ros::get-param "/active_user/launch_user_name")

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_warning.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_warning.l
@@ -38,6 +38,7 @@
 	)) ;; when
     )) ;; let
 
+(ros::advertise "/tweet" std_msgs::String 1)
 (ros::subscribe "/diagnostics_agg" diagnostic_msgs::DiagnosticArray #'diagnostics-cb)
 (ros::rate (/ 1.0 3.0))
 (while (ros::ok)

--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_worktime.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_worktime.l
@@ -9,6 +9,32 @@
   (setq *robot-name* (ros::get-param "/active_user/robot_name"))
   )
 
+;; next tweet timing ( x(i+1) = x(i) * 2, 5 * 60 = 300 sec)
+(while (not (ros::has-param "/active_user/elapsed_time"))
+  (unix::sleep 3)
+  (ros::ros-info "Wait for /active_user/elapsed_time parameter ..."))
+
+(cond
+ ((ros::has-param "/active_user/tweet_second")
+  (setq *tweet-second* (ros::get-param "/active_user/tweet_second")))
+ (t
+  (setq *tweet-second* 300)
+  ))
+
+(setq *target-second* (+ (ros::get-param "/active_user/elapsed_time")
+                         *tweet-second*))
+
+(setq *waking-tweet-second* 3600.0)
+(cond
+ ((ros::has-param "/active_user/start_time")
+  (let ((st (ros::get-param "/active_user/start_time")))
+    (setq *waking-target-second*
+          (+ (- (send (ros::time-now) :to-sec) st)
+             *waking-tweet-second*))))
+ (t
+  (setq *waking-target-second* *waking-tweet-second*)))
+
+(ros::advertise "/tweet" std_msgs::String 1)
 (ros::rate 0.1)
 (do-until-key
   (setq *user-name* (ros::get-param "/active_user/launch_user_name")


### PR DESCRIPTION
I moved `ROS` node codes from `tweet_client.l` to each nodes, and make the file loadable from non-ROS file.
this PR is useful if you want to use kinematics simulation.
if some file load `tweet_cline.l` in kinematics simulation, this part get stucks and wait `rosparam` forever.