### PR TITLE
[jsk_robot_startup] Fix variable name; *speak* -> *speak-enable*

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_warning.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client_warning.l
@@ -61,7 +61,7 @@
         (setq id (random (length status)))
         (when (= (mod (round (send tm :sec)) 1000) 0)
           (tweet-string (format nil "Warning!! ~A is ~A at ~0,3f" (car (elt status id)) (cdr (elt status id)) (send tm :to-sec))
-                        :warning-time 1 :with-image t :volume *volume* :speak *speak*)))
+                        :warning-time 1 :with-image t :volume *volume* :speak *speak-enable*)))
       )))
 
 (ros::advertise "/tweet" std_msgs::String 1)


### PR DESCRIPTION
This PR fixes a following bug.
`*speak-enable*` variable is set instead of `*speak*`, but the argument is not changed.

```lisp
[http://fetch1075:11311][133.11.216.83] tsukamoto@tsukamoto-desktop-ryzen ~/ros/fetch_ws/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup (develop/fetch *$%=) 
$ rosrun jsk_robot_startup tweet_client_warning.l _name:=warning_debug
configuring by "/home/tsukamoto/ros/fetch_ws/devel/share/euslisp/jskeus/eus//lib/eusrt.l"
;; readmacro ;; object ;; packsym ;; common ;; constants ;; stream ;; string ;; loader ;; pprint ;; process ;; hashtab ;; array ;; mathtran ;; eusdebug ;; eusforeign ;; extnum ;; conditions ;; coordinates ;; tty ;; history ;; toplevel ;; trans ;; comp ;; builtins ;; par ;; intersection ;; geoclasses ;; geopack ;; geobody ;; primt ;; compose ;; polygon ;; viewing ;; viewport ;; viewsurface ;; hid ;; shadow ;; bodyrel ;; dda ;; helpsub ;; eushelp ;; xforeign ;; Xdecl ;; Xgraphics ;; Xcolor ;; Xeus ;; Xevent ;; Xpanel ;; Xitem ;; Xtext ;; Xmenu ;; Xscroll ;; Xcanvas ;; Xtop ;; Xapplwin 
connected to Xserver DISPLAY=:1
X events are being asynchronously monitored.
;; pixword ;; RGBHLS ;; convolve ;; piximage ;; pbmfile ;; image_correlation ;; oglforeign ;; gldecl ;; glconst ;; glforeign ;; gluconst ;; gluforeign ;; glxconst ;; glxforeign ;; eglforeign ;; eglfunc ;; glutil ;; gltexture ;; glprim ;; gleus ;; glview ;; toiv-undefined ;; fstringdouble irtmath irtutil irtc irtgeoc irtgraph gnuplotlib ___time ___pgsql irtgeo euspqp pqp irtscene irtmodel irtdyna irtrobot irtsensor irtbvh irtcollada irtstl irtwrl irtpointcloud 
;; extending gcstack 0x564d77dc0680[16374] --> 0x564d7827c140[32748] top=3e4c
eusbullet bullet irtcollision irtx eusjpeg euspng png irtimage irtglrgb irtgl irtglc irtviewer 
EusLisp 9.29(43bb04e6 1.2.5) for Linux64 created on tsukamoto-desktop-ryzen(Wed Nov 30 12:34:00 JST 2022)
Welcome to eus10 beta. Please report any bugs at https://github.com/Affonso-Gui/EusLisp/issues or directly to affonso@jsk.imi.i.u-tokyo.ac.jp
roseus ;; loading roseus("1.7.5-219-g42e0c20") on euslisp((9.29 tsukamoto-desktop-ryzen Wed Nov 30 12:34:00 JST 2022 43bb04e6 1.2.5))
eustf roseus_c_util [ INFO] [1669960661.469118307]: start
[ INFO] [1669960661.550126639]: finish
Call Stack (max depth 20):
  0: at (tweet-string (format nil "Warning!! ~A is ~A at ~0,3f" (car (elt status id)) (cdr (elt status id)) (send tm :to-sec)) :warning-time 1 :with-image t :volume *volume* :speak *speak*)
  1: at (progn (tweet-string (format nil "Warning!! ~A is ~A at ~0,3f" (car (elt status id)) (cdr (elt status id)) (send tm :to-sec)) :warning-time 1 :with-image t :volume *volume* :speak *speak*))
  2: at (if (= (mod (round (send tm :sec)) 1000) 0) (progn (tweet-string (format nil "Warning!! ~A is ~A at ~0,3f" (car (elt status id)) (cdr (elt status id)) (send tm :to-sec)) :warning-time 1 :with-image t :volume *volume* :speak *speak*)))
  3: at (when (= (mod (round (send tm :sec)) 1000) 0) (tweet-string (format nil "Warning!! ~A is ~A at ~0,3f" (car (elt status id)) (cdr (elt status id)) (send tm :to-sec)) :warning-time 1 :with-image t :volume *volume* :speak *speak*))
  4: at (progn (setq id (random (length status))) (when (= (mod (round (send tm :sec)) 1000) 0) (tweet-string (format nil "Warning!! ~A is ~A at ~0,3f" (car (elt status id)) (cdr (elt status id)) (send tm :to-sec)) :warning-time 1 :with-image t :volume *volume* :speak *speak*)))
  5: at (if status (progn (setq id (random (length status))) (when (= (mod (round (send tm :sec)) 1000) 0) (tweet-string (format nil "Warning!! ~A is ~A at ~0,3f" (car (elt status id)) (cdr (elt status id)) (send tm :to-sec)) :warning-time 1 :with-image t :volume *volume* :speak *speak*))))
  6: at (when status (setq id (random (length status))) (when (= (mod (round (send tm :sec)) 1000) 0) (tweet-string (format nil "Warning!! ~A is ~A at ~0,3f" (car (elt status id)) (cdr (elt status id)) (send tm :to-sec)) :warning-time 1 :with-image t :volume *volume* :speak *speak*)))
  7: at (let ((diagnostics (make-hash-table :test #'equal)) (tm (ros::time-now)) status id) (ros::ros-debug (format nil "~0,3f diagnostics_msgs~%" (send tm :to-sec))) (dolist (status (send msg :status)) (when (>= (send status :level) diagnostic_msgs::diagnosticstatus::*warn*) (cond ((substringp "/Motors" (send status :name)) t) ((substringp "/Other/Accelerometer" (send status :name)) t) ((substringp "/Other/Pressure" (send status :name)) t) ((and (string= "/Computers/Network/Wifi Status (ddwrt)" (send status :name)) (string= "Updates Stale" (send status :message))) t) ((and (string= "/Computers/Network" (send status :name)) (string= "Error" (send status :message))) t) ((substringp "/Peripherals/PS3 Controller" (send status :name)) t) ((position 47 (send status :name) :count 2) (setq key (subseq (send status :name) 0 (position 47 (send status :name) :count 2))) (when (> (length (send status :name)) (length (gethash key diagnostics))) (setf (gethash key diagnostics) (cons (send status :name) (send status :message)))))))) (maphash #'(lambda (k v) (ros::ros-debug (format nil "Warnings ~A ~A~%" (length status) v)) (push v status)) diagnostics) (when status (setq id (random (length status))) (when (= (mod (round (send tm :sec)) 1000) 0) (tweet-string (format nil "Warning!! ~A is ~A at ~0,3f" (car (elt status id)) (cdr (elt status id)) (send tm :to-sec)) :warning-time 1 :with-image t :volume *volume* :speak *speak*))))
  8: at (if *enable* (let ((diagnostics (make-hash-table :test #'equal)) (tm (ros::time-now)) status id) (ros::ros-debug (format nil "~0,3f diagnostics_msgs~%" (send tm :to-sec))) (dolist (status (send msg :status)) (when (>= (send status :level) diagnostic_msgs::diagnosticstatus::*warn*) (cond ((substringp "/Motors" (send status :name)) t) ((substringp "/Other/Accelerometer" (send status :name)) t) ((substringp "/Other/Pressure" (send status :name)) t) ((and (string= "/Computers/Network/Wifi Status (ddwrt)" (send status :name)) (string= "Updates Stale" (send status :message))) t) ((and (string= "/Computers/Network" (send status :name)) (string= "Error" (send status :message))) t) ((substringp "/Peripherals/PS3 Controller" (send status :name)) t) ((position 47 (send status :name) :count 2) (setq key (subseq (send status :name) 0 (position 47 (send status :name) :count 2))) (when (> (length (send status :name)) (length (gethash key diagnostics))) (setf (gethash key diagnostics) (cons (send status :name) (send status :message)))))))) (maphash #'(lambda (k v) (ros::ros-debug (format nil "Warnings ~A ~A~%" (length status) v)) (push v status)) diagnostics) (when status (setq id (random (length status))) (when (= (mod (round (send tm :sec)) 1000) 0) (tweet-string (format nil "Warning!! ~A is ~A at ~0,3f" (car (elt status id)) (cdr (elt status id)) (send tm :to-sec)) :warning-time 1 :with-image t :volume *volume* :speak *speak*)))))
  9: at (ros::spin-once)
 10: at (ros::spin-once)
 11: at (while (ros::ok) (ros::spin-once) (ros::sleep))
NAME-ERROR: unbound variable *speak* in (tweet-string (format nil "Warning!! ~A is ~A at ~0,3f" (car (elt status id)) (cdr (elt status id)) (send tm :to-sec)) :warning-time 1 :with-image t :volume *volume* :speak *speak*)

```