### PR TITLE
[develop/fetch] use enable and speak_enable for volume control

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/auto_speak_volume_lower.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/auto_speak_volume_lower.l
@@ -1,6 +1,11 @@
 #!/usr/bin/env roseus
 
 (ros::roseus "speak_volume_lower")
+(ros::set-dynamic-reconfigure-param "/audible_warning" "enable" :bool t)
+(ros::set-dynamic-reconfigure-param "/tweet_client_tablet" "speak_enable" :bool t)
+(ros::set-dynamic-reconfigure-param "/tweet_client_uptime" "speak_enable" :bool t)
+(ros::set-dynamic-reconfigure-param "/tweet_client_warning" "speak_enable" :bool t)
+(ros::set-dynamic-reconfigure-param "/tweet_client_worktime" "speak_enable" :bool t)
 (ros::set-dynamic-reconfigure-param "/audible_warning" "volume" :double 0.2)
 (ros::set-dynamic-reconfigure-param "/tweet_client_tablet" "volume" :double 0.2)
 (ros::set-dynamic-reconfigure-param "/tweet_client_uptime" "volume" :double 0.2)

--- a/jsk_robot_common/jsk_robot_startup/lifelog/auto_speak_volume_reset.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/auto_speak_volume_reset.l
@@ -1,6 +1,11 @@
 #!/usr/bin/env roseus
 
 (ros::roseus "speak_volume_reset")
+(ros::set-dynamic-reconfigure-param "/audible_warning" "enable" :bool t)
+(ros::set-dynamic-reconfigure-param "/tweet_client_tablet" "speak_enable" :bool t)
+(ros::set-dynamic-reconfigure-param "/tweet_client_uptime" "speak_enable" :bool t)
+(ros::set-dynamic-reconfigure-param "/tweet_client_warning" "speak_enable" :bool t)
+(ros::set-dynamic-reconfigure-param "/tweet_client_worktime" "speak_enable" :bool t)
 (ros::set-dynamic-reconfigure-param "/audible_warning" "volume" :double 1.0)
 (ros::set-dynamic-reconfigure-param "/tweet_client_tablet" "volume" :double 1.0)
 (ros::set-dynamic-reconfigure-param "/tweet_client_uptime" "volume" :double 1.0)

--- a/jsk_robot_common/jsk_robot_startup/lifelog/auto_speak_volume_zero.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/auto_speak_volume_zero.l
@@ -1,6 +1,11 @@
 #!/usr/bin/env roseus
 
 (ros::roseus "speak_volume_zero")
+(ros::set-dynamic-reconfigure-param "/audible_warning" "enable" :bool nil)
+(ros::set-dynamic-reconfigure-param "/tweet_client_tablet" "speak_enable" :bool nil)
+(ros::set-dynamic-reconfigure-param "/tweet_client_uptime" "speak_enable" :bool nil)
+(ros::set-dynamic-reconfigure-param "/tweet_client_warning" "speak_enable" :bool nil)
+(ros::set-dynamic-reconfigure-param "/tweet_client_worktime" "speak_enable" :bool nil)
 (ros::set-dynamic-reconfigure-param "/audible_warning" "volume" :double 0.0)
 (ros::set-dynamic-reconfigure-param "/tweet_client_tablet" "volume" :double 0.0)
 (ros::set-dynamic-reconfigure-param "/tweet_client_uptime" "volume" :double 0.0)


### PR DESCRIPTION
this PR set `enable` and `speak_enable` to `nil` for `volume zero` app.
setting `volume` `0` means that robot speaks but no voice.
this causes interruption when other nodes speaks something.

this PR changes to set `enable` and `speak_enable` `nil`.
this change does not sent `sound_play` action, so it does't interrupt any other nodes.

