### PR TITLE
[baxtereus] fix &rest args position

### DIFF
--- a/jsk_baxter_robot/baxtereus/baxter-softhand-interface.l
+++ b/jsk_baxter_robot/baxtereus/baxter-softhand-interface.l
@@ -42,14 +42,14 @@
           ((equal arm :arms)
            (list lgripper-interface rgripper-interface))
           (t nil)))
-  (:start-grasp (&optional (arm :arms) &key (rotate-angle nil) &rest args &allow-other-keys)
+  (:start-grasp (&optional (arm :arms) &rest args &key (rotate-angle nil) &allow-other-keys)
     (cond
       ((equal arm :arms)
        (let ((larm-start-grasp-p (send* self :start-grasp-step :larm :rotate-angle rotate-angle args))
              (rarm-start-grasp-p (send* self :start-grasp-step :rarm :rotate-angle rotate-angle args)))
          (and larm-start-grasp-p rarm-start-grasp-p)))
       (t (send* self :start-grasp-step arm :rotate-angle rotate-angle args))))
-  (:start-grasp-step (arm &key (rotate-angle nil) &rest args &allow-other-keys)
+  (:start-grasp-step (arm &rest args &key (rotate-angle nil) &allow-other-keys)
     (cond
       ((equal (send self :get-gripper-type arm) :parallel)
        (send-super* :start-grasp arm args))
@@ -57,14 +57,14 @@
            (equal (send self :get-gripper-type arm) :softhand-v2))
        (send (send self :get-gripper-interface arm) :start-grasp :rotate-angle rotate-angle))
       (t nil)))
-  (:stop-grasp (&optional (arm :arms) &key (rotate-angle nil) &rest args &allow-other-keys)
+  (:stop-grasp (&optional (arm :arms) &rest args &key (rotate-angle nil) &allow-other-keys)
     (cond
       ((equal arm :arms)
        (let ((larm-stop-grasp-p (send* self :stop-grasp-step :larm :rotate-angle rotate-angle args))
              (rarm-stop-grasp-p (send* self :stop-grasp-step :rarm :rotate-angle rotate-angle args)))
          (and larm-stop-grasp-p rarm-stop-grasp-p)))
       (t (send* self :stop-grasp-step arm args))))
-  (:stop-grasp-step (arm &key (rotate-angle nil) &rest args &allow-other-keys)
+  (:stop-grasp-step (arm &rest args &key (rotate-angle nil) &allow-other-keys)
     (cond
       ((equal (send self :get-gripper-type arm) :parallel)
        (send-super* :stop-grasp arm args))


### PR DESCRIPTION
this PR fix `&rest args` position.

```
12.irteusgl$ (defun fuga (&optional opt &key (arm nil) &rest args &allow-other-keys) (pprint args))
fuga
13.irteusgl$ (fuga 1 :arm t :wait t)
nil
nil
14.irteusgl$ (defun hoge (&optional opt &rest args &key (arm nil) &allow-other-keys) (pprint args))
hoge
15.irteusgl$ (hoge 1 :arm t :wait t)
(:arm t :wait t)
nil
```