### PR TITLE
[jsk_naoqi_robot/cross] add attach.sh to attach session which you detached once

### DIFF
--- a/jsk_naoqi_robot/cross/build_user.sh
+++ b/jsk_naoqi_robot/cross/build_user.sh
@@ -88,6 +88,7 @@ docker run -it --rm \
 cp -a ${PWD}/startup_scripts/user_setup.bash ${SOURCE_ROOT}/
 cp -a ${PWD}/startup_scripts/start.sh ${SOURCE_ROOT}/
 cp -a ${PWD}/startup_scripts/screenrc ${SOURCE_ROOT}/
+cp -a ${PWD}/startup_scripts/attach.sh ${SOURCE_ROOT}/
 
 echo "
 

--- a/jsk_naoqi_robot/cross/startup_scripts/attach.sh
+++ b/jsk_naoqi_robot/cross/startup_scripts/attach.sh
@@ -1,0 +1,2 @@
+source User/user_setup.bash
+screen -c User/screenrc -r


### PR DESCRIPTION
Based on https://github.com/jsk-ros-pkg/jsk_robot/pull/1583#issuecomment-1235043472,
I added `attach.sh` to attach session which we detached once.

I will add how to use this at https://github.com/jsk-ros-pkg/jsk_robot/pull/1767
=> https://github.com/jsk-ros-pkg/jsk_robot/pull/1767/commits/c75b14f22c3779dd10e8c286b9ec2bbe9da369ed