### PR TITLE
[jsk_robot_startup] advertise when no tweet publisher is advertised yet

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/tweet_client.l
@@ -6,7 +6,10 @@
 
 (load "package://pr2eus/speak.l")
 
-(defun tweet-string (twit-str &key (warning-time) (with-image) (image-wait 30) (speak t))
+(defun tweet-string (twit-str &key (warning-time) (with-image) (image-wait 30) (speak t)
+                              (tweet-topic-name "/tweet"))
+  (if (null (ros::get-num-subscribers tweet-topic-name))
+    (ros::advertise tweet-topic-name std_msgs::String 1))
   (let (prev-image-topic img)
   (when warning-time
     (unless (numberp warning-time)
@@ -53,13 +56,13 @@
         (progn
           (write-image-file "/tmp/tweet_image.jpg" (ros::sensor_msgs/Image->image img))
           (ros::ros-info "tweeting ~A" twit-str)
-          (ros::publish "/tweet"
+          (ros::publish tweet-topic-name
                         (instance std_msgs::String :init
                                   :data (format nil "~A ~A"
                                                 twit-str (format nil "/tmp/tweet_image.jpg")))))
         (ros::ros-error "fail saving image and tweeting"))
       (ros::service-call "/tweet_image_mux/select" (instance topic_tools::muxselectrequest :init :topic prev-image-topic)))
     (t
-      (ros::publish "/tweet" (instance std_msgs::String :init :data twit-str))))
+      (ros::publish tweet-topic-name (instance std_msgs::String :init :data twit-str))))
   (when speak (speak-jp "ついーとしました" :wait t))))
 


### PR DESCRIPTION
advertise publisher needed for tweet in `tweet-string` when the publishers are not yet advertised.
with this change, we don't need to write `(ros::advertise "/tweet" ...)` in our script, and we can tweet by just runining `tweet-string` 