### PR TITLE
[jsk_robot_startup] fix python3 decode error in smach_to_mail

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -182,7 +182,10 @@ class SmachToMail():
                 image = EmailBody()
                 image.type = 'img'
                 image.img_size = 100
-                image.img_data = x['IMAGE']
+                img_txt = x['IMAGE']
+                if isinstance(img_txt, bytes):
+                    img_txt = img_txt.decode('utf-8')
+                image.img_data = img_txt
                 email_msg.body.append(image)
                 email_msg.body.append(changeline)
         email_msg.body.append(changeline)

--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -175,7 +175,10 @@ class SmachToMail():
             if 'DESCRIPTION' in x:
                 description = EmailBody()
                 description.type = 'text'
-                description.message = x['DESCRIPTION']
+                description_txt = x['DESCRIPTION']
+                if isinstance(description_txt, bytes):
+                    description_txt = description_txt.decode('utf-8')
+                description.message = description_txt
                 email_msg.body.append(description)
                 email_msg.body.append(changeline)
             if 'IMAGE' in x and x['IMAGE']:
@@ -196,7 +199,10 @@ class SmachToMail():
             if 'INFO' in x:
                 info = EmailBody()
                 info.type = 'text'
-                info.message = x['INFO']
+                info_txt = x['INFO']
+                if isinstance(info_txt, bytes):
+                    info_txt = info_txt.decode('utf-8')
+                info.message = info_txt
                 email_msg.body.append(info)
                 email_msg.body.append(changeline)
         # rospy.loginfo("body:{}".format(email_msg.body))


### PR DESCRIPTION
this PR fix error in `python3` + `smach_to_mail.py`.
`x['MAIL']` is `bytes` object, so it should be decoded to `utf-8`.
