### PR TITLE
Update mongodb_replication_params.yaml

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/lifelog/mongodb_replication_params.yaml
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/mongodb_replication_params.yaml
@@ -1,4 +1,4 @@
-mongodb_store_extras: [["robot-database.jsk.imi.i.u-tokyo.ac.jp", 27017],["musca.jsk.imi.i.u-tokyo.ac.jp",27017]]
+mongodb_store_extras: [["robot-database.jsk.imi.i.u-tokyo.ac.jp", 27017]]
 replication_client:
   interval: 3600
   delete_after_move: true


### PR DESCRIPTION
`robot-database.jsk.imi.i.u-tokyo.ac.jp` is CNAME of `musca.jsk....`  maybe this is the cause of following error
```
    [/message_store /opt/ros/melodic/lib/python2.7/dist-packages/rospy/topics.py:753] [ERROR] [1681119907.337053]: bad callback: <bound method MessageStore.insert_ros_msg of <__main__.M
essageStore object at 0x7f750d1860>>                                                                                                                                                 Traceback (most recent call last):                                                                                                                                                   
  File "/opt/ros/melodic/lib/python2.7/dist-packages/rospy/topics.py", line 750, in _invoke_callback                                                                                     cb(msg)                                                                                 
  File "/home/spot/ws/src/mongodb_store/mongodb_store/scripts/message_store_node.py", line 103, in insert_ros_msg                                                                        self.insert_ros_srv(msg)                                                                                                                                                         
  File "/home/spot/ws/src/mongodb_store/mongodb_store/scripts/message_store_node.py", line 152, in insert_ros_srv                                                                        dc_util.store_message(extra_collection, obj, meta, obj_id)                                                                                                                       
  File "/home/spot/ws/src/mongodb_store/mongodb_store/src/mongodb_store/util.py", line 258, in store_message                                                                             return collection.insert(doc)                                                                                                                                                    
  File "/usr/lib/python3/dist-packages/pymongo/collection.py", line 2941, in insert                                                                                                      check_keys, manipulate, write_concern)                                                                                                                                           
  File "/usr/lib/python3/dist-packages/pymongo/collection.py", line 599, in _insert                                                                                                      bypass_doc_val, session)                                                                                                                                                         
  File "/usr/lib/python3/dist-packages/pymongo/collection.py", line 580, in _insert_one                                                                                                  _check_write_command_response(result)                                                       
  File "/usr/lib/python3/dist-packages/pymongo/helpers.py", line 207, in _check_write_command_response                                                                               
    _raise_last_write_error(write_errors)                                                                                                                                              File "/usr/lib/python3/dist-packages/pymongo/helpers.py", line 188, in _raise_last_write_error                                                                                     
    raise DuplicateKeyError(error.get("errmsg"), 11000, error)                                                                                                                       pymongo.errors.DuplicateKeyError: E11000 duplicate key error collection: jsk_robot_lifelog.strelka index: _id_ dup key: { : ObjectId('6433daa31cf4582bb939adf7') }                   
                                  
```