### PR TITLE
[jsk_fetch_startup] Add ros_google_cloud_language to fetch_bringup.launch

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_bringup.launch
@@ -35,6 +35,7 @@
   <arg name="launch_google_chat" default="true" />
   <arg name="launch_mail_notification" default="true" />
   <arg name="launch_smach_image_publisher" default="true" />
+  <arg name="launch_google_analyze_text" default="true" />
 
   <!-- hardware -->
   <arg name="launch_battery_warning" default="true" />
@@ -407,6 +408,11 @@
       duration: 0.5
     </rosparam>
   </node>
+
+  <include if="$(arg launch_google_analyze_text)"
+           file="$(find ros_google_cloud_language)/launch/analyze_text.launch">
+    <arg name="google_cloud_credentials_json" value="/var/lib/robot/eternal-byte-236613-4bc6962824d1.json" />
+  </include>
 
   <!-- Two robots cannot use one rosserial device at the same time -->
   <group if="$(arg launch_rosserial)">


### PR DESCRIPTION
This PR adds `ros_google_cloud_launguage` to default fetch_bringup.launch.

This enables us to realize https://github.com/jsk-ros-pkg/jsk_demos/pull/1388 in fetch robot every day.