### PR TITLE
[WIP] [unitree/cross] Fix unitree system build

### DIFF
--- a/jsk_unitree_robot/cross/build_ros1_dependencies.sh
+++ b/jsk_unitree_robot/cross/build_ros1_dependencies.sh
@@ -45,5 +45,6 @@ docker run -it --rm \
     pip install -U --user pip && \
     export PYTHONPATH=\"/opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages\" && \
     export PKG_CONFIG_PATH=\"/opt/jsk/${INSTALL_ROOT}/ros1_dependencies/lib/pkgconfig\" && \
+    pip install spidev==3.5 pixel-ring==0.1.0 && \
     ~/.local/bin/pip install --prefix=/opt/jsk/${INSTALL_ROOT}/Python -r /home/user/ros1_dependencies_sources/go1_requirements.txt \
     " 2>&1 | tee ${TARGET_MACHINE}_build_ros1_dependencies.log

--- a/jsk_unitree_robot/cross/docker/Dockerfile_ros1
+++ b/jsk_unitree_robot/cross/docker/Dockerfile_ros1
@@ -29,7 +29,9 @@ RUN apt install -y --no-install-recommends $(cat ros-packages.txt | grep -v ^#)
 RUN apt install -y python-pip
 RUN git clone https://github.com/k-okada/rosinstall_generator /tmp/rosinstall_generator -b add_depend_type
 RUN pip install /tmp/rosinstall_generator
-RUN apt install -y python3-vcstool
+RUN apt install -y python3-vcstool python-typing
+# python-typing is necessary to avoid import error in build_ros1_dependencies.sh
+
 #
 # Setup Users
 #

--- a/jsk_unitree_robot/cross/repos/ros1_dependencies.repos
+++ b/jsk_unitree_robot/cross/repos/ros1_dependencies.repos
@@ -230,3 +230,17 @@ repositories:
   postfix:
     type: tar
     url: http://mirror.postfix.jp/postfix-release/official/postfix-3.4.3.tar.gz
+  libfcl-dev:
+    type: tar
+    url: http://archive.ubuntu.com/ubuntu/pool/universe/f/fcl/fcl_0.5.0.orig.tar.gz
+  libfcl-dev/debian:
+    type: tar
+    url: http://archive.ubuntu.com/ubuntu/pool/universe/f/fcl/fcl_0.5.0-5.debian.tar.xz
+    # geometric_shapes depends on fcl
+  libccd-dev:
+    type: tar
+    url: http://archive.ubuntu.com/ubuntu/pool/universe/libc/libccd/libccd_2.0.orig.tar.gz
+  libccd-dev/debian:
+    type: tar
+    url: http://archive.ubuntu.com/ubuntu/pool/universe/libc/libccd/libccd_2.0-1.debian.tar.xz
+    # fcl depends on ccd

--- a/jsk_unitree_robot/cross/repos/unitree.repos
+++ b/jsk_unitree_robot/cross/repos/unitree.repos
@@ -19,5 +19,8 @@ repositories:
     version: develop
   app_manager:
     type: git
-    url: https://github.com/Affonso-Gui/app_manager
-    version: enable-parallel-run-apps
+    url: https://github.com/PR2/app_manager
+    version: kinetic-devel
+    # enable to run simple apps parallel to other apps
+    # https://github.com/PR2/app_manager/pull/59 have been merged,
+    # but 1.4.0 have not released yet.

--- a/jsk_unitree_robot/cross/ros1_dependencies_build_scripts/1043-libccd-dev
+++ b/jsk_unitree_robot/cross/ros1_dependencies_build_scripts/1043-libccd-dev
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -xeu -o pipefail
+
+DEBIAN_DIR=/home/user/ros1_dependencies_sources/src/libccd-dev/debian/debian
+SOURCE_DIR=/home/user/ros1_dependencies_sources/src/libccd-dev/libccd-2.0
+
+#
+# libccd-dev does not have patches
+#
+# cd ${DEBIAN_DIR}/patches
+# for patch_file in $(grep -v ^# series); do
+#     OUT="$(patch -p1 --forward --directory ${SOURCE_DIR} < ${patch_file} | tee /dev/tty)" || echo "${OUT}" | grep "Skipping patch" -q || (echo "$OUT" && false) || echo "OK"
+# done
+
+mkdir -p /home/user/ros1_dependencies_sources/build/libccd-dev
+cd /home/user/ros1_dependencies_sources/build/libccd-dev
+cmake \
+  -DCMAKE_INSTALL_PREFIX=/opt/jsk/${INSTALL_ROOT}/ros1_dependencies \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_SKIP_RPATH=ON \
+  -DENABLE_SSE=OFF -DENABLE_SSE2=OFF -DENABLE_SSSE3=OFF \
+  -DOPT_COLLADA15=ON \
+  -DOPT_COLLADA14=ON \
+  -DOPT_COMPILE_VIEWER=OFF \
+  -DOPT_COMPILE_FX=OFF \
+  -DOPT_COMPILE_RT=OFF \
+  -DOPT_BUILD_PACKAGES=OFF \
+  -DOPT_BUILD_PACKAGE_DEFAULT=OFF \
+  -DOPT_DOUBLE_PRECISION=ON \
+  ${SOURCE_DIR}
+
+make install

--- a/jsk_unitree_robot/cross/ros1_dependencies_build_scripts/1044-libfcl-dev
+++ b/jsk_unitree_robot/cross/ros1_dependencies_build_scripts/1044-libfcl-dev
@@ -11,6 +11,7 @@ done
 
 mkdir -p /home/user/ros1_dependencies_sources/build/libfcl-dev
 cd /home/user/ros1_dependencies_sources/build/libfcl-dev
+LD_LIBRARY_PATH=/opt/jsk/${INSTALL_ROOT}/ros1_dependencies/lib:${LD_LIBRARY_PATH}
 cmake \
   -DCMAKE_INSTALL_PREFIX=/opt/jsk/${INSTALL_ROOT}/ros1_dependencies \
   -DCMAKE_BUILD_TYPE=Release \

--- a/jsk_unitree_robot/cross/ros1_dependencies_build_scripts/1044-libfcl-dev
+++ b/jsk_unitree_robot/cross/ros1_dependencies_build_scripts/1044-libfcl-dev
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -xeu -o pipefail
+
+DEBIAN_DIR=/home/user/ros1_dependencies_sources/src/libfcl-dev/debian/debian
+SOURCE_DIR=/home/user/ros1_dependencies_sources/src/libfcl-dev/fcl-0.5.0
+
+cd ${DEBIAN_DIR}/patches
+for patch_file in $(grep -v ^# series); do
+    OUT="$(patch -p1 --forward --directory ${SOURCE_DIR} < ${patch_file} | tee /dev/tty)" || echo "${OUT}" | grep "Skipping patch" -q || (echo "$OUT" && false) || echo "OK"
+done
+
+mkdir -p /home/user/ros1_dependencies_sources/build/libfcl-dev
+cd /home/user/ros1_dependencies_sources/build/libfcl-dev
+cmake \
+  -DCMAKE_INSTALL_PREFIX=/opt/jsk/${INSTALL_ROOT}/ros1_dependencies \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_SKIP_RPATH=ON \
+  -DENABLE_SSE=OFF -DENABLE_SSE2=OFF -DENABLE_SSSE3=OFF \
+  -DOPT_COLLADA15=ON \
+  -DOPT_COLLADA14=ON \
+  -DOPT_COMPILE_VIEWER=OFF \
+  -DOPT_COMPILE_FX=OFF \
+  -DOPT_COMPILE_RT=OFF \
+  -DOPT_BUILD_PACKAGES=OFF \
+  -DOPT_BUILD_PACKAGE_DEFAULT=OFF \
+  -DOPT_DOUBLE_PRECISION=ON \
+  ${SOURCE_DIR}
+
+make install


### PR DESCRIPTION
Currently, unitree system build (`build_ros1_dependencies.sh` and `build_ros1.sh`) fails at several points.

This PR includes
- [x]  Fix `app_manager`  url and version (772dc9a67ad1d15795a24fee85848da2c0f5cdc1)
- [x] Install python-typing to avoid import typing error (772dc9a67ad1d15795a24fee85848da2c0f5cdc1)
- [x] Add libfcl-dev and libccd-dev to dependencies because `geometric_shapes` package needs them (0ec465c1b8483f221ccfb971108eaefca41a6ac2, [929ae6e](https://github.com/jsk-ros-pkg/jsk_robot/pull/1793/commits/929ae6e28c9ad51e28228155123d939f9540999d))
- [x] Avoid setuptools version error caused by `spidev==3.6` (af35715082126af9c475411e4f3bb292c6595127)

But, this PR  do not fix the following issue

- [ ] Unable to install `python-twisted` in `build_ros1_dependencies.sh` because of the following error. 
```
Installed /opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages/Twisted-17.9.0-py2.7-linux-aarch64.egg                                                                                                                                                                                                                                                                               
Processing dependencies for Twisted==17.9.0                                                                                                                                                                                                                                                                                                                                                  
Searching for zope.interface>=3.6.0                                                                                                                                                                                                                                                                                                                                                          
Reading https://pypi.python.org/simple/zope.interface/                                                                                                                                                                                                                                                                                                                                       
Downloading https://files.pythonhosted.org/packages/1f/ef/cae21b6295cb2960429f463e6e99daf3623a0c4ced7242a809a0c94c9605/zope.interface-6.1a2.tar.gz#sha256=167ea1a5c28aad2fa7fb0ca8761229bf54766ab6e696c80e592ee8c936ab1776                                                                                                                                                                   
Best match: zope.interface 6.1a2                                                                                                                                                                                                                                                                                                                                                             
Processing zope.interface-6.1a2.tar.gz                                                                                                                                                                                                                                                                                                                                                       
Writing /tmp/easy_install-ur5jc9/zope.interface-6.1a2/setup.cfg                                                                                                                                                                                                                                                                                                                              
Running zope.interface-6.1a2/setup.py -q bdist_egg --dist-dir /tmp/easy_install-ur5jc9/zope.interface-6.1a2/egg-dist-tmp-3dtby3                                                                                                                                                                                                                                                              
warning: no files found matching '*.txt' under directory 'docs'                                                                                                                                                                                                                                                                                                                              
src/zope/interface/_zope_interface_coptimizations.c:765:5: error: unknown type name ‘Py_hash_t’                                                                                                                                                                                                                                                                                              
     Py_hash_t _v_cached_hash;                                                                                                                                                                                                                                                                                                                                                               
     ^~~~~~~~~                                                                                                                                                                                                                                                                                                                                                                               
src/zope/interface/_zope_interface_coptimizations.c:907:8: error: unknown type name ‘Py_hash_t’                                                                                                                                                                                                                                                                                              
 static Py_hash_t                                                                                                                                                                                                                                                                                                                                                                            
        ^~~~~~~~~                                                                                                                                                                                                                                                                                                                                                                            
********************************************************************************                                                                                                                                                                                                                                                                                                             
WARNING:                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                             
        An optional code optimization (C extension) could not be compiled.                               
                                                                                                         
        Optimizations for this package will not be available!                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                             
command 'aarch64-linux-gnu-gcc' failed with exit status 1                                                
********************************************************************************                         
  File "build/bdist.linux-aarch64/egg/zope/interface/tests/test_advice.py", line 117                                                                                                                               
    class Meta(type, metaclass=Metameta):                                                                                                                                                                          
                              ^                                                                          
SyntaxError: invalid syntax                                                                              
                                                                                                         
  File "build/bdist.linux-aarch64/egg/zope/interface/adapter.py", line 336                               
    yield from cls._allKeys(v, i - 1, new_parent_k)                                                                                                                                                                
             ^                                                                                           
SyntaxError: invalid syntax                                                                                                                                                                                        
                                                                                                         
  File "build/bdist.linux-aarch64/egg/zope/interface/registry.py", line 294                                                                                                                                        
    yield from self.utilities.lookupAll((), interface)                                                   
             ^                                                                                           
SyntaxError: invalid syntax                                                                              
                                                                                                                                                                                                                   
creating /opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages/zope.interface-6.1a2-py2.7-linux-aarch64.egg                                                                                                
Extracting zope.interface-6.1a2-py2.7-linux-aarch64.egg to /opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages                                                                                           
  File "/opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages/zope.interface-6.1a2-py2.7-linux-aarch64.egg/zope/interface/adapter.py", line 336                                                            
    yield from cls._allKeys(v, i - 1, new_parent_k)                                                                                                                                                                
             ^                                                                                           
SyntaxError: invalid syntax                                                                              
                                                                                                         
  File "/opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages/zope.interface-6.1a2-py2.7-linux-aarch64.egg/zope/interface/registry.py", line 294                                                                                                                        
    yield from self.utilities.lookupAll((), interface)                                                                                                                                                             
             ^                                                                                           
SyntaxError: invalid syntax                                                                              
                                                                                                         
  File "/opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages/zope.interface-6.1a2-py2.7-linux-aarch64.egg/zope/interface/tests/test_advice.py", line 117                                                  
    class Meta(type, metaclass=Metameta):                                                                                                                                                                          
                              ^                                                                          
SyntaxError: invalid syntax                                                                              
                                                                                                                                                                                                                   
Adding zope.interface 6.1a2 to easy-install.pth file                                                     
                                                                                                         
Installed /opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages/zope.interface-6.1a2-py2.7-linux-aarch64.egg                                                                                                                                                            
Searching for constantly>=15.1                                                                                                                                                                                     
Reading https://pypi.python.org/simple/constantly/                                                                                                                                                                 
Downloading https://files.pythonhosted.org/packages/b9/65/48c1909d0c0aeae6c10213340ce682db01b48ea900a7d9fce7a7910ff318/constantly-15.1.0-py2.py3-none-any.whl#sha256=dd2fa9d6b1a51a83f0d7dd76293d734046aa176e384bf6e33b7e44880eb37c5d                                           
Best match: constantly 15.1.0                                                                                                                                                                                      
Processing constantly-15.1.0-py2.py3-none-any.whl                                                        
Installing constantly-15.1.0-py2.py3-none-any.whl to /opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages                                                                                                                                                              
Adding constantly 15.1.0 to easy-install.pth file                                                        
                                                                                                                                                                                                                   
Installed /opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages/constantly-15.1.0-py2.7.egg                                     
Searching for Automat>=0.3.0                                                                             
Reading https://pypi.python.org/simple/Automat/                                                          
Downloading https://files.pythonhosted.org/packages/29/90/64aabce6c1b820395452cc5472b8f11cd98320f40941795b8069aef4e0e0/Automat-22.10.0-py2.py3-none-any.whl#sha256=c3164f8742b9dc440f3682482d32aaff7bb53f71740dd018533f9de286b64180                                             
Best match: Automat 22.10.0                                                                                                                                                                   
Processing Automat-22.10.0-py2.py3-none-any.whl                     
Installing Automat-22.10.0-py2.py3-none-any.whl to /opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages                                                                                                                                                                
writing requirements to /opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages/Automat-22.10.0-py2.7.egg/EGG-INFO/requires.txt                                                                                                                                           
Adding Automat 22.10.0 to easy-install.pth file                     
Installing automat-visualize script to /opt/jsk/System/ros1_dependencies/bin                                                            
                                                                                                                                                                                              
Installed /opt/jsk/System/ros1_dependencies/lib/python2.7/site-packages/Automat-22.10.0-py2.7.egg                                       
Searching for attrs>=19.2.0                                                                                                                                                                   
Reading https://pypi.python.org/simple/attrs/                                                                                                                                                 
Downloading https://files.pythonhosted.org/packages/97/90/81f95d5f705be17872843536b1868f351805acf6971251ff07c1b8334dbb/attrs-23.1.0.tar.gz#sha256=6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015                                                              
Best match: attrs 23.1.0                                                                                                                                                                      
Processing attrs-23.1.0.tar.gz                                                                                                                                                                
error: Couldn't find a setup script in /tmp/easy_install-_r9Nfn/attrs-23.1.0.tar.gz    
```

I installed `attrs<23.0` manually and then tried to install `python-twisted`, but almost same error occurs. I think easy_install cannnot find `attrs<23.0.` in local.