### PR TITLE
[jsk_pr2_startup] Change launch_virtual_force arg to avoid dupulicated node error

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/pr2_bringup.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2_bringup.launch
@@ -159,9 +159,6 @@
     </include>
   </group>
 
-  <!-- Virtual force -->
-  <include file="$(find virtual_force_publisher)/launch/dualarm_virtual_force_publisher.launch" />
-
   <!-- Audio -->
   <include file="$(find audio_play)/launch/play.launch" if="$(arg launch_audio_play)">
     <arg name="ns" value="audio_play" />


### PR DESCRIPTION
Currently both `pr2.launch` and `pr2_bringup.launch` run virtual_force_publisher and the nodes are killed for `new node registered with same name` error.
This PR makes  `pr2.launch` stop launching the nodes.