### PR TITLE
[Fetch] Fix jsk_recognition branch in jsk_fetch.rosinstall.melodic

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -65,12 +65,11 @@
     local-name: jsk-ros-pkg/jsk_pr2eus
     uri: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
     version: master
-# we need this PR for fisheye vital check
-# https://github.com/jsk-ros-pkg/jsk_recognition/pull/2734
+# we need to use the development branch until the next release.
 - git:
     local-name: jsk-ros-pkg/jsk_recognition
-    uri: https://github.com/knorth55/jsk_recognition.git
-    version: fisheye-vital-check
+    uri: https://github.com/jsk-ros-pkg/jsk_recognition.git
+    version: master
 # we need to use the development branch (fetch15 branch in knorth55's fork)
 # until it is merged to master
 - git:

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -70,7 +70,7 @@
     local-name: jsk-ros-pkg/jsk_recognition
     uri: https://github.com/jsk-ros-pkg/jsk_recognition.git
     version: master
-# we need to use the development branch (fetch15 branch in knorth55's fork)
+# we need to use the development branch (develop/fetch branch in jsk-ros-pkg)
 # until it is merged to master
 - git:
     local-name: jsk-ros-pkg/jsk_robot


### PR DESCRIPTION
Currently, jsk_recognition remote branch that Fetch's internal workspace tracks (knorth55's `fisheye-vital-check`) has already deleted because https://github.com/jsk-ros-pkg/jsk_recognition/pull/2734 has merged.
And I fixed the comment about develop/fetch branch of jsk_robot.

If we should set another branch of jsk_recognition, please tell me.