### PR TITLE
pixel-ring requires spidev and spidev >=3.6 requires setuptools>=61.0, which is not support python2. same as https://github.com/jsk-ros-pkg/jsk_robot/pull/1794

### DIFF
--- a/jsk_naoqi_robot/cross/repos/pepper_requirements.txt
+++ b/jsk_naoqi_robot/cross/repos/pepper_requirements.txt
@@ -7,4 +7,5 @@ paho-mqtt==1.6.1
 # https://github.com/jsk-ros-pkg/jsk_3rdparty/blob/master/respeaker_ros/package.xml
 speechrecognition==3.8.1
 pyusb==1.1.1
+spidev==3.5  # pixel-ring requires spidev and spidev >=3.6 requires setuptools>=61.0. same as https://github.com/jsk-ros-pkg/jsk_robot/pull/1794
 pixel-ring==0.1.0

--- a/jsk_naoqi_robot/cross/repos/ros1_dependencies.repos
+++ b/jsk_naoqi_robot/cross/repos/ros1_dependencies.repos
@@ -333,3 +333,9 @@ repositories:
   libtheora/debian:
     type: tar
     url: http://archive.ubuntu.com/ubuntu/pool/main/libt/libtheora/libtheora_1.1.1+dfsg.1-14.debian.tar.xz
+  libjpeg-turbo:
+    type: tar
+    url: http://archive.ubuntu.com/ubuntu/pool/main/libj/libjpeg-turbo/libjpeg-turbo_1.5.2.orig.tar.gz
+  libjpeg-turbo/debian:
+    type: tar
+    url: http://archive.ubuntu.com/ubuntu/pool/main/libj/libjpeg-turbo/libjpeg-turbo_1.5.2-0ubuntu5.18.04.6.debian.tar.xz

--- a/jsk_naoqi_robot/cross/ros1_dependencies_build_scripts/1047-libjpeg-turbo
+++ b/jsk_naoqi_robot/cross/ros1_dependencies_build_scripts/1047-libjpeg-turbo
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -xeuf -o pipefail
+
+DEBIAN_DIR=/home/nao/ros1_dependencies_sources/src/libjpeg-turbo/debian/debian
+SOURCE_DIR=/home/nao/ros1_dependencies_sources/src/libjpeg-turbo/libjpeg-turbo-1.5.2
+
+cd ${DEBIAN_DIR}/patches
+if [ ! -e .patched ]; then
+    for patch_file in $(grep -v ^# series); do
+        [ -e "${patch_file}" ] || continue
+        OUT="$(patch -p1 --forward --directory ${SOURCE_DIR} < ${patch_file} | tee /dev/tty)" || echo "${OUT}" | grep "Skipping patch" -q || (echo "$OUT" && false)
+    done
+    touch .patched
+fi
+
+cd ${SOURCE_DIR}
+
+./configure \
+  --prefix=/home/nao/${INSTALL_ROOT}/ros1_dependencies \
+  --enable-static --host=i686-aldebaran-linux-gnu \
+  --without-simd
+
+make -j4
+install -m755 turbojpeg.h                 /home/nao/${INSTALL_ROOT}/ros1_dependencies/include/
+install -m755 .libs/libturbojpeg.a        /home/nao/${INSTALL_ROOT}/ros1_dependencies/lib/
+install -m755 .libs/libturbojpeg.so       /home/nao/${INSTALL_ROOT}/ros1_dependencies/lib/
+install -m755 .libs/libturbojpeg.so.0     /home/nao/${INSTALL_ROOT}/ros1_dependencies/lib/
+install -m755 .libs/libturbojpeg.so.0.1.0 /home/nao/${INSTALL_ROOT}/ros1_dependencies/lib/
+install -m755 pkgscripts/libturbojpeg.pc  /home/nao/${INSTALL_ROOT}/ros1_dependencies/lib/pkgconfig/
+


### PR DESCRIPTION
same as https://github.com/jsk-ros-pkg/jsk_robot/pull/1794