### PR TITLE
[devlop/fetch] [jsk_robot_startup/lifelog] Add replicate_on_write arg to mongodb.launch to search at replication server

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
@@ -3,6 +3,7 @@
   <arg name="map_frame" default="map" />
   <arg name="vital_check" default="false" />
   <arg name="extra_collections" default="[go_to_kitchen]" />
+  <arg name="replicate_on_write" default="true"/>
 
   <include file="$(find jsk_fetch_startup)/jsk_fetch.machine" />
 
@@ -13,12 +14,14 @@
     <arg name="port" value="27017" />
     <arg name="repl_set_mode" value="false" />
     <arg name="extra_collections" value="$(arg extra_collections)" />
+    <arg name="replicate_on_write" value="$(arg replicate_on_write)"/>
   </include>
   <include file="$(find jsk_robot_startup)/lifelog/mongodb.launch"
            unless="$(arg use_system_mongod)">
     <arg name="use_daemon" value="false"/>
     <arg name="repl_set_mode" value="false" />
     <arg name="extra_collections" value="$(arg extra_collections)" />
+    <arg name="replicate_on_write" value="$(arg replicate_on_write)"/>
   </include>
 
   <include file="$(find jsk_robot_startup)/lifelog/common_logger.launch">

--- a/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/mongodb.launch
@@ -11,6 +11,7 @@
   <arg name="replicator_param_path"
        default="$(find jsk_robot_startup)/lifelog/mongodb_replication_params.yaml" />
   <arg name="extra_collections" default="" />
+  <arg name="replicate_on_write" default="false"/>
 
   <arg name="test_mode" default="false" />
 
@@ -25,6 +26,7 @@
           output="screen" machine="$(arg machine)">
       <rosparam subst_value="true" if="$(eval arg('extra_collections') != '')">
         extra_collections: $(arg extra_collections)
+        replicate_on_write: $(arg replicate_on_write)
       </rosparam>
     </node>
   </group>


### PR DESCRIPTION
This is a develop/fetch version of of #1801 . 

I added arg replicate_on_write to search at replication database server.