### PR TITLE
[jsk_robot_startup][jsk_fetch_startup] Add dry run option of update_workspace.sh

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/update_workspace_main.sh
+++ b/jsk_robot_common/jsk_robot_startup/scripts/update_workspace_main.sh
@@ -62,15 +62,15 @@ do
 done
 
 if [ "$WORKSPACE" = "" ]; then
-    echo "Please set valid workspace -w $WORKSPACE"
+    echo "Please set valid workspace -w $WORKSPACE<br>"
     exit 1
 fi
 if [ "$ROSINSTALL" = "" ]; then
-    echo "Please set valid rosinstall -r $ROSINSTALL"
+    echo "Please set valid rosinstall -r $ROSINSTALL<br>"
     exit 1
 fi
 if [ "$ROBOT_TYPE" = "" ]; then
-    echo "Please set valid robot type -t $ROBOT_TYPE"
+    echo "Please set valid robot type -t $ROBOT_TYPE<br>"
     exit 1
 fi
 
@@ -88,7 +88,7 @@ echo "" > $TMP_MAIL_BODY_FILE
 wstool foreach -t $WORKSPACE/src --git 'git fetch origin --prune'
 WSTOOL_STATUS=$(wstool status -t $WORKSPACE/src)
 if [ -n "$WSTOOL_STATUS" ]; then
-    echo -e "Please commit robot internal change and send pull request.\n" >> $TMP_MAIL_BODY_FILE
+    echo -e "Please commit robot internal change and send pull request.<br>" >> $TMP_MAIL_BODY_FILE
     echo -e $WSTOOL_STATUS >> $TMP_MAIL_BODY_FILE
     # escape " ' , -- and add change line code to end of line
     wstool diff -t $WORKSPACE/src | sed -e "s/'/ /g" -e "s/^--/ /g" -e 's/"/ /g' -e "s/<br>/\\\n/" -e 's/$/<br>/g' -e "s/,/ /g" | tee -a $TMP_MAIL_BODY_FILE
@@ -123,13 +123,13 @@ catkin build --continue-on-failure
 CATKIN_BUILD_RESULT=$?
 # Send mail
 if [ $WSTOOL_UPDATE_RESULT -ne 0 ]; then
-    echo "Please wstool update workspace manually.\n" >> $TMP_MAIL_BODY_FILE
+    echo "Please wstool update workspace manually.<br>" >> $TMP_MAIL_BODY_FILE
 fi
 if [ $ROSDEP_INSTALL_RESULT -ne 0 ]; then
-    echo "Please install dependencies manually.\n" >> $TMP_MAIL_BODY_FILE
+    echo "Please install dependencies manually.<br>" >> $TMP_MAIL_BODY_FILE
 fi
 if [ $CATKIN_BUILD_RESULT -ne 0 ]; then
-    echo "Please catkin build workspace manually.\n" >> $TMP_MAIL_BODY_FILE
+    echo "Please catkin build workspace manually.<br>" >> $TMP_MAIL_BODY_FILE
 fi
 set +x
 } 2>&1 | tee $LOGFILE
@@ -148,7 +148,7 @@ if [ -n "$MAIL_BODY" ] && [ "${SEND_MAIL}" == "true" ]; then
   frame_id: ''
 subject: 'Daily workspace update fails'
 body:
-- {type: 'text', message: '${MAIL_BODY}', file_path: '', img_data: '', img_size: 0}
+- {type: 'html', message: '${MAIL_BODY}', file_path: '', img_data: '', img_size: 0}
 sender_address: '$(hostname)@jsk.imi.i.u-tokyo.ac.jp'
 receiver_address: '$ROBOT_TYPE@jsk.imi.i.u-tokyo.ac.jp'
 smtp_server: ''

--- a/jsk_robot_common/jsk_robot_startup/scripts/update_workspace_main.sh
+++ b/jsk_robot_common/jsk_robot_startup/scripts/update_workspace_main.sh
@@ -80,8 +80,8 @@ TMP_MAIL_BODY_FILE=/tmp/update_workspace_mailbody.txt
 set -x
 # Update workspace
 
-wstool foreach -t $WORKSPACE/src --git 'git stash'
 wstool foreach -t $WORKSPACE/src --git 'git fetch origin --prune'
+wstool foreach -t $WORKSPACE/src --git 'git stash'
 wstool update -t $WORKSPACE/src jsk-ros-pkg/jsk_robot --delete-changed-uris
 ln -sf $ROSINSTALL $WORKSPACE/src/.rosinstall
 wstool update -t $WORKSPACE/src --delete-changed-uris

--- a/jsk_robot_common/jsk_robot_startup/scripts/update_workspace_main.sh
+++ b/jsk_robot_common/jsk_robot_startup/scripts/update_workspace_main.sh
@@ -84,8 +84,14 @@ TMP_MAIL_BODY_FILE=/tmp/update_workspace_mailbody.txt
 {
 set -x
 # Update workspace
-
+echo "" > $TMP_MAIL_BODY_FILE
 wstool foreach -t $WORKSPACE/src --git 'git fetch origin --prune'
+WSTOOL_STATUS=$(wstool status -t $WORKSPACE/src)
+if [ -n "$WSTOOL_STATUS" ]; then
+    echo -e "Please commit robot internal change and send pull request.\n" >> $TMP_MAIL_BODY_FILE
+    echo -e $WSTOOL_STATUS >> $TMP_MAIL_BODY_FILE
+    wstool diff -t $WORKSPACE/src # rostopic pub fail when wstool diff has single quote or double quotes
+fi
 if [ "${UPDATE_WORKSPACE}" == "true" ]; then
     wstool foreach -t $WORKSPACE/src --git 'git stash'
     wstool update -t $WORKSPACE/src jsk-ros-pkg/jsk_robot --delete-changed-uris
@@ -115,7 +121,6 @@ catkin config -DCMAKE_BUILD_TYPE=Release
 catkin build --continue-on-failure
 CATKIN_BUILD_RESULT=$?
 # Send mail
-echo "" > $TMP_MAIL_BODY_FILE
 if [ $WSTOOL_UPDATE_RESULT -ne 0 ]; then
     echo "Please wstool update workspace manually.\n" >> $TMP_MAIL_BODY_FILE
 fi

--- a/jsk_robot_common/jsk_robot_startup/scripts/update_workspace_main.sh
+++ b/jsk_robot_common/jsk_robot_startup/scripts/update_workspace_main.sh
@@ -90,7 +90,8 @@ WSTOOL_STATUS=$(wstool status -t $WORKSPACE/src)
 if [ -n "$WSTOOL_STATUS" ]; then
     echo -e "Please commit robot internal change and send pull request.\n" >> $TMP_MAIL_BODY_FILE
     echo -e $WSTOOL_STATUS >> $TMP_MAIL_BODY_FILE
-    wstool diff -t $WORKSPACE/src # rostopic pub fail when wstool diff has single quote or double quotes
+    # escape " ' , -- and add change line code to end of line
+    wstool diff -t $WORKSPACE/src | sed -e "s/'/ /g" -e "s/^--/ /g" -e 's/"/ /g' -e "s/<br>/\\\n/" -e 's/$/<br>/g' -e "s/,/ /g" | tee -a $TMP_MAIL_BODY_FILE
 fi
 if [ "${UPDATE_WORKSPACE}" == "true" ]; then
     wstool foreach -t $WORKSPACE/src --git 'git stash'

--- a/jsk_robot_common/jsk_robot_startup/scripts/update_workspace_main.sh
+++ b/jsk_robot_common/jsk_robot_startup/scripts/update_workspace_main.sh
@@ -88,7 +88,7 @@ echo "" > $TMP_MAIL_BODY_FILE
 wstool foreach -t $WORKSPACE/src --git 'git fetch origin --prune'
 WSTOOL_STATUS=$(wstool status -t $WORKSPACE/src)
 if [ -n "$WSTOOL_STATUS" ]; then
-    echo -e "Please commit robot internal change and send pull request.<br>" >> $TMP_MAIL_BODY_FILE
+    echo -e "<b>Please commit robot internal change and send pull request.</b><br><br>" >> $TMP_MAIL_BODY_FILE
     echo -e $WSTOOL_STATUS >> $TMP_MAIL_BODY_FILE
     # escape " ' , -- and add change line code to end of line
     wstool diff -t $WORKSPACE/src | sed -e "s/'/ /g" -e "s/^--/ /g" -e 's/"/ /g' -e "s/<br>/\\\n/" -e 's/$/<br>/g' -e "s/,/ /g" | tee -a $TMP_MAIL_BODY_FILE
@@ -123,13 +123,13 @@ catkin build --continue-on-failure
 CATKIN_BUILD_RESULT=$?
 # Send mail
 if [ $WSTOOL_UPDATE_RESULT -ne 0 ]; then
-    echo "Please wstool update workspace manually.<br>" >> $TMP_MAIL_BODY_FILE
+    echo "<b>Please wstool update workspace manually.</b><br>" >> $TMP_MAIL_BODY_FILE
 fi
 if [ $ROSDEP_INSTALL_RESULT -ne 0 ]; then
-    echo "Please install dependencies manually.<br>" >> $TMP_MAIL_BODY_FILE
+    echo "<b>Please install dependencies manually.</b><br>" >> $TMP_MAIL_BODY_FILE
 fi
 if [ $CATKIN_BUILD_RESULT -ne 0 ]; then
-    echo "Please catkin build workspace manually.<br>" >> $TMP_MAIL_BODY_FILE
+    echo "<b>Please catkin build workspace manually.</b><br>" >> $TMP_MAIL_BODY_FILE
 fi
 set +x
 } 2>&1 | tee $LOGFILE


### PR DESCRIPTION
This PR added dry run option of update_workspace.sh.

Now fetch and pr2 workspaces forcefully update at 3:00, but this function forcibly erases changes in the robot body, which was troublesome when, for example, we wanted to prepare a demonstration the day before a tour.
This PR avoids that situation.

豊島岡の見学会準備のフィードバックを受けての変更です．
毎朝3時にロボット体内の変更をすべて消し去るのはよくないのではないか，というところを反映しています．
今回の変更を適用するとFetchのwstool updateは手動で行うのがデフォルトになります．