### PR TITLE
[jsk_fetch_startup] Logging /sound_play/goal and /speech_to_text

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
@@ -41,6 +41,7 @@
   <rosparam ns="lifelog/speech_logger">
     topics:
     - /sound_play/goal
+    - /robotsound_jp/goal
     - /speech_to_text
   </rosparam>
 

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch_lifelog.xml
@@ -26,6 +26,7 @@
     <arg name="save_joint_states" value="true" />
     <arg name="save_base_trajectory" value="true" />
     <arg name="save_object_detection" value="false" />
+    <arg name="save_speech" value="true" />
     <arg name="save_action" value="true" />
     <arg name="camera_ns" value="head_camera" />
     <arg name="enable_monitor" value="false" />
@@ -36,6 +37,12 @@
     <arg name="base_frame_id" value="base_link" />
     <arg name="vital_check" value="$(arg vital_check)" />
   </include>
+
+  <rosparam ns="lifelog/speech_logger">
+    topics:
+    - /sound_play/goal
+    - /speech_to_text
+  </rosparam>
 
   <rosparam ns="lifelog/joint_states_throttle">
     periodic: false


### PR DESCRIPTION
This PR is a master version of https://github.com/jsk-ros-pkg/jsk_robot/pull/1806.
`/robotsound_jp` is being saved at mongodb.
And I added additional commit left in develop/fetch branch about speech_logger. (52c671faf6ec4d2cdf71935f97ae3c03b109e92e, merged at https://github.com/jsk-ros-pkg/jsk_robot/pull/1728)