### PR TITLE
[jsk_fetch_startup] Avoid collision between l515 and head_pan_link

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/robots/head_l515.srdf.xacro
+++ b/jsk_fetch_robot/jsk_fetch_startup/robots/head_l515.srdf.xacro
@@ -3,4 +3,6 @@
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
   <disable_collisions link1="head_tilt_link" link2="head_l515_mount_link" reason="Never" />
   <disable_collisions link1="head_tilt_link" link2="l515_head_link" reason="Never" />
+  <disable_collisions link1="head_pan_link" link2="head_l515_mount_link" reason="Never" />
+  <disable_collisions link1="head_pan_link" link2="l515_head_link" reason="Never" />
 </robot>


### PR DESCRIPTION
This PR fixes #1807.

I added disable_collision about head_pan link and l515.