### PR TITLE
Revert "[Fetch] Switch branch of jsk_pr2eus to develop/fetch"

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -60,17 +60,11 @@
     local-name: jsk-ros-pkg/jsk_demos
     uri: https://github.com/jsk-ros-pkg/jsk_demos.git
     version: master
-# we need to use the development branch until PR below are merged.
-#  - https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/495
 # we need to use the development branch until the next release.
-# - git:
-#     local-name: jsk-ros-pkg/jsk_pr2eus
-#     uri: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
-#     version: master
 - git:
     local-name: jsk-ros-pkg/jsk_pr2eus
     uri: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
-    version: develop/fetch
+    version: master
 # we need to use the development branch until the next release.
 - git:
     local-name: jsk-ros-pkg/jsk_recognition


### PR DESCRIPTION
Since https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/495 has merged into master.
And refrect comment at https://github.com/jsk-ros-pkg/jsk_robot/pull/1820.

Revert "[Fetch] Fix comment develop/fetch --> master"

This reverts commit 1cddbe050e2e7832f9ae0fa5fd6e4ed37a0c8bcf.

Revert "[Fetch] Switch branch of jsk_pr2eus to develop/fetch"

This reverts commit b8041d2746767a8da5ddd2566f6a2510663ebd7e.