### PR TITLE
Add enr_message_board capability to kitchen demo

### DIFF
--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -8,6 +8,7 @@
 (ros::load-ros-manifest "jsk_recognition_msgs")
 (ros::load-ros-manifest "power_msgs")
 (ros::load-ros-manifest "sensor_msgs")
+(ros::load-ros-manifest "esp_now_ros")
 
 (defparameter *dock-action* nil)
 (defparameter *undock-action* nil)
@@ -654,4 +655,38 @@ Args:
     (send *ri* :go-pos-unsafe 0 0 -80) ;; face the front against the trash can
     success-move-to-trashcan-front))
 
+(defun padding-byte-array (byte-array target-length)
+  (concatenate cons byte-array (make-list (- target-length (length byte-array)) :initial-element 0)))
+
+(defun write-message-on-message-board (target-addr message timeout-duration source-name)
+  "Send packet to write message on a message board.
+
+  Args:
+    target-addr: list of integer to represent mac address of target message board.
+    message: string
+    timeout-duration: ros::time to represent message timoeut
+    source-name: string
+    "
+  (let* ((packet-type-array (list 42 0))
+         (source-name-array (padding-byte-array (coerce source-name cons) 64))
+         (timeout-duration-msec (floor (* 1000 (send timeout-duration :to-sec))))
+         (timeout-duration-array
+           (mapcar
+             #'(lambda (order) 
+                    (/
+                      (- timeout-duration-msec
+                         (* (round (expt 256 (+ 1 order))) (/ timeout-duration-msec (round (expt 256 (+ 1 order))))))
+                      (round (expt 256 order))))
+             '(0 1 2 3 4 5 6 7)
+             ))
+         (message-array (padding-byte-array (coerce message cons) 64))
+         (byte-data (concatenate cons packet-type-array source-name-array timeout-duration-array message-array))
+         (msg (instance esp_now_ros::Packet :init
+                        :mac_address (coerce target-addr string)
+                        :data (coerce byte-data string)))
+         )
+    (ros::advertise "/esp_now_ros/send" esp_now_ros::Packet 1)
+    (ros::publish "/esp_now_ros/send" msg)
+    )
+  )
 

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -8,7 +8,8 @@
 (ros::load-ros-manifest "jsk_recognition_msgs")
 (ros::load-ros-manifest "power_msgs")
 (ros::load-ros-manifest "sensor_msgs")
-(ros::load-ros-manifest "esp_now_ros")
+(if (ros::rospack-find "esp_now_ros")
+    (ros::load-ros-manifest "esp_now_ros")
 
 (defparameter *dock-action* nil)
 (defparameter *undock-action* nil)

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -429,6 +429,12 @@ Args:
          (label-names (if msg (send msg :label_names))))
     (when label-names
       (ros::ros-info (format nil "Notify app that ~A is found." label-names))
+      (write-message-on-message-board
+        (list 255 255 255 255 255 255)
+        (format nil "Notify app that ~A is found." label-names)
+        (ros::time 600)
+        (ros::get-param "/robot/name" "default_name")
+        )
       (notify-app "object recognition"
                   (send msg :header :stamp)
                   location
@@ -695,6 +701,7 @@ Args:
     (ros::advertise "/esp_now_ros/send" esp_now_ros::Packet 1)
     (ros::publish "/esp_now_ros/send" (instance esp_now_ros::Packet :init)) ; publish dummy packet
     (ros::publish "/esp_now_ros/send" msg)
+    (ros::ros-info "Write message ~A to board ~A" message target-addr)
     )
   )
 

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -430,7 +430,7 @@ Args:
     (when label-names
       (ros::ros-info (format nil "Notify app that ~A is found." label-names))
       (write-message-on-message-board
-        (list 255 255 255 255 255 255)
+        (list 120 33 132 149 126 152)
         (format nil "Notify app that ~A is found." label-names)
         (ros::time 600)
         (ros::get-param "/robot/name" "default_name")
@@ -464,7 +464,7 @@ Args:
       (ros::ros-info
        (format nil "Notify app that the occupancy of trash can is measured. ~A." occupancy))
       (write-message-on-message-board
-        (list 255 255 255 255 255 255)
+        (list 120 33 132 149 126 152)
         (format nil "~A Trashcan occupancy is ~A" notify-text occupancy)
         (ros::time 600)
         (ros::get-param "/robot/name" "default_name")

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -693,6 +693,7 @@ Args:
                         :data (coerce byte-data string)))
          )
     (ros::advertise "/esp_now_ros/send" esp_now_ros::Packet 1)
+    (ros::publish "/esp_now_ros/send" (instance esp_now_ros::Packet :init)) ; publish dummy packet
     (ros::publish "/esp_now_ros/send" msg)
     )
   )

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -456,6 +456,12 @@ Args:
     (when occupancy
       (ros::ros-info
        (format nil "Notify app that the occupancy of trash can is measured. ~A." occupancy))
+      (write-message-on-message-board
+        (list 255 255 255 255 255 255)
+        (format nil "~A Trashcan occupancy is ~A" notify-text occupancy)
+        (ros::time 600)
+        (ros::get-param "/robot/name" "default_name")
+        )
       (notify-app "trashcan occupancy"
                   (ros::time-now)
                   location

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -9,7 +9,7 @@
 (ros::load-ros-manifest "power_msgs")
 (ros::load-ros-manifest "sensor_msgs")
 (if (ros::rospack-find "esp_now_ros")
-    (ros::load-ros-manifest "esp_now_ros")
+    (ros::load-ros-manifest "esp_now_ros"))
 
 (defparameter *dock-action* nil)
 (defparameter *undock-action* nil)

--- a/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
+++ b/jsk_fetch_robot/jsk_fetch_startup/euslisp/navigation-utils.l
@@ -699,7 +699,6 @@ Args:
                         :data (coerce byte-data string)))
          )
     (ros::advertise "/esp_now_ros/send" esp_now_ros::Packet 1)
-    (ros::publish "/esp_now_ros/send" (instance esp_now_ros::Packet :init)) ; publish dummy packet
     (ros::publish "/esp_now_ros/send" msg)
     (ros::ros-info "Write message ~A to board ~A" message target-addr)
     )


### PR DESCRIPTION
Add enr_message_board feature to kitchen demo's trashcan capacity checking.

![IMG_20230627_171251](https://github.com/jsk-ros-pkg/jsk_robot/assets/9410362/8a26a6de-3a3b-4ffe-a46d-2352307cbcd5)


With this PR, Fetch write a message about trashcan occupancy to enr_message_board.


For string - byte array conversion, see https://github.com/euslisp/jskeus/issues/635 for detail.