### PR TITLE
Revert "[Fetch] Use bugfix branch of executive_smach_visualization"

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -151,16 +151,10 @@
     uri: https://github.com/jsk-ros-pkg/coral_usb_ros.git
     version: master
 # we need melodic-devel branch for headless visualization
-# - git:
-#     local-name: ros-visualization/executive_smach_visualization
-#     uri: https://github.com/ros-visualization/executive_smach_visualization.git
-#     version: master
-# UnicodeDecodeError is output without the following PR
-# https://github.com/ros-visualization/executive_smach_visualization/pull/54
 - git:
     local-name: ros-visualization/executive_smach_visualization
-    uri: https://github.com/tkmtnt7000/executive_smach_visualization.git
-    version: fix-pickle-loads-python-version
+    uri: https://github.com/ros-visualization/executive_smach_visualization.git
+    version: melodic-devel
 # we need this for eus10 and roseus_resume
 - git:
     local-name: euslisp/Euslisp


### PR DESCRIPTION
Reverts jsk-ros-pkg/jsk_robot#1832 as https://github.com/ros-visualization/executive_smach_visualization/pull/54 has merged.