### PR TITLE
[jsk_fetch_startup] Use dynamicreconfigure to change speak volume of time_signal.py

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -5,10 +5,12 @@
 # https://github.com/PR2/app_manager/pull/50
 # In order to run multiple app_managers in one master, we need this PR
 # https://github.com/PR2/app_manager/pull/54
+# This PR add run_name entry to specif node name when we use run entry
+# https://github.com/PR2/app_manager/pull/64
 - git:
     local-name: PR2/app_manager
-    uri: https://github.com/knorth55/app_manager.git
-    version: fetch15
+    uri: https://github.com/tkmtnt7000/app_manager.git
+    version: add-run-name-entry-fetch15
 # we need this for proximity sensors
 - git:
     local-name: RoboticMaterials/FA-I-sensor

--- a/jsk_fetch_robot/jsk_fetch_startup/CMakeLists.txt
+++ b/jsk_fetch_robot/jsk_fetch_startup/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+  dynamic_reconfigure
   roscpp
   std_msgs
   sensor_msgs
@@ -24,10 +25,16 @@ find_package(catkin REQUIRED COMPONENTS
 )
 find_package(Boost REQUIRED COMPONENTS)
 
+generate_dynamic_reconfigure_options(
+  cfg/TimeSignal.cfg
+)
+
 ###################################
 ## catkin specific configuration ##
 ###################################
-catkin_package()
+catkin_package(
+  CATKIN_DEPENDS dynamic_reconfigure
+)
 
 catkin_add_env_hooks(99.jsk_fetch_startup SHELLS bash zsh sh
   DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)

--- a/jsk_fetch_robot/jsk_fetch_startup/apps/time_signal/time_signal.app
+++ b/jsk_fetch_robot/jsk_fetch_startup/apps/time_signal/time_signal.app
@@ -1,6 +1,8 @@
 display: Speak time signal
 platform: fetch
 run: jsk_fetch_startup/time_signal.py
+run_name: "time_signal"
+# run_name needs https://github.com/PR2/app_manager/pull/64
 interface: jsk_fetch_startup/time_signal.interface
 icon: jsk_fetch_startup/time_signal.png
 timeout: 120

--- a/jsk_fetch_robot/jsk_fetch_startup/cfg/TimeSignal.cfg
+++ b/jsk_fetch_robot/jsk_fetch_startup/cfg/TimeSignal.cfg
@@ -1,0 +1,11 @@
+#! /usr/bin/env python
+
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+PACKAGE = 'jsk_fetch_startup'
+
+gen = ParameterGenerator()
+gen.add("volume", double_t, 0, "Volume of sound.", 1.0, 0.0, 1.0)
+
+exit(gen.generate(PACKAGE, PACKAGE, "TimeSignal"))

--- a/jsk_fetch_robot/jsk_fetch_startup/package.xml
+++ b/jsk_fetch_robot/jsk_fetch_startup/package.xml
@@ -12,7 +12,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend version_gte="0.7.11">fetch_teleop</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
 
+  <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>image_proc</run_depend>
   <run_depend>jsk_fetch_accessories</run_depend>
   <run_depend>jsk_fetch_diagnosis</run_depend>

--- a/jsk_robot_common/jsk_robot_startup/lifelog/auto_speak_volume_lower.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/auto_speak_volume_lower.l
@@ -11,4 +11,5 @@
 (ros::set-dynamic-reconfigure-param "/tweet_client_uptime" "volume" :double 0.2)
 (ros::set-dynamic-reconfigure-param "/tweet_client_warning" "volume" :double 0.2)
 (ros::set-dynamic-reconfigure-param "/tweet_client_worktime" "volume" :double 0.2)
+(ros::set-dynamic-reconfigure-param "/time_signal" "volume" :double 0.2)
 (exit)

--- a/jsk_robot_common/jsk_robot_startup/lifelog/auto_speak_volume_reset.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/auto_speak_volume_reset.l
@@ -11,4 +11,5 @@
 (ros::set-dynamic-reconfigure-param "/tweet_client_uptime" "volume" :double 1.0)
 (ros::set-dynamic-reconfigure-param "/tweet_client_warning" "volume" :double 1.0)
 (ros::set-dynamic-reconfigure-param "/tweet_client_worktime" "volume" :double 1.0)
+(ros::set-dynamic-reconfigure-param "/time_signal" "volume" :double 1.0)
 (exit)

--- a/jsk_robot_common/jsk_robot_startup/lifelog/auto_speak_volume_zero.l
+++ b/jsk_robot_common/jsk_robot_startup/lifelog/auto_speak_volume_zero.l
@@ -11,4 +11,5 @@
 (ros::set-dynamic-reconfigure-param "/tweet_client_uptime" "volume" :double 0.0)
 (ros::set-dynamic-reconfigure-param "/tweet_client_warning" "volume" :double 0.0)
 (ros::set-dynamic-reconfigure-param "/tweet_client_worktime" "volume" :double 0.0)
+(ros::set-dynamic-reconfigure-param "/time_signal" "volume" :double 0.0)
 (exit)


### PR DESCRIPTION
This PR enables us to change volume of `time_signal.py` from `volume_lower/volume_reset` app.

This change may help us avoid  Fetch's noisy information voice.

c.f. https://github.com/PR2/app_manager/pull/64