### PR TITLE
[jsk_robot_startup] Fix mongo record subscribe at specified rate

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/mongo_record.py
+++ b/jsk_robot_common/jsk_robot_startup/src/jsk_robot_startup/lifelog/mongo_record.py
@@ -83,6 +83,10 @@ class MongoRecord(LoggerBase):
         self.insert(msg,
                     meta={'input_topic': topic},
                     wait=self.blocking)
+        # Unregister and register subscriber again to subscribe topic at specified rate
+        # See https://github.com/jsk-ros-pkg/jsk_robot/issues/1838
+        self.subscribers[topic].unregister()
+        del self.subscribers[topic]
 
     def run(self):
         rate = rospy.Rate(self.update_rate)


### PR DESCRIPTION
This PR is a develop/fetch branch version of #1839.

Unregister subscriber when callback function is called to subscribe topic at specified rate.