### PR TITLE
[jsk_pr2_startup] Save face true in db_client.launch

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/db_client.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/db_client.launch
@@ -16,6 +16,7 @@
     <arg name="save_base_trajectory" value="true" />
     <arg name="save_object_detection" value="false" />
     <arg name="save_action" value="true" />
+    <arg name="save_faces" value="true" />
     <arg name="enable_monitor" value="false" />
     <arg name="log_rate" value="1.0" />
     <arg name="localhost" value="false" />


### PR DESCRIPTION
I changed `save_face` arg into true to store face name to mongodb.

I would like to use face name to make pick-object demo richer.