### PR TITLE
GA fails on meodic, due to build error at julius, (https://github.com/jsk-ros-pkg/jsk_robot/actions/runs/5503866662/jobs/10029487836?pr=18439), whcih is installed as source tree, but switchbot_ros is alrady released, https://build.ros.org/job/Msrc_uB__switchbot_ros__ubuntu_bionic__source/

### DIFF
--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -54,9 +54,3 @@
     local-name: DENSORobot/denso_cobotta_ros
     uri: https://github.com/DENSORobot/denso_cobotta_ros.git
     version: bb60e75adb8477ed3402561b4ec3ba687af3f397
-# switchbot_ros is not correctly released.
-# see: https://github.com/jsk-ros-pkg/jsk_3rdparty/issues/356
-- git:
-    local-name: jsk-ros-pkg/jsk_3rdparty 
-    uri: https://github.com/jsk-ros-pkg/jsk_3rdparty.git
-    version: f0ab7bba54523b8f9945ed4a3e9c0efec0c8dde9 


### PR DESCRIPTION
GA fails on meodic, due to build error at julius, (https://github.com/jsk-ros-pkg/jsk_robot/actions/runs/5503866662/jobs/10029487836?pr=18439), whcih is installed as source tree, but switchbot_ros is alrady released, https://build.ros.org/job/Msrc_uB__switchbot_ros__ubuntu_bionic__source/