### PR TITLE
[naoqieus/cross] use $ROS_DISTRO instead of melodic when installing pepper_meshes to allow us to use ROS noetic for build cross environment

### DIFF
--- a/jsk_naoqi_robot/cross/build_user.sh
+++ b/jsk_naoqi_robot/cross/build_user.sh
@@ -43,13 +43,13 @@ done
 
 # force copy pepper_meshes
 if [ ! -e ${SOURCE_ROOT}/src/pepper_meshes/meshes ]; then
-    if [ ! -e /opt/ros/melodic/share/pepper_meshes/meshes/ ]; then
+    if [ ! -e /opt/ros/$ROS_DISTRO/share/pepper_meshes/meshes/ ]; then
         set +x
-        echo "ERROR: You need /opt/ros/melodic/share/pepper_meshes/meshes/ " 1>&2
-        echo "ERROR: run apt 'install ros-melodic-pepper-meshes'" 1>&2
+        echo "ERROR: You need /opt/ros/$ROS_DISTRO/share/pepper_meshes/meshes/ " 1>&2
+        echo "ERROR: run apt 'install ros-$ROS_DISTRO-pepper-meshes'" 1>&2
         exit -1
     fi
-    cp -r /opt/ros/melodic/share/pepper_meshes/meshes/ ${SOURCE_ROOT}/src/pepper_meshes/
+    cp -r /opt/ros/$ROS_DISTRO/share/pepper_meshes/meshes/ ${SOURCE_ROOT}/src/pepper_meshes/
 fi
 
 ## UPDATE_SOURCE_ROOT=1  # TRUE


### PR DESCRIPTION
Related commit: 
https://github.com/kochigami/jsk_robot/commit/1a0cfe08e51421a2378bc2938ea3014b62e788fb
https://github.com/jsk-ros-pkg/jsk_robot/pull/1583

When I used ubuntu 20.04 + ROS noetic PC, `./build_user.sh` of pepper cross failed.
That is because this script tries to copy `/opt/ros/melodic/share/pepper_meshes/meshes/` forcefully.

`kochigami@kochigami-pc:~/catkin_ws/src/jsk_robot/jsk_naoqi_robot/cross$ ./build_user.sh`

```
.......

+ vcs import i386_User/src
.........
=== i386_User/src/app_manager (git) ===
Cloning into '.'...
=== i386_User/src/nao_interaction (git) ===
Cloning into '.'...
=== i386_User/src/nao_robot (git) ===
Cloning into '.'...
=== i386_User/src/naoqi_bridge (git) ===
Cloning into '.'...
=== i386_User/src/naoqi_bridge_msgs (git) ===
Cloning into '.'...
=== i386_User/src/naoqi_dashboard (git) ===
Cloning into '.'...
=== i386_User/src/naoqi_driver (git) ===
Cloning into '.'...
=== i386_User/src/pepper_meshes (git) ===
Cloning into '.'...
=== i386_User/src/pepper_robot (git) ===
Cloning into '.'...
+ '[' '!' -e i386_User/src/pepper_meshes/meshes ']'
+ '[' '!' -e /opt/ros/melodic/share/pepper_meshes/meshes/ ']'
+ set +x
ERROR: You need /opt/ros/melodic/share/pepper_meshes/meshes/ 
```

Therefore, I changed `melodic` to `$ROS_DISTRO` in https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_naoqi_robot/cross/build_user.sh#L45-L52.
When I checked `cross/i386_User/src/pepper_meshes/package.xml`, version 0.2.5 was installed.