### PR TITLE
Fix unitreeeus building

### DIFF
--- a/jsk_unitree_robot/cross/repos/unitree.repos
+++ b/jsk_unitree_robot/cross/repos/unitree.repos
@@ -9,7 +9,7 @@ repositories:
   unitree_ros:
     type: git
     url: https://github.com/unitreerobotics/unitree_ros.git
-    veresion: master
+    veresion: 5dee20c
   unitree_ros_to_real:
     type: git
     url: https://github.com/k-okada/unitree_ros_to_real.git

--- a/jsk_unitree_robot/unitree.rosinstall
+++ b/jsk_unitree_robot/unitree.rosinstall
@@ -4,11 +4,11 @@
     uri: https://github.com/k-okada/unitree_legged_sdk.git
     version: develop
 - git:
-    # Use 50ff98 commit since unitree_ros has unitree_ros_to_real as submodule and 
-    # causes https://github.com/jsk-ros-pkg/jsk_robot/issues/1858
+    # Use a version before 2e566b7 commit since unitree_ros has unitree_ros_to_real as submodule
+    # and it causes https://github.com/jsk-ros-pkg/jsk_robot/issues/1858
     local-name: unitree_ros
     uri: https://github.com/unitreerobotics/unitree_ros.git
-    version: 50ff982dfbd4b9d2d08f1a05d66f141ab9f8d7f9
+    version: 5dee20c
 - git:
     # waiting for https://github.com/unitreerobotics/unitree_ros_to_real/pull/22 - 25
     local-name: unitree_ros_to_real

--- a/jsk_unitree_robot/unitreeeus/.gitignore
+++ b/jsk_unitree_robot/unitreeeus/.gitignore
@@ -1,1 +1,2 @@
 *go1.l
+*go1-simple.l

--- a/jsk_unitree_robot/unitreeeus/go1-utils.l
+++ b/jsk_unitree_robot/unitreeeus/go1-utils.l
@@ -1,18 +1,18 @@
 (require :go1 "package://unitreeeus/go1.l")
 
-(defun go1 () (setq *go1* (instance go1_description-robot :init)))
+(defun go1 () (setq *go1* (instance go1-robot :init)))
 
 ;; euscollada can not generate end-coords without limbs...
 ;; head-end-coords:
 ;;  parent : camera_optical_face_lk
 ;;   translate : [0, -12.5, -6.7]
 ;;   rotate : [0, 1, 0, 0]
-(defmethod go1_description-robot
+(defmethod go1-robot
   (:head-end-coords (&rest args) (forward-message-to camera_optical_face_lk args))
   )
 
 ;; define ik methods
-(defmethod go1_description-robot
+(defmethod go1-robot
   (:fullbody-inverse-kinematics
    ;; see https://github.com/euslisp/jskeus/pull/349 for detail
    (target-coords move-target &rest args &key

--- a/jsk_unitree_robot/unitreeeus/package.xml
+++ b/jsk_unitree_robot/unitreeeus/package.xml
@@ -20,6 +20,7 @@
 
   <run_depend>roseus</run_depend>
   <run_depend>pr2eus</run_depend>
+  <run_depend>unitree_legged_msgs</run_depend>
 
   <export>
   </export>

--- a/jsk_unitree_robot/unitreeeus/unitree-interface.l
+++ b/jsk_unitree_robot/unitreeeus/unitree-interface.l
@@ -36,7 +36,7 @@
   (:init
    (&rest args)
    (prog1
-       (send-super* :init :robot go1_description-robot :base-frame-id "base_lk" :odom-topic "/odom_combined" :base-controller-action-name nil args)
+       (send-super* :init :robot go1-robot :base-frame-id "base_lk" :odom-topic "/odom_combined" :base-controller-action-name nil args)
      (setq body-pose-topic "/go1/body_pose")
      (ros::advertise body-pose-topic geometry_msgs::Pose 1)
      (setq cmd-vel-topic "/go1/cmd_vel")


### PR DESCRIPTION
Fix https://github.com/jsk-ros-pkg/jsk_robot/issues/1866#issuecomment-1751636386

To do this

- Update unitree-ros version to 5dee20c
  - Both of `unitree.rosinstall` and `cross/repo/unitree.repos`
- Use go1-robot instead of go1_description-robot in unitreeeus
- Fix misc
  - add go1-simple.l (which is automatically generated during catkin build) to .gitignre
  - add unitree_legged_msgs to the dependencies of unitreeeus