### PR TITLE
README.md: use archive for docker, System, Users.

### DIFF
--- a/jsk_unitree_robot/README.md
+++ b/jsk_unitree_robot/README.md
@@ -2,6 +2,8 @@
 
 ROS package for Unitree Go1 robot.
 
+This document assumes that your robot is already configured with JSK's ROS environment. To configure this, please ask your robot's administrator along with [this instruction](./cross/README.md#setup-go1-robot).
+
 ## How to Run
 
 See [manual](https://drive.google.com/drive/folders/1PZDOo8WUcqwU8mNek2qAaTwW9WjJVVRL?usp=sharing) before you use Go 1. (jsk.imi.i.u-tokyo.ac.jp account is required.)
@@ -25,10 +27,6 @@ catkin build unitreeeus jsk_unitree_startup
 source devel/setup.bash
 ```
 
-### Prepare JSK Environment to Go1 Robot
-
-Please follow [this instruction](./cross/README.md#setup-go1-robot). This is only required for the first time.
-
 ### Program Go1 robot
 
 1. Connect to the robot via Ethernet
@@ -46,7 +44,7 @@ Please follow [this instruction](./cross/README.md#setup-go1-robot). This is onl
    rossetip 192.168.96.162
    ```
 
-6. Run roseus
+4. Run roseus
 
    ```lisp
    (load "package://unitreeeus/unitree-interface.l") ;; load modules
@@ -55,11 +53,12 @@ Please follow [this instruction](./cross/README.md#setup-go1-robot). This is onl
 
    See `https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_unitree_robot/unitreeeus/test/test-go1.l` for example.
 
-7. Deployment
+5. Deployment
 
    Once you have completed your development, put your code into [apps](https://github.com/jsk-ros-pkg/jsk_robot/blob/master/jsk_unitree_robot/jsk_unitree_startup/apps/) directory and build on cross environment and copy to onboard computer.
 
-   To run cross compile, you need to do following steps.
+   To run cross compile, you need `ros1-unitree` docker image and `arm64v8_System` directory. If you do not have them, pleas ask your development environment administrator along with following instructions.
+
 
    - [prepare-cross-compiling-environment-run-only-the-fist-time-per-host-computer](./cross/README.md#prepare-cross-compiling-environment-run-only-the-fist-time-per-host-computer)
    - [build-ros-system-on-docker--run-only-the-fist-time-per-host-computer](./cross/README.md#build-ros-system-on-docker--run-only-the-fist-time-per-host-computer)

--- a/jsk_unitree_robot/cross/README.md
+++ b/jsk_unitree_robot/cross/README.md
@@ -8,33 +8,50 @@ This project contains a set of patches and scripts to compile and run ROS1 on a 
 
 We're going to use Docker to set up a container that will compile all the tools for cross-compiling ROS and all of its dependencies. Go to https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-using-the-repository to install it for your Linux distribution.
 
+We strongly recommend using an arm64v8 machine, but it will also work on x86_64 machines.
+
 1. Add your user to docker group
 ```
 $ sudo usermod -aG docker $USER
 $ newgrp
 ```
 
-2. Install Qemu software
+2. Install Qemu software (Only for x86_64 machine)
 ```
 $ sudo apt install -y qemu-user-static
 ```
 
-### Build ROS System on Docker  (Run only the fist time per host computer)
+### <<For JSK users>> Build ROS System on Docker from Archive (Run only the fist time per host computer)
+
+**Caution!!! Build ROS System for Unitree robot will take more than a few hours !! (some times longer than 24 hours). Therefor, if you are not a unitree robot's JSK ROS system developer, we strongly recommend to use the archive, **
+
+Download the docker image (`ros1-unitree-arm64v8.tar`) and System and User archvie file (`arm64v8_System.tgz` and `arm64v8_User.tgz`) from [here](https://drive.google.com/drive/u/2/folders/1SBA9oAwjfD84yRFEB-jsCH1m5Q8eEGSK)
+
+To extract archive, run folowing commands
+```
+cat ~/Downloads/ros1-unitree-arm64v8.tar | docker import - ros1-unitree:arm64v8
+roscd jsk_unitree_startup/../cross
+tar -xvzf ~/Downloads/arm64v8_System.tgz
+tar -xvzf ~/Downloads/arm64v8_User.tgz
+```
+
+To confarm evemTo verify that the archive was decompressed correctly, check that the following commands are executed without error.
+```
+make user
+```
+
+### Build ROS System on Docker from Scratch (Run only the fist time per host computer)
 
 ```
 make system
 ```
-
-**Caution!!! It will take more than a few hours !! (some times longer than 24 hours).**
-
-So For JSK users, download the output of this command (`arm64v8_System.tgz` archive file) from [here](https://drive.google.com/drive/u/2/folders/1SBA9oAwjfD84yRFEB-jsCH1m5Q8eEGSK) and extract under `jsk_unitree_robot/cross/` directory so that you can skip this process.
 
 ### Deploy ROS System to Go1 robot
 
 After finishing former step, run following command to copy ROS1 base sytem to Go1 onboard computer. This should be done only in the first time. So normally user do not have to run this command
 
 ```
-./install.sh -p 123 -D System
+./install.sh -p 123 -d System
 ```
 
 ### Build `jsk_unitree_robot` software on Docker


### PR DESCRIPTION
Please ask @tkmtnt7000 for System/Users .tgz file. You can also use mars@/tmp/ros1-unitree-arm64v8.tar as saved docker image. If this works, please upload to google drive.

@tkmtnt7000 confirmed https://github.com/jsk-ros-pkg/jsk_robot/pull/1868 works, but in `install.sh` process, we need to enter password several times. I have made https://github.com/k-okada/jsk_robot/pull/101 which should fix this problem, but not confirmed on real robot. Please let me know if this fixed version works @sktometometo 