### PR TITLE
[jsk_robot_startup] Fix arg name reveiver --> receiver

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/launch/smach_to_mail.launch
+++ b/jsk_robot_common/jsk_robot_startup/launch/smach_to_mail.launch
@@ -10,7 +10,7 @@
 
   <group if="$(arg use_mail)" ns="$(arg namespace)">
     <param name="sender_address" value="$(arg email_sender_address)" />
-    <param name="receiver_address" value="$(arg email_reveiver_address)" />
+    <param name="receiver_address" value="$(arg email_receiver_address)" />
   </group>
   <group if="$(arg use_google_chat)" ns="$(arg namespace)">
     <param name="google_chat_space" value="$(arg google_chat_space)" />


### PR DESCRIPTION
This PR fixes an argument name reveiver --> receiver to avoid the following error.

```bash
RLException: [smach_to_mail.launch] requires the 'email_reveiver_address' arg to be set
The traceback for the exception was written to the log file

```