### PR TITLE
[develop/fetch] Suppress TF Duplicated stamp warning in noetic client PC

### DIFF
--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -193,8 +193,9 @@
     uri: https://github.com/sktometometo/esp_now_ros.git
     version: v0.4.0
 # melodic version of robot_localization causes TF_REPEATED_DATA Errors to noetic client
-# So we have to use noetic-devel of robot_localization
+# So we have to adopt https://github.com/cra-ros-pkg/robot_localization/pull/595 (Using noetic-devel causes some localization trouble)
+# After https://github.com/cra-ros-pkg/robot_localization/pull/840 has been merged, we can use upstream melodic-devel branch
 - git:
     local-name: cra-ros-pkg/robot_localization
-    uri: https://github.com/cra-ros-pkg/robot_localization.git
-    version: noetic-devel
+    uri: https://github.com/mqcmd196/robot_localization.git
+    version: 2.6.9-suppress

--- a/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
+++ b/jsk_fetch_robot/jsk_fetch.rosinstall.melodic
@@ -192,3 +192,9 @@
     local-name: sktometometo/esp_now_ros
     uri: https://github.com/sktometometo/esp_now_ros.git
     version: v0.4.0
+# melodic version of robot_localization causes TF_REPEATED_DATA Errors to noetic client
+# So we have to use noetic-devel of robot_localization
+- git:
+    local-name: cra-ros-pkg/robot_localization
+    uri: https://github.com/cra-ros-pkg/robot_localization.git
+    version: noetic-devel

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
@@ -111,7 +111,12 @@
                      false, false, false]
       odom0_nodelay: true
       odom0_differential: true
+      permit_corrected_publication: true
     </rosparam>
+    <!--
+    See https://github.com/jsk-ros-pkg/jsk_robot/issues/1876
+        for permit_corrected_publication
+    -->
   </node>
 
   <!-- Visual Odom -->

--- a/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
+++ b/jsk_fetch_robot/jsk_fetch_startup/launch/fetch.launch
@@ -111,7 +111,7 @@
                      false, false, false]
       odom0_nodelay: true
       odom0_differential: true
-      permit_corrected_publication: true
+      permit_corrected_publication: false
     </rosparam>
     <!--
     See https://github.com/jsk-ros-pkg/jsk_robot/issues/1876


### PR DESCRIPTION
To solve https://github.com/jsk-ros-pkg/jsk_robot/issues/1876 .

@sktometometo did the work https://github.com/jsk-ros-pkg/jsk_robot/pull/1877 , but it causes some strange behavior in the real robot. So I want to adopt [the patch](https://github.com/cra-ros-pkg/robot_localization/pull/595) only for suppressing the warning. Upstream PR is https://github.com/cra-ros-pkg/robot_localization/pull/840