### PR TITLE
[jsk_pr2_startup] Add smach topic to rosbag_record.launch

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/rosbag_record.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_lifelog/rosbag_record.launch
@@ -36,6 +36,9 @@
           /kinect_head/depth_registered/throttled/camera_info
           /kinect_head/rgb/throttled/image_rect_color/compressed
           /kinect_head/depth_registered/throttled/image_rect/compressedDepth
+          /server_name/smach/container_init
+          /server_name/smach/container_status
+          /server_name/smach/container_structure
           /audio
           $(arg other_topics)
           $(arg regex_flag)


### PR DESCRIPTION
This PR added smach topic like `/server_name/smach/container_status` to PR2 default rosbag_record.launch.
This feature is convenient for some robot demonstration that uses smach (especially uses smach userdata).
Same as Fetch.