### PR TITLE
[Bugfix] [jsk_pr2_startup] Remove a slash of the first character for noetic (tf2) in publish_empty_cloud.py

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/pr2_2dnav.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_move_base/pr2_2dnav.launch
@@ -32,7 +32,7 @@
     </node>
     <node name="empty_cloud_publisher" pkg="jsk_pr2_startup"
           type="publish_empty_cloud.py">
-      <param name="frame_id" value="/laser_tilt_link" />
+      <param name="frame_id" value="laser_tilt_link" />
     </node>
 
     <!-- look path forward when navigation -->

--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_sensors/publish_empty_cloud.py
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2_sensors/publish_empty_cloud.py
@@ -11,7 +11,7 @@ class PublishEmptyCloud(ConnectionBasedTransport):
     def __init__(self):
         super(PublishEmptyCloud, self).__init__()
 
-        frame_id = rospy.get_param('~frame_id', '/base_laser_link')
+        frame_id = rospy.get_param('~frame_id', 'base_laser_link')
         max_range = rospy.get_param('~max_range', 25.0)
         rotate_points = rospy.get_param('~rotate_points', False)
 


### PR DESCRIPTION
This PR removed slashes from the first character of the topics for noetic tf2 compatibility.

Without this PR, tf is not solved and PR2 does not move with `move_base`  when we use `empty_cloud` in navigation that PR2 Subway demostration uses.

cc: Thanks to @pazeshun