### PR TITLE
[jsk_pr2_startup] set jsk_demos to origin/master

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2.rosinstall.noetic
+++ b/jsk_pr2_robot/jsk_pr2_startup/jsk_pr2.rosinstall.noetic
@@ -68,8 +68,8 @@
     version: master
 - git:
     local-name: jsk-ros-pkg/jsk_demos
-    uri: https://github.com/knorth55/jsk_demos.git
-    version: develop/pr2
+    uri: https://github.com/jsk-ros-pkg/jsk_demos.git
+    version: master
 - git:
     local-name: jsk-ros-pkg/jsk_model_tools
     uri: https://github.com/jsk-ros-pkg/jsk_model_tools.git


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_demos/pull/1366 is merged so set jsk_demos branch to origin/master