### PR TITLE
naoqi-interface.l: enable to pass string as joint-name

### DIFF
--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -141,13 +141,17 @@
 	(setq joint-name (list "LHand")))
        (:rhand
 	(setq joint-name (list "RHand")))
+       (t
+        (setq joint-name joint)
+        (if (/= (length joint-name) (length stiffness))
+            (ros::ros-warn "length for 'joint' and 'sitffness' must be same")))
        )
      (send goal :goal :trajectory :joint_names joint-name)
      (send goal :goal :trajectory :header :stamp (ros::time-now))
      (send goal :goal :trajectory :points
 	   (list (instance trajectory_msgs::JointTrajectoryPoint
 			   :init
-			   :positions (fill (instantiate float-vector (length joint-name)) stiffness)
+			   :positions (if (numberp stiffness) (fill (instantiate float-vector (length joint-name)) stiffness) stiffness)
 			   :time_from_start (ros::time 1))))
      (send joint-stiffness-trajectory-action :send-goal goal)
      ))


### PR DESCRIPTION


try to support 
```
(send *ri* :send-stiffness-controller (send-all (send *pepper* :rarm :joint-list) :name) #f(1.0 1.0 1.0 .1 0.4))
```

but Qi only support 
```
“Head”, “LArm” and “RArm”
“LHand” and “RHand”
```
???
http://doc.aldebaran.com/2-4/naoqi/motion/control-stiffness.html#control-stiffness
