### PR TITLE
[jsk_pr2_startup] Set png_level of compressedDepth

### DIFF
--- a/jsk_pr2_robot/jsk_pr2_startup/config/pr2_png_level.yaml
+++ b/jsk_pr2_robot/jsk_pr2_startup/config/pr2_png_level.yaml
@@ -1,0 +1,59 @@
+# Check each node png_level by the following command
+# for f in $(rosparam list | grep png_level); do echo "$f: $(rosparam get $f)"; done
+
+# Set png_level to 5 according to the following information
+# https://github.com/start-jsk/jsk_apc/pull/2706
+# https://gist.github.com/iory/12dda33908024223be74cb03f19997b5
+
+kinect_head:
+  depth:
+    image:
+      disable_pub_plugins:
+        - 'image_transport/compressed'
+        - 'image_transport/theora'
+      compressedDepth:
+        png_level: 5
+    image_raw:
+      disable_pub_plugins:
+        - 'image_transport/compressed'
+        - 'image_transport/theora'
+      compressedDepth:
+        png_level: 5
+    image_rect:
+      disable_pub_plugins:
+        - 'image_transport/compressed'
+        - 'image_transport/theora'
+      compressedDepth:
+        png_level: 5
+    image_rect_raw:
+      disable_pub_plugins:
+        - 'image_transport/compressed'
+        - 'image_transport/theora'
+      compressedDepth:
+        png_level: 5
+  depth_registered:
+    hw_registered:
+      image_rect:
+        disable_pub_plugins:
+          - 'image_transport/compressed'
+          - 'image_transport/theora'
+        compressedDepth:
+          png_level: 5
+      image_rect_raw:
+        disable_pub_plugins:
+          - 'image_transport/compressed'
+          - 'image_transport/theora'
+        compressedDepth:
+          png_level: 5
+    image:
+      disable_pub_plugins:
+        - 'image_transport/compressed'
+        - 'image_transport/theora'
+      compressedDepth:
+        png_level: 5
+    image_raw:
+      disable_pub_plugins:
+        - 'image_transport/compressed'
+        - 'image_transport/theora'
+      compressedDepth:
+        png_level: 5

--- a/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
+++ b/jsk_pr2_robot/jsk_pr2_startup/pr2.launch
@@ -76,6 +76,8 @@
            file="$(find jsk_pr2_startup)/jsk_pr2_sensors/kinect_head.launch" >
     <arg name="monitor_driver" value="true" />  <!-- iory 2022/05/11-->
   </include>
+  <!-- Set image compressedDepth png_leve to 5 -->
+  <rosparam file="$(find jsk_pr2_startup)/config/pr2_png_level.yaml" command="load"/>
 
   <!-- logging node for PR2  -->
   <include if="$(arg launch_db)"


### PR DESCRIPTION
Currently, if we want to use the depth topic of pr2's kinect camera image outside of pr2, the Hz is low due to the compressedDepth `png_level` problem.  
https://github.com/jsk-ros-pkg/jsk_robot/pull/1493 

Referring to https://github.com/jsk-ros-pkg/jsk_robot/pull/1493, set the `png_level` and avoid unnecessary topics.  


### Before
```bash
$ rostopic hz /kinect_head/depth_registered/image_rect/compressedDepth 
[/kinect_head/depth_registered/image_rect/compressedDepth]
no new messages
average rate: 3.728
	min: 0.266s max: 0.271s std dev: 0.00213s window: 4
$ for f in $(rosparam list | grep png_level); do echo "$f: $(rosparam get $f)"; done 
/kinect_head/depth/image/compressed/png_level: 9
/kinect_head/depth/image/compressedDepth/png_level: 9
/kinect_head/depth/image_raw/compressed/png_level: 9
/kinect_head/depth/image_raw/compressedDepth/png_level: 9
/kinect_head/depth/image_rect/compressed/png_level: 9
/kinect_head/depth/image_rect/compressedDepth/png_level: 9
/kinect_head/depth/image_rect_raw/compressed/png_level: 9
/kinect_head/depth/image_rect_raw/compressedDepth/png_level: 9
/kinect_head/depth_registered/hw_registered/image_rect/compressed/png_level: 9
/kinect_head/depth_registered/hw_registered/image_rect/compressedDepth/png_level: 9
/kinect_head/depth_registered/hw_registered/image_rect_raw/compressed/png_level: 9
/kinect_head/depth_registered/hw_registered/image_rect_raw/compressedDepth/png_level: 9
/kinect_head/depth_registered/image/compressed/png_level: 9
/kinect_head/depth_registered/image/compressedDepth/png_level: 9
/kinect_head/depth_registered/image_raw/compressed/png_level: 9
/kinect_head/depth_registered/image_raw/compressedDepth/png_level: 9
``` 

### After
```bash
$ rostopic hz /kinect_head/depth_registered/image_rect/compressedDepth 
subscribed to [/kinect_head/depth_registered/image_rect/compressedDepth]
average rate: 31.463
	min: 0.021s max: 0.040s std dev: 0.00569s window: 9
$ for f in $(rosparam list | grep png_level); do echo "$f: $(rosparam get $f)"; done /kinect_head/depth/image/compressedDepth/png_level: 5
/kinect_head/depth/image_raw/compressedDepth/png_level: 5
/kinect_head/depth/image_rect/compressedDepth/png_level: 5
/kinect_head/depth/image_rect_raw/compressedDepth/png_level: 5
/kinect_head/depth_registered/hw_registered/image_rect/compressedDepth/png_level: 5
/kinect_head/depth_registered/hw_registered/image_rect_raw/compressedDepth/png_level: 5
/kinect_head/depth_registered/image/compressedDepth/png_level: 5
/kinect_head/depth_registered/image_raw/compressedDepth/png_level: 5
```