### PR TITLE
fix CI, override node20 directory.

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -48,7 +48,11 @@ jobs:
             BEFORE_SCRIPT : "apt-get download ros-noetic-julius; wget -O stripdeb.sh https://gist.githubusercontent.com/jordansissel/748313/raw/8aebce360bc082e33af7bba3c90f755eb655783b/stripdeb.sh; bash stripdeb.sh ros-noetic-julius*.deb; sudo dpkg --force-all -i ros-noetic-julius*.deb; sudo apt-get -y -f install; sudo apt-mark hold ros-noetic-julius; git clone https://github.com/k-okada/denso_robot_ros.git; (cd ..; git clone https://github.com/k-okada/cobotta_descriptions.git); (cd denso_robot_ros/denso_robot_descriptions; cp -r ../../../cobotta_descriptions/cobotta_description . )"
 
 
-    container: ${{ matrix.CONTAINER }}
+    container:
+      image: ${{ matrix.CONTAINER }}
+      volumes:
+        - /tmp/node20:/__e/node20
+
     steps:
       - name: Install latest git ( use sudo for ros-ubuntu )
         run: |
@@ -69,6 +73,21 @@ jobs:
           fi
           git config --global --add safe.directory $GITHUB_WORKSPACE
         shell: bash
+
+      - name: Try to replace `node` with an glibc 2.17
+        shell: bash
+        run: |
+          if [[ "${{ matrix.CONTAINER }}" =~ "jskrobotics/ros-ubuntu:".* ]]; then
+             export USER=$(whoami)
+             sudo chmod 777 -R /__e/node20
+             sudo chown -R $USER /__e/node20
+          fi
+          ls -lar /__e/node20 &&
+          sudo apt-get install -y curl &&
+          curl -Lo /tmp/node.tar.gz https://unofficial-builds.nodejs.org/download/release/v20.17.0/node-v20.17.0-linux-x64-glibc-217.tar.gz &&
+          cd /__e/node20 &&
+          tar -x --strip-components=1 -f /tmp/node.tar.gz &&
+          ls -lar /__e/node20/bin/
 
       - name: Chcekout
         uses: actions/checkout@v3.0.2


### PR DESCRIPTION
- fix CI, override node20. See actions/upload-artifact#616 (comment) c.f.
   jsk-ros-pkg/jsk_control#790

``` Post job cleanup.
   /usr/bin/docker exec
    a73c1686824111e1103ab64b9f540a586c9548c53a8213840c21206b2f17403a sh -c "cat
    /etc/*release | grep ^ID" OCI runtime exec failed: exec failed: unable to
    start container process: exec: "/__e/node20/bin/node": stat
    /__e/node20/bin/node: no such file or directory: unknown
```

-  update .travis to 0.5.27