### PR TITLE
[ros-o] [jsk_robot_startup] do not specify c++11

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -120,3 +120,95 @@ jobs:
           TEST_PKGS : ${{ matrix.TEST_PKGS }}
           BEFORE_SCRIPT : ${{ matrix.BEFORE_SCRIPT }}
           EXTRA_DEB : ${{ matrix.EXTRA_DEB }}
+
+  # ROS-O setup for v4hn https://github.com/v4hn/ros-o-builder/blob/jammy-one/README.md#install-instructions
+  # ROS-O setup for techfak https://ros.packages.techfak.net/
+  # note that v4hn uses ROS_DISTRO=one and techfak uses ROS_DISTRO
+  ros-o:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - DISTRO: ubuntu:22.04
+            ROS_ONE_VARIANT: v4hn
+            ROS_REPOSITORY_URL: "deb [trusted=yes] https://raw.githubusercontent.com/v4hn/ros-o-builder/jammy-one/repository ./"
+            ROSDEP_PACKAGE_MAPPING: "yaml https://raw.githubusercontent.com/v4hn/ros-o-builder/jammy-one/repository/local.yaml debian"
+          - DISTRO: ubuntu:24.04
+            ROS_ONE_VARIANT: techfak
+            ROS_REPOSITORY_URL: "deb [trusted=yes] https://ros.packages.techfak.net noble main"
+            ROSDEP_PACKAGE_MAPPING: "yaml https://ros.packages.techfak.net/ros-one.yaml ubuntu"
+
+    container: ${{ matrix.DISTRO }}
+
+    env:
+      DEBIAN_FRONTEND : noninteractive
+
+    steps:
+      - name: Chcekout Source
+        uses: actions/checkout@v3.0.2
+
+      - name: Setup ROS-O deb repository
+        run: |
+          set -x
+          apt update && apt install -qq -y ca-certificates git
+          echo ${{ matrix.ROS_REPOSITORY_URL }} | tee /etc/apt/sources.list.d/ros-o-builder.list
+          ##
+          # https://github.com/v4hn/ros-deb-builder-action/blob/b7c0ed93fde3a86b5b1027bf8f7145cad6067c90/prepare.sh#L27-L28
+          # Canonical dropped the Debian ROS packages from 24.04 for political reasons. Wow.
+          if [[ "${{ matrix.ROS_ONE_VARIANT }}" == "v4hn" && "${{ matrix.DISTRO }}" == "ubuntu:24.04" ]]; then apt install -y software-properties-common retry && retry -d 50,10,30,300 -t 12 add-apt-repository -y ppa:v-launchpad-jochen-sprickerhof-de/ros; fi
+          ##
+          apt update
+          if [[ "${{ matrix.ROS_ONE_VARIANT }}" == "v4hn" ]]; then
+              apt install -qq -y python3-rosdep2
+          fi
+          if [[ "${{ matrix.ROS_ONE_VARIANT }}" == "techfak"  ]]; then
+              # Do not install python3-rosdep2, which is an outdated version of rosdep shipped via the Ubuntu repositories (instead of ROS)!
+              apt install -qq -y python3-rosdep
+              rosdep init
+          fi
+          echo ${{ matrix.ROSDEP_PACKAGE_MAPPING }} | tee /etc/ros/rosdep/sources.list.d/1-ros-o-builder.list
+          rosdep update
+        shell: bash
+
+      - name: Setup catkin-tools
+        run: |
+          set -x
+          # setup catkin tools
+          apt install -qq -y python3-pip
+          if [[ "${{ matrix.ROS_ONE_VARIANT }}" == "v4hn" ]]; then
+              pip3 install catkin-tools==0.9.4
+              apt install -qq -y catkin
+          fi
+          if [[ "${{ matrix.ROS_ONE_VARIANT }}" == "techfak" ]]; then
+              apt install -qq -y ros-one-catkin python3-catkin-tools
+          fi
+          # setup build tools
+          apt install -qq -y cmake build-essential ros-one-rosbash
+        shell: bash
+
+      - name: Setup Workspace
+        run: |
+          source /opt/ros/one/setup.bash
+          set -x
+          # setup workspace
+          mkdir -p ~/ws/src
+          cd ~/ws/src
+          if [[ "${{ matrix.ROS_ONE_VARIANT }}" == "techfak" ]]; then
+          # TODO: remove these lines and uncomment https://github.com/ubi-agni/ros-builder-action/blob/191fab06004ad5784c28cf2ba2b18f6d163a860d/ros-one.repos#L1089
+              git clone https://github.com/locusrobotics/catkin_virtualenv.git
+          fi
+          ln -sf $GITHUB_WORKSPACE .
+          rosdep install -qq -r -y --from-path . --ignore-src || echo "OK"
+          # check all system packages are able to install, because ROS-O build deb files that needs all packages
+          PIP_BREAK_SYSTEM_PACKAGES=1 rosdep install -qq --simulate -y --from-path . --ignore-src -t exec -t buildtool_export -t buildtool -t build -t build_export | tee rosdep-install.sh
+          sed 's/apt-get install/apt-get -y install/;/install ros-one/s/^/#/;/pip3 install/s/^/#/' rosdep-install.sh | bash -xe
+        shell: bash
+
+      - name: Compile Packages
+        run: |
+          source /opt/ros/one/setup.bash
+          set -x
+          cd ~/ws/
+          catkin build --no-status -sv ${{ matrix.CATKIN_OPTIONS }} --cmake-args -DCATKIN_ENABLE_TESTING=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ${{ matrix.CMAKE_OPTIONS }}
+        shell: bash

--- a/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
+++ b/jsk_robot_common/jsk_robot_startup/CMakeLists.txt
@@ -2,14 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(jsk_robot_startup)
 
 # for ROS indigo compile without c++11 support
-if(DEFINED ENV{ROS_DISTRO})
-  if($ENV{ROS_DISTRO} STRGREATER "indigo")
-    add_compile_options(-std=c++11)
-    message(STATUS "Building with C++11 support")
-  else() 
-    message(STATUS "ROS Indigo and before: building without C++11 support")
-  endif()
-else()
+if(NOT DEFINED ENV{ROS_DISTRO})
   message(STATUS "Environmental variable ROS_DISTRO not defined, checking OS version")
   file(STRINGS /etc/os-release RELEASE_CODENAME
 		REGEX "VERSION_CODENAME=")


### PR DESCRIPTION
Fix the compile error in jammy

```
Errors     << jsk_robot_startup:make /home/obinata/ros/catkin_ws/logs/jsk_robot_startup/build.make.003.log
In file included from /usr/include/log4cxx/log4cxx.h:45,
                 from /usr/include/log4cxx/logstring.h:28,
                 from /usr/include/log4cxx/level.h:22,
                 from /opt/ros/one/include/ros/console.h:46,
                 from /opt/ros/one/include/ros/ros.h:40,
                 from /home/obinata/ros/catkin_ws/build/jsk_robot_startup/JSK_NODELET_jsk_robot_startup_lightweight_logger.cpp:35:
/usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
   10 |     typedef std::shared_mutex shared_mutex;
      |                  ^~~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
   10 |     typedef std::shared_mutex shared_mutex;
      |             ^~~
/usr/include/log4cxx/boost-std-configuration.h:12:30: error: ‘shared_lock’ in namespace ‘std’ does not name a template type
   12 |     using shared_lock = std::shared_lock<T>;
      |                              ^~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:12:25: note: ‘std::shared_lock’ is only available from C++14 onwards
   12 |     using shared_lock = std::shared_lock<T>;
      |                         ^~~
In file included from /usr/include/log4cxx/log4cxx.h:45,
                 from /usr/include/log4cxx/logstring.h:28,
                 from /usr/include/log4cxx/level.h:22,
                 from /opt/ros/one/include/ros/console.h:46,
                 from /opt/ros/one/include/ros/ros.h:40,
                 from /home/obinata/ros/catkin_ws/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/quadruped_joystick_teleop.cpp:1:
/usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
   10 |     typedef std::shared_mutex shared_mutex;
      |                  ^~~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
   10 |     typedef std::shared_mutex shared_mutex;
      |             ^~~
/usr/include/log4cxx/boost-std-configuration.h:12:30: error: ‘shared_lock’ in namespace ‘std’ does not name a template type
   12 |     using shared_lock = std::shared_lock<T>;
      |                              ^~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:12:25: note: ‘std::shared_lock’ is only available from C++14 onwards
   12 |     using shared_lock = std::shared_lock<T>;
      |                         ^~~
In file included from /usr/include/log4cxx/log4cxx.h:45,
                 from /usr/include/log4cxx/logstring.h:28,
                 from /usr/include/log4cxx/level.h:22,
                 from /opt/ros/one/include/ros/console.h:46,
                 from /opt/ros/one/include/ros/ros.h:40,
                 from /home/obinata/ros/catkin_ws/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/joint_states_throttle_node.cpp:45:
/usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
   10 |     typedef std::shared_mutex shared_mutex;
      |                  ^~~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
   10 |     typedef std::shared_mutex shared_mutex;
      |             ^~~
/usr/include/log4cxx/boost-std-configuration.h:12:30: error: ‘shared_lock’ in namespace ‘std’ does not name a template type
   12 |     using shared_lock = std::shared_lock<T>;
      |                              ^~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:12:25: note: ‘std::shared_lock’ is only available from C++14 onwards
   12 |     using shared_lock = std::shared_lock<T>;
      |                         ^~~
make[2]: *** [CMakeFiles/JSK_NODELET_jsk_robot_startup_lightweight_logger.dir/build.make:76: CMakeFiles/JSK_NODELET_jsk_robot_startup_lightweight_logger.dir/JSK_NODELET_jsk_robot_startup_lightweight_logger.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2489: CMakeFiles/JSK_NODELET_jsk_robot_startup_lightweight_logger.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/quadruped_joystick_teleop.dir/build.make:76: CMakeFiles/quadruped_joystick_teleop.dir/src/quadruped_joystick_teleop.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2570: CMakeFiles/quadruped_joystick_teleop.dir/all] Error 2
In file included from /usr/include/log4cxx/log4cxx.h:45,
                 from /usr/include/log4cxx/logstring.h:28,
                 from /usr/include/log4cxx/level.h:22,
                 from /opt/ros/one/include/ros/console.h:46,
                 from /opt/ros/one/include/ros/ros.h:40,
                 from /opt/ros/one/include/mongodb_store/message_store.h:4,
                 from /home/obinata/ros/catkin_ws/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/message_store_singleton.h:45,
                 from /home/obinata/ros/catkin_ws/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/message_store_singleton.cpp:40:
/usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
   10 |     typedef std::shared_mutex shared_mutex;
      |                  ^~~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
   10 |     typedef std::shared_mutex shared_mutex;
      |             ^~~
/usr/include/log4cxx/boost-std-configuration.h:12:30: error: ‘shared_lock’ in namespace ‘std’ does not name a template type
   12 |     using shared_lock = std::shared_lock<T>;
      |                              ^~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:12:25: note: ‘std::shared_lock’ is only available from C++14 onwards
   12 |     using shared_lock = std::shared_lock<T>;
      |                         ^~~
In file included from /home/obinata/ros/catkin_ws/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/message_store_singleton.cpp:40:
/home/obinata/ros/catkin_ws/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/message_store_singleton.h: In member function ‘jsk_robot_startup::lifelog::MessageStoreSingleton& jsk_robot_startup::lifelog::MessageStoreSingleton::operator=(const jsk_robot_startup::lifelog::MessageStoreSingleton&)’:
/home/obinata/ros/catkin_ws/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/message_store_singleton.h:68:67: warning: no return statement in function returning non-void [-Wreturn-type]
   68 |   MessageStoreSingleton& operator=(MessageStoreSingleton const&) {};
      |                                                                   ^
      |                                                                   return *this;
In file included from /usr/include/log4cxx/log4cxx.h:45,
                 from /usr/include/log4cxx/logstring.h:28,
                 from /usr/include/log4cxx/level.h:22,
                 from /opt/ros/one/include/ros/console.h:46,
                 from /opt/ros/one/include/ros/assert.h:35,
                 from /opt/ros/one/include/ros/common.h:36,
                 from /opt/ros/one/include/ros/publisher.h:32,
                 from /opt/ros/one/include/ros/node_handle.h:32,
                 from /opt/ros/one/include/diagnostic_updater/diagnostic_updater.h:42,
                 from /home/obinata/ros/catkin_ws/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/include/jsk_robot_startup/lightweight_logger.h:46,
                 from /home/obinata/ros/catkin_ws/src/jsk-ros-pkg/jsk_robot/jsk_robot_common/jsk_robot_startup/src/lightweight_logger_nodelet.cpp:40:
/usr/include/log4cxx/boost-std-configuration.h:10:18: error: ‘shared_mutex’ in namespace ‘std’ does not name a type
   10 |     typedef std::shared_mutex shared_mutex;
      |                  ^~~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:10:13: note: ‘std::shared_mutex’ is only available from C++17 onwards
   10 |     typedef std::shared_mutex shared_mutex;
      |             ^~~
/usr/include/log4cxx/boost-std-configuration.h:12:30: error: ‘shared_lock’ in namespace ‘std’ does not name a template type
   12 |     using shared_lock = std::shared_lock<T>;
      |                              ^~~~~~~~~~~
/usr/include/log4cxx/boost-std-configuration.h:12:25: note: ‘std::shared_lock’ is only available from C++14 onwards
   12 |     using shared_lock = std::shared_lock<T>;
      |                         ^~~
make[2]: *** [CMakeFiles/joint_states_throttle.dir/build.make:76: CMakeFiles/joint_states_throttle.dir/src/joint_states_throttle_node.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2543: CMakeFiles/joint_states_throttle.dir/all] Error 2
make[2]: *** [CMakeFiles/jsk_robot_lifelog.dir/build.make:90: CMakeFiles/jsk_robot_lifelog.dir/src/message_store_singleton.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/jsk_robot_lifelog.dir/build.make:76: CMakeFiles/jsk_robot_lifelog.dir/src/lightweight_logger_nodelet.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2516: CMakeFiles/jsk_robot_lifelog.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
cd /home/obinata/ros/catkin_ws/build/jsk_robot_startup; catkin build --get-env jsk_robot_startup | catkin env -si  /usr/bin/make --jobserver-auth=3,4; cd -

................................................................................................................................................................................................
Failed     << jsk_robot_startup:make                   [ Exited with code 2 ]
Failed    <<< jsk_robot_startup                        [ 11.5 seconds ]
```

Cc: @Michi-Tsubaki 